### PR TITLE
 Portal message on AR listing workflow changes is incorrect

### DIFF
--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -58,6 +58,7 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                 return
 
         if action == "sample":
+            message = None
             objects = AnalysisRequestWorkflowAction._get_selected_items(self)
             transitioned = {'to_be_preserved':[], 'sample_due':[]}
             for obj_uid, obj in objects.items():
@@ -103,8 +104,10 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                     new_state = workflow.getInfoFor(sample, 'review_state')
                     doActionFor(ar, action)
                     transitioned[new_state].append(sample.Title())
+                else:
+                    message = _('Both Sampler and DataSampled are required')
+                    self.context.plone_utils.addPortalMessage(message, 'error')
 
-            message = None
             for state in transitioned:
                 tlist = transitioned[state]
                 if len(tlist) > 1:

--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -71,6 +71,14 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                     ar = sample.aq_parent
                 # can't transition inactive items
                 if workflow.getInfoFor(sample, 'inactive_state', '') == 'inactive':
+                    message = _('Sample %s is inactive' % sample.Title())
+                    self.context.plone_utils.addPortalMessage(message, 'error')
+                    continue
+                transitions = [a['id'] for a in get_workflow_actions(sample)]
+                if 'sample' not in transitions:
+                    message = _('"Sample" is not a valid action for %s' % \
+                                                                sample.Title())
+                    self.context.plone_utils.addPortalMessage(message, 'error')
                     continue
 
                 # grab this object's Sampler and DateSampled from the form
@@ -105,12 +113,7 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                     for a in analyses:
                         a.getObject().reindexObject()
 
-                transitions = [a['id'] for a in get_workflow_actions(sample)]
-                if 'sample' not in transitions:
-                    message = _('"Sample" is not a valid action for %s' % \
-                                                                sample.Title())
-                    self.context.plone_utils.addPortalMessage(message, 'error')
-                elif Sampler and DateSampled:
+                if Sampler and DateSampled:
                     workflow.doActionFor(sample, action)
                     new_state = workflow.getInfoFor(sample, 'review_state')
                     doActionFor(ar, action)

--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -105,7 +105,7 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                     doActionFor(ar, action)
                     transitioned[new_state].append(sample.Title())
                 else:
-                    message = _('Both Sampler and DataSampled are required')
+                    message = _('Both Sampler and Date Sampled are required')
                     self.context.plone_utils.addPortalMessage(message, 'error')
 
             for state in transitioned:

--- a/bika/lims/locales/af/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/af/LC_MESSAGES/bika.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Afrikaans (http://www.transifex.com/bikalabs/bika-lims/language/af/)\n"
@@ -26,49 +26,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} kan inlog met ${contact_username} as gebruikernaam. Kontakte moet self hulle wagwoorde verander.  As 'n wagwoord vergeet is, kan 'n kontak 'n nuwe wagwoord vanag die inlogskerm aanvra."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} ontbreek. Preserveerder of Preserveer datum"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} wag op preservering."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} wag op ontvangs."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${item} ongeldig gemaak."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} suksesvol geskep."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: afdelings wag op ontvangs."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} benodig Preserveerder of Preserveer datum"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} wag op preservering."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} wag op preservering."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${items} suksesvol geskep."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}:  ${part} wag op preservering."
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Fout"
 
@@ -98,15 +98,15 @@ msgstr "% Uitgevoer"
 msgid "% Published"
 msgstr "% Gepubliseer"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s het geen '%s' kolom."
 
@@ -118,15 +118,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Classic' dui op die invoer van analise versoeke per monster en analise seleksie. Met 'profiele', analise profiel trefwoorde gebruik verskeie analise dienste om saam te kies"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blanko)"
@@ -139,7 +139,7 @@ msgstr "(Kontrole)"
 msgid "(Duplicate)"
 msgstr "(Duplikaat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Gevaarlik)"
 
@@ -148,32 +148,26 @@ msgid "(Required)"
 msgstr "(Vereis)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "16 x 16 pixel sinbool"
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "32 x 32 pixel sinbool"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -184,16 +178,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Maks"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "OV ${ar_number}"
 
@@ -205,7 +199,7 @@ msgstr "OV Aanhangsel Keuse"
 msgid "AR ID Padding"
 msgstr "OV ID Kussing"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "OV Invoer"
 
@@ -213,17 +207,17 @@ msgstr "OV Invoer"
 msgid "AR Import options"
 msgstr "OV Invoeropsies"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "OV Template"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "OV vir hertoetse"
 
@@ -231,54 +225,54 @@ msgstr "OV vir hertoetse"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "OVs: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Rekening Naam"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Rekeningnommer"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Rekening Tipe"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akkreditasie"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akkreditasie Liggaam Afkorting"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akkreditasie Liggaam URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akkreditasie logo"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akkreditasie Verwysing"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Akkreditasie bladsy hoof"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Geakkrediteerd"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -292,21 +286,21 @@ msgstr "Aksies deur gebruikers vir gegewe periode"
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktief"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Voeg By"
 
@@ -326,11 +320,7 @@ msgstr "Voeg Kontrole Verwysing By"
 msgid "Add Duplicate"
 msgstr "Voeg Duplikaat By"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Voeg templaat by"
 
@@ -338,16 +328,16 @@ msgstr "Voeg templaat by"
 msgid "Add a remarks field to all analyses"
 msgstr "Voeg 'n kommnetaar veld toe aan alle ontledings"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Voeg nuwe by"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Addisionele opmerkings"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adres"
@@ -360,26 +350,26 @@ msgstr "Voeg tweesyfer jaar na ID voorvoegsel in"
 msgid "Administrative Reports"
 msgstr "Administratiewe Verslae"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Na ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agentskap"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Alle"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Alle ge-akkrediteerde ontledings is hier gelys"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Alle Ontledings Toegewys"
 
@@ -391,7 +381,7 @@ msgstr "Alle Ontledings van Tipe"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Laat Lab Klerke toe om  kliënte te skep en wysig "
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Laat handmatige  waarneming grense invoer"
 
@@ -399,15 +389,15 @@ msgstr "Laat handmatige  waarneming grense invoer"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Toegang tot werkkaarte net deur toegewysde analiste"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Laat handmatige Onsekerheidswaarde invoer toe"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -415,11 +405,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Laat die analis toe om die verstek waarnemings grense handmatig aan te pas op resulltaat invoer skerms"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Laat die analis toe om onsekerheidswaardes handmatig aan te pas"
 
@@ -427,48 +417,48 @@ msgstr "Laat die analis toe om onsekerheidswaardes handmatig aan te pas"
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Alternatiewe Berekening"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Wys altyd die gekose kategorieë in kliëntaansigte."
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Bedrag"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Ontledings"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Ontledings in skouer area"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Ontledings buite reikwydte"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Ontledings per ontledingsdiens"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Ontledings per monstertipe"
@@ -482,7 +472,7 @@ msgstr "Ontledings per diens"
 msgid "Analyses performed and published as % of total"
 msgstr "Ontledings gepubliseer as % van totaal"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Ontledings as % van totaal"
 
@@ -495,27 +485,27 @@ msgstr "Ontledings verslae"
 msgid "Analyses repeated"
 msgstr "Ontledings herhaal"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Resultate buite spesifikasie"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Ontledings hertoets"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Ontledings opgesom per departement"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Ontleding wat hertoets is"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Ontleding"
 
@@ -523,52 +513,52 @@ msgstr "Ontleding"
 msgid "Analysis Attachment Option"
 msgstr "Ontleding Aanhangsel Keuse"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Ontledingskategoriee"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Ontledingskategorie"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Ontleding Sleutelwoord"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Ontleding Profiel"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "OV profiele"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Ontledingsversoek"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Ontleding Versoek ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Ontleding Versoek Invoere"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Ontledingsversoek Prioriteite"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Ontledingsversoek Spesifikasies"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -576,65 +566,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Ontledingsversoeke"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Ontledingsdiens"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Ontledingsdienste"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Ontleding Spesifikasie"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Ontledingspesifikasies"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Ontleding status"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Ontledingstipe"
@@ -643,46 +633,46 @@ msgstr "Ontledingstipe"
 msgid "Analysis category"
 msgstr "Ontleding kategorie"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Ontledingsversoek ${AR} suksesvol geskep"
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Ontledingsversoeke ${ARs} suksesvol geskep"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Ontledingsversoeke en Ontledings"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Ontledingsversoeke en Ontledings per Klient"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Ontledingsversoeke Ongefaktureerd"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Ontledingsresultaat binne foutbereik"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Ontleding resultate"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Ontleding resultate vir ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Ontleding resultate per monster punt en ontleding"
 
@@ -690,12 +680,12 @@ msgstr "Ontleding resultate per monster punt en ontleding"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Ontledingsresultate buite lab- of kliënt-gespesifiseerde bereik. Let daarop dat dit verskeie minute mag neem."
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Ontledingsdiens"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Ontledingspesifikasie herstel na lab verstek."
 
@@ -711,17 +701,17 @@ msgstr "Ontledingsomkeertyd"
 msgid "Analysis turnaround time over time"
 msgstr "Ontledings omkeertyd oor tyd"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Ontledings omkeertye"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Ontledings omkeertye oor tyd"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Ontleder"
 
@@ -730,7 +720,7 @@ msgid "Analyst must be specified."
 msgstr "Analis verpligtend"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Enige"
 
@@ -742,7 +732,7 @@ msgstr "Pas toe"
 msgid "Apply template"
 msgstr "Pas Templaat Toe"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Pas oral toe"
 
@@ -760,15 +750,15 @@ msgstr "Batenommer"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Toegeken"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Toegewys aan werksblad"
 
@@ -786,27 +776,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Heg Aan By"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Aanhangsel"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Aanhangsel Sleutels"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Aanhangsel Keuse"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Aanhangsel Tipe"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Aanhangsel Tipes"
 
@@ -816,25 +806,25 @@ msgstr "Aanhangsel Tipes"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Aanhangsel nie toegelaat"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Aanhangsel vereis"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Aanhegseltipe"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Aanhangsels"
 
@@ -846,7 +836,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "'Autofill'"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "'Autoimport'"
 
@@ -863,27 +853,27 @@ msgstr "Auto plakker druk"
 msgid "Available templates"
 msgstr "Beskikbare template"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Gemiddelde omkeertyd"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Gemiddeld vroeg"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Gemiddeld laat"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Stukkende status: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Bank Tak"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Bank Naam"
 
@@ -892,31 +882,31 @@ msgid "Basis"
 msgstr "Basis"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Groep"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Groep ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Groep etiket"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Groepe"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Rigting"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Voor ${start_date}"
 
@@ -924,7 +914,7 @@ msgstr "Voor ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Groot ikoon"
 
@@ -932,7 +922,7 @@ msgstr "Groot ikoon"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS Konfigurasie"
 
@@ -940,63 +930,67 @@ msgstr "Bika LIMS Konfigurasie"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Rekeningadres"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blanko"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Blanko kwaliteit ontledings"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Handelsmerk"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Volume afslag toegepas"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Groot volume prys (BTW uitgesluit)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Business Foon"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Teen"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC Kontakte"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "Kopie aan E-pos"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Bereken presisie van onsekerheid"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Berekening"
 
@@ -1004,8 +998,8 @@ msgstr "Berekening"
 msgid "Calculation Formula"
 msgstr "Berekening Formule"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Berekening Interim Velde"
@@ -1018,11 +1012,11 @@ msgstr "Berekening: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Berekening: Geen"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Berekenings"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Kalibrasie"
 
@@ -1034,12 +1028,12 @@ msgstr "Kalibrasie Sertifikate"
 msgid "Calibration report date"
 msgstr "Kalibrasie Sertifikaat datum"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Kalibreerder"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1053,9 +1047,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Gekanselleer"
 
@@ -1071,18 +1065,18 @@ msgstr "Kan berekening nie deaktiveer nie, want dit word deur die volgende diens
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Mag nie verifieer: resultate deur huidige gebruiker"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Kapasiteit"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Vasgelê"
 
@@ -1091,7 +1085,7 @@ msgid "Cardinal"
 msgstr "Kardinaal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalogusnommer"
 
@@ -1099,17 +1093,17 @@ msgstr "Katalogusnommer"
 msgid "Categorise analysis services"
 msgstr "Kategoriseer ontledings dienste"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Kategorie kan nie deaktiveer word nie weens"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Sertifikaat nommer"
 
@@ -1122,31 +1116,31 @@ msgstr "Sertifikaat kode"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Kliek indien die metode ge-akkrediteer is"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Merk indien die ontleding in die laboratorium se akkreditasie skedule ingesluit is"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Merk indien die monster by hierdie punt 'n 'saamgestelde' monster moet wees, bv. 'n hele aantal oppervlakte monsters van 'n dam vermeng om 'n verteenwoordigende monster vir die dam te vorm. Die verstekwaarde, nie gemerk nie, dui 'n 'gryp' monster aan"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Merk indien die houer reeds gepreserveer is. Die preserverings stappe vir monsters in hierdie houer sal dan outomaties uit die werkvloei uitgesluit word"
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Kies indien hierdie die verstek prioriteit is"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Merk indien jou laboratorium ge-akkrediteer is"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Kies hierdie blokkie om 'n afsonderlike monsterhouer te gebruik vir dierdie ontledingsdiens"
 
@@ -1154,7 +1148,7 @@ msgstr "Kies hierdie blokkie om 'n afsonderlike monsterhouer te gebruik vir dier
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Kies hier om 'n afsonderlike ID-bediener te gebruik. Voorvoegsels is afsonderlik stelbaar in elke Bika-webwerf"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Kies Verstek OV spesifikasie"
 
@@ -1170,19 +1164,19 @@ msgstr ""
 msgid "City"
 msgstr "Stad"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klassiek"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Kliek op ontledingskategorieë (teen geskakeerde agtergrond) om Ontledingsdienste in elke kategorie te sien. Sleutel minimum en maksimumwaardes in om 'n geldige resultaatbereik aan te dui. Enige resultaat buite hierdie bereik sal 'n waarskuwing veroorsaak. Die % Fout veld laat 'n % onsekerheid toe wanneer resulate teen minimum en makismumwaardes geëvalueer word. 'n Resultaat buite die bereik maar steeds binne die fout % word in ag geneem, en sal 'n minder ernstige waarskuwing veroorsaak. "
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Kliek op ontledingskategorieë (teen geskakeerde agtergrond) om Ontledingsdienste in elke kategorie te wys. Voeg minimum en maksimumwaardes in om 'n geldige uitslagbereik aan te dui. Enige uitslag buite hierdie bereik sal veroorsaak dat 'n waarskuwing gewys word. Die % Fout veld laat 'n % onsekerheid toe wanneer uitslae teen minimum en maksimumwaardes geëvalueer word. 'n Uitslag buite die bereik maar steeds binne die fout % word in ag geneem, en sal 'n minder ernstige waarskuwing wys. "
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Kliek op ontledingskategorieë (teen geskakeerde agtergrond) om Ontledingsdienste in elke kategorie te sien. Sleutel minimum en maksimumwaardes in om 'n geldige resultaatbereik aan te dui. Enige resultaat buite hierdie bereik sal 'n waarskuwing veroorsaak. Die % Fout veld laat 'n % onsekerheid toe wanneer resulate teen minimum en makismumwaardes geëvalueer word. 'n Resultaat buite die bereik maar steeds binne die fout % word in ag geneem, en sal 'n minder ernstige waarskuwing veroorsaak. "
 
@@ -1190,19 +1184,19 @@ msgstr "Kliek op ontledingskategorieë (teen geskakeerde agtergrond) om Ontledin
 msgid "Click to download"
 msgstr "Kliek om af te laai"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Kliënt"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "Kliënt Groep ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Kliënt ID"
 
@@ -1210,59 +1204,59 @@ msgstr "Kliënt ID"
 msgid "Client Landing Page"
 msgstr "Kliënt landings blad"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Kliënt Naam"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Kliënt Bestelling"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Kliënt bestelling nommer"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Kliënt Ref"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Kliënt Verwysing"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Kliënt SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Klient Monster ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Kliënt kontak word vereis voordat versoek ingehandig mag word"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Kliënte"
 
@@ -1271,39 +1265,39 @@ msgstr "Kliënte"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Toe"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Kode vir die plek"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Kode vir die werf"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Kode vir die rak"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Komma (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Kommentaar"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Kommentaar of interpretasie van resultate"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "Komersiële ID"
 
@@ -1311,21 +1305,21 @@ msgstr "Komersiële ID"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Saamgesteld"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Sekerheidsvlak  %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Stel die monsterafdelings en preservering vir hierdie templaat. Wys ontledings toe aan die verskeie afdelings op die templaat se Ontledings tab"
 
@@ -1334,13 +1328,13 @@ msgid "Confirm password"
 msgstr "Bevestig Wagwoord"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Oorwegings"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontak"
@@ -1349,8 +1343,8 @@ msgstr "Kontak"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontakte"
@@ -1359,48 +1353,48 @@ msgstr "Kontakte"
 msgid "Contacts to CC"
 msgstr "Kontakte te kopieer"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Houer"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Houer tipe"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Houer tipes"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Monster houers"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Inhoud Tipe"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Inhoudstipe"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrole"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Kwaliteitsbestuur beheer ontledings"
 
@@ -1416,12 +1410,12 @@ msgstr "Kopieer ontledings dienste"
 msgid "Copy from"
 msgstr "Kopieer vanaf"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Kopieer na nuwe"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Telling"
 
@@ -1434,18 +1428,18 @@ msgstr "Land"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Skep 'n nuwe monster van hierdie tipe"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Geskep"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Geskep deur"
 
@@ -1453,7 +1447,7 @@ msgstr "Geskep deur"
 msgid "Created by:"
 msgstr "Geskep deur:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1461,8 +1455,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Skepper"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Kriteria"
 
@@ -1470,12 +1464,12 @@ msgstr "Kriteria"
 msgid "Currency"
 msgstr "Geldeenheid"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Tans"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Eie desimale teken"
 
@@ -1488,7 +1482,7 @@ msgstr "WG"
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1502,88 +1496,88 @@ msgstr "Datakoppelvlak"
 msgid "Data Interface Options"
 msgstr "Datakoppelvlak Keuses"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Data invoer dagboek"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Datum"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Datum geskep"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Datum Versend"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Datum Verwyder"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Datum Verval"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Datum Ingevoer"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Datum Gelaai"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Datum Geopen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Datum gepreserveer"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Datum Gepubliseer"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Datum Ontvang"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Datum Versoek"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Datum Gemonster"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1599,7 +1593,7 @@ msgstr "Kalibrasie sertifikaat begin datum"
 msgid "Date from which the instrument is under calibration"
 msgstr "Datum van wanneer instrument gekalibreer word"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Datum van wanneer instrument onderhoud begin"
 
@@ -1617,7 +1611,7 @@ msgid "Date until the certificate is valid"
 msgstr "Kalibrasie sertifikaat eind datum"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Datum tot wanneer die instrument onbeskikbaar bly"
@@ -1626,11 +1620,11 @@ msgstr "Datum tot wanneer die instrument onbeskikbaar bly"
 msgid "Date when the calibration certificate was granted"
 msgstr "Datum waarop die sertifisering toegeken was"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dae"
 
@@ -1642,17 +1636,17 @@ msgstr "De-aktiveer tot volgende kalibrasie toets"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Desimale teken on in kliënte verslag te gebruik"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Verstek"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Verstek OV specifikasie"
 
@@ -1660,49 +1654,49 @@ msgstr "Verstek OV specifikasie"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Verstek formule"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Verstekhouer"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Verstek houertipe"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Verstek Instrument"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Verstek Metode"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Verstekpreservering"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Verstek Prioriteit?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Verstek berekening om te gebruik vir die gekose standaard Metode. Die berekening vir 'n metode kan in die Metode gewysig word."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Verstek kategorië"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Verstek houer vir nuwe monster gedeelte"
 
@@ -1711,11 +1705,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Verstekhouers: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Verstek desimale teken"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1739,11 +1733,11 @@ msgstr "Verstek wetenskaplike notasie vir verslae"
 msgid "Default scientific notation format for results"
 msgstr "Verstek wetenskaplike notasie vir resultate"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Verstek value"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "VerstekOVSpesifikasie_beskrywing"
 
@@ -1751,7 +1745,7 @@ msgstr "VerstekOVSpesifikasie_beskrywing"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definieer 'n unieke indentifikasie kode vir die metode."
 
@@ -1759,11 +1753,11 @@ msgstr "Definieer 'n unieke indentifikasie kode vir die metode."
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Spesifiseer die hoeveelheid desimale vir die resultaat"
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Definieer die presisie vir eksponensiele notering. Die verstek waarde is 7."
 
@@ -1771,16 +1765,16 @@ msgstr "Definieer die presisie vir eksponensiele notering. Die verstek waarde is
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Definieer die voorvoegsels vir die unieke reeksID's wat die stelsel uitreik. Dui in die 'kussing' veld aan hoeveel nulle voorgevoeg word, bv 'n voorvoegsel van WB vir werksblad met 'n kussing van 4 sal genommer word vanaf WB-0001 tot WB-9999. LW: monsters en ontledingsresultate kry voorvoegsels met monstertipe afkortings en word nie in hierdie tabel opgetel nie - hulle kussing kan in die gespesifiseerde velde hieronder gestel word."
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Grade"
 
@@ -1788,9 +1782,9 @@ msgstr "Grade"
 msgid "Delete attachment"
 msgstr "Verwyder aanhangsel"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Department"
 
@@ -1803,13 +1797,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Afhanklike Ontledings"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Bekryf die metode in leketaal. Hierdie inligting word aan kliënte vertoon."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Beskrywing"
 
@@ -1817,7 +1811,7 @@ msgstr "Beskrywing"
 msgid "Description of the actions made during the calibration"
 msgstr "Beskrywing van die kalibrasie stappe"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Beskrywing van die onderhouds stappe"
 
@@ -1825,19 +1819,19 @@ msgstr "Beskrywing van die onderhouds stappe"
 msgid "Description of the actions made during the validation"
 msgstr "Beskrywing van die evaluering stappe"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Kode vir die plek"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Rak Beskrywing"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Beskrywing"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1845,7 +1839,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Afslag %"
 
@@ -1853,16 +1847,16 @@ msgstr "Afslag %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Versend"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Vertoonwaarde"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Vertoon 'n waarnemings grens kiesskakelaar"
 
@@ -1874,7 +1868,7 @@ msgstr "Vertoon 'n boodskap wanneer nuwe Bika weergawes beskikbaar is"
 msgid "Display individual sample partitions "
 msgstr "Vertoon individuele monster dele"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Weggooidatum"
 
@@ -1883,8 +1877,8 @@ msgstr "Weggooidatum"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Verwyderd"
@@ -1893,54 +1887,54 @@ msgstr "Verwyderd"
 msgid "District"
 msgstr "Distrik"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Deel deur zero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Dokument"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Dormant"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Punt (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Vanaf"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Tot"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Laai af"
 
@@ -1953,20 +1947,20 @@ msgstr "Droe"
 msgid "Dry matter analysis"
 msgstr "Droe Materiaalontleding"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Verwag"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Verwag op Datum"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Dup Var"
 
@@ -1975,20 +1969,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplikaat"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplikaat Of"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Duplikaat KB ontledings"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Duplikaat Variasie %"
 
@@ -2000,35 +1994,35 @@ msgstr "Duplikaat Ontleding KB"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Duplikaat Ontleding Kwaliteitsbeheer Grafieke"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Duur"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Bv. SANAS, APLAC, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Voortydig"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Vroeg"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Hoogte"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "E-pos"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "E-posadres"
 
@@ -2036,7 +2030,7 @@ msgstr "E-posadres"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "E-pos Onderwerpnaam"
 
@@ -2056,14 +2050,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Eind datum"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Verbetering"
 
@@ -2075,16 +2069,16 @@ msgstr "Voer 'n gebruikersnaam in, gewoonlik iets soos 'jsmit'. Geen spasies of 
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Verskaf 'n epos adres. Dit is nodig ingeval die wagwoord verlore gaan. Ons respekteer u privaatheid en die adres word met niemand gedeel en nêrens vertoon nie"
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Sleutel afslag persentasie in"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Sleutel 'n persentasie in, bv. 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Sleutel 'n persentasie in, bv. 14.0. Die persentasie word deur die hele stelsel gebruik, maar kan oorskryf word vir individuele items"
 
@@ -2092,15 +2086,15 @@ msgstr "Sleutel 'n persentasie in, bv. 14.0. Die persentasie word deur die hele 
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Sleutel 'n persentasie in, bv. 14.0. Die persentasie word deur die hele stelsel gebruik, maar kan oorskryf word vir individuele items"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Sleutel 'n persentasie in, bv. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Sleutel die posisie se breedte graad in 0-90, minute 0-59, sekondes 0-59 en 'n N/S aanwysing"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Sleutel die posisie se lengtegraad in, in grade 0-180, minute 0-59, sekondes 0-59 en 'n Oos/Wes (E/W) aanduiding"
 
@@ -2108,7 +2102,7 @@ msgstr "Sleutel die posisie se lengtegraad in, in grade 0-180, minute 0-59, seko
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Tik die besonderhede in van elk van die ontleding dienste wat jy wil kopieer."
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2116,45 +2110,45 @@ msgstr ""
 msgid "Entity"
 msgstr "Entiteit"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Foutiewe resultaat publikasie van ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Sluit uit van faktuur"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Verwagte Resultaat"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Verwagte waardes"
 
@@ -2163,19 +2157,19 @@ msgstr "Verwagte waardes"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Verval"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Vervaldatum"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Eksponensiële formaat presisie "
 
@@ -2183,44 +2177,40 @@ msgstr "Eksponensiële formaat presisie "
 msgid "Exponential format threshold"
 msgstr "Eksponensiële formaat drumpel"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Faks"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Faks (besigheids)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Vroulik"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Veld"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Veld Ontledings"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Veld preservering"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Veld Titel"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Leër"
 
@@ -2228,19 +2218,19 @@ msgstr "Leër"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Aanhegsels vir resultate, bv mikroskoop foto's, sal ingesluit word in e-pos aan die ontvangers met hierdie opsie geaktiveer"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Leërnaam"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2260,16 +2250,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Voornaam"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formule"
 
@@ -2279,18 +2269,18 @@ msgstr "Formule"
 msgid "From"
 msgstr "Van"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Van ${start_date} tot ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Volle Naam"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Toekomstige monster"
 
@@ -2300,7 +2290,7 @@ msgstr "Toekomstige monster"
 msgid "Generate report"
 msgstr "Skep verslag"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titel, bv. Mnr., Mv., Dr."
 
@@ -2312,37 +2302,37 @@ msgstr "Groepeer ontledings dienste per kategorie in tabelle, help baie waar dit
 msgid "Group by"
 msgstr "Groepeer onder"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Groeperings periode"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Skadelik"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Verskuilde veld"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Verskuilde veld"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Ure"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2351,8 +2341,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID bediener URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID bediener onbeskikbaar"
 
@@ -2360,31 +2350,31 @@ msgstr "ID bediener onbeskikbaar"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Indien 'n monster periodiek by hierdie posisisie geneem word, sleutel die periode hier in, bv. weekliks, daagliks"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2396,7 +2386,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2404,27 +2394,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Geaktiveer, word die ontleding nam skuinsdruk geskryf."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "geen Titel verskaf, die Bondel ID word gebruik"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Indien nodig, kies 'n berekening vir hierdie ontleding. Berekeninge kan opgestel word onder die berekenings item in die stelselopstelling"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Indien nodig, kies 'n berekening formule hier vir die ontleding. Formules kan saamgestel word onder die formule hoof in die stelsel opstelling"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2432,7 +2422,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Indien hierdie houer vooraf gepreserveerd is, moet die preserveringsmetode hier gekies word."
 
@@ -2445,7 +2435,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Indien afgeskakel, sal analiste toegang tot alle werkkaarte hê"
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Invoer"
@@ -2454,7 +2444,7 @@ msgstr "Invoer"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Ingevoer"
@@ -2463,8 +2453,8 @@ msgstr "Ingevoer"
 msgid "In-lab calibration procedure"
 msgstr "Laboratorium kalibrasie prosedure"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Onaktief"
@@ -2473,7 +2463,7 @@ msgstr "Onaktief"
 msgid "Include Previous Results From Batch"
 msgstr "Sluit vroeër resultate vir hierdie groep in"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Sluit all OVs in wat aan die geselekteerde objects behoort"
 
@@ -2481,7 +2471,7 @@ msgstr "Sluit all OVs in wat aan die geselekteerde objects behoort"
 msgid "Include and display pricing information"
 msgstr "Sluit prysinligting in en vertoon dit"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Insluitende Beskrywings"
 
@@ -2489,30 +2479,27 @@ msgstr "Insluitende Beskrywings"
 msgid "Include year in ID prefix"
 msgstr "Sluit Jaar in ID voorvoegsel in"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "Verkeerde IBAN nommer: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "Verkeerde NIB nommer: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Onbepaalbare resultaat"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Dui aan of lêeraanhangsels bv. mikroskoopbeelde nodig is vir die ontleding en of die lêer-oplaaifunksie beskikbaar sal wees daarvoor vir data-ontvangsskerms."
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Erf van"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Aanvanklike Hersiening"
 
@@ -2536,7 +2523,7 @@ msgstr "Installasie sertifikaat invoer"
 msgid "InstallationDate"
 msgstr "Installasie Datum"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instruksies"
@@ -2549,17 +2536,17 @@ msgstr "Instruksies vir gereelde kalibrasies deur laboartorium ontleders"
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instruksies vir gereelde voorkomende en onderhouds roetines vir analiste"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Instrument"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Instrument kalibrasies"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2572,16 +2559,16 @@ msgstr "Instrument invoer"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Instrument Onderhoud"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Geskeduleerder instrument take"
 
@@ -2589,19 +2576,19 @@ msgstr "Geskeduleerder instrument take"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Instrument tipes"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Instrument Validasies"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2645,9 +2632,9 @@ msgstr "Instrumenttipe"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Instrumente"
 
@@ -2671,7 +2658,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Interne Kalibrasie Toetse"
 
@@ -2687,24 +2674,21 @@ msgstr "Interpolasie"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Ongeldig"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "Ongeldige OV weer getoets"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Ongeldige wildcards gevind: ${wildcards}"
 
@@ -2712,43 +2696,43 @@ msgstr "Ongeldige wildcards gevind: ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Faktuur"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Faktuur datum"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Faktuur Sluit uit"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Faltuur nommer"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "Geen Bondel Einddatum"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "Geen Bondel Begindatum"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "Faltuur Bondel sonder datum"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Item is onaktief."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Items on in epos-onderwerpe ingesluit te word."
 
@@ -2758,7 +2742,7 @@ msgstr "Items on in epos-onderwerpe ingesluit te word."
 msgid "Job Title"
 msgstr "Werkstitel"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Werkstitel"
 
@@ -2766,12 +2750,12 @@ msgstr "Werkstitel"
 msgid "Key"
 msgstr "Sleutel"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Sleutel fout"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Sleutelwoord"
@@ -2780,47 +2764,47 @@ msgstr "Sleutelwoord"
 msgid "Keywords"
 msgstr "Sleutelwoorde"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Lab"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Lab Ontledings"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Lab Kontakte"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Lab Departemente"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Laboratorium preservering"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Lab Produkte"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etiket"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorium"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorium Geakkrediteer"
 
@@ -2840,13 +2824,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Voorheen verander"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Laat"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Laat Ontledings"
@@ -2856,7 +2840,7 @@ msgstr "Laat Ontledings"
 msgid "Late Analysis"
 msgstr "Laat Ontleding"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Lengtegraad"
 
@@ -2878,11 +2862,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Gevoegte Monster"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2894,7 +2878,7 @@ msgstr "Lys alle monsters vir 'n gegewe periode"
 msgid "Load Setup Data"
 msgstr "Laai opstelling data"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Laai beskrywende dokumente vir die metode"
 
@@ -2906,41 +2890,41 @@ msgstr "Laai van legger"
 msgid "Load the certificate document here"
 msgstr "Laai die Sertifikaat Dokument hier"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Gelaai"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Plek Kode"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Plek Beskrywing"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Plek Titel"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Plek Tipe"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Plek waar monsters gehou word"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Plek waar monsters geneem was"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Log"
@@ -2965,35 +2949,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Breedtegraad"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Lot Nommer"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Laer Waarnemings Grens (LWG)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Posadres"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Onderhouer"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Onderhoud tipe"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Manlik"
 
@@ -3001,16 +2985,16 @@ msgstr "Manlik"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Bestuurder"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Bestuurder E-pos"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Bestuurder Foon"
 
@@ -3018,31 +3002,25 @@ msgstr "Bestuurder Foon"
 msgid "Manual"
 msgstr "Handmatig"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Handmatige toevoeging"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Handmatige inskrywing van resultate"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Vervaardiger"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Vervaardigers"
 
@@ -3051,14 +3029,14 @@ msgstr "Vervaardigers"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Maks"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Maks Tyd"
 
@@ -3066,30 +3044,30 @@ msgstr "Maks Tyd"
 msgid "Maximum columns per results email"
 msgstr "Maksimum aantal kolomme per resultate epos"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Maksimum moontlike volume vir monsters"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Maksimum tydsverloop toegelaat vir die afhandeling van die ontleding. 'n Laat ontleding waarskuwing word vertoon na afloop van hierdie periode"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maksimum Omkeertyd"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Lid afslag %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Lid afslag toepaslik"
 
@@ -3098,22 +3076,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Metode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Metode Dokument"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "Metode ID"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Metode Instruksies"
 
@@ -3125,9 +3103,9 @@ msgstr "Metode: ${method_name}"
 msgid "Method: None"
 msgstr "Metode: Geen"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Metodes"
 
@@ -3135,17 +3113,17 @@ msgstr "Metodes"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Metodes ingeslote in  ${accreditation_body} skedule"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Middel letter"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Middel naam"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3157,8 +3135,8 @@ msgstr "Myne"
 msgid "Minimum 5 characters."
 msgstr "Minimum 5 karakters."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Minimumvolume"
 
@@ -3166,27 +3144,27 @@ msgstr "Minimumvolume"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimum aantal resultate vir kwaliteit statistiek berekeninge"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutes"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Mobiele Foon"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Datum verander"
 
@@ -3200,7 +3178,7 @@ msgstr ""
 msgid "More"
 msgstr "Meer"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3212,13 +3190,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "NIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Naam"
 
@@ -3227,17 +3205,17 @@ msgstr "Naam"
 msgid "New"
 msgstr "Nuut"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Nee"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Geen ontledings versoekes voldoen aan navraag"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3253,18 +3231,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Geen aksies vir gebruiker ${user} gevind nie"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Geen ontledings gekies"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Geen ontledings stem ooreen met jou navraag nie"
 
@@ -3276,23 +3254,23 @@ msgstr "Geen ontledings bygevoeg"
 msgid "No analyses were added to this worksheet."
 msgstr "Geen ontledings bygevoeg op hierdie werkskaart"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Geen ontledings gekies nie"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Geen ontledingsdiens gekies"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Geen ontledingsdienste is gekies nie"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Geen veranderinge aangebring"
 
@@ -3300,7 +3278,7 @@ msgstr "Geen veranderinge aangebring"
 msgid "No control type specified"
 msgstr "Geen kontrole tipe gespesifiseer"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3312,17 +3290,17 @@ msgstr "Geen verstekhouers gespesifiseer vir hierdie diens"
 msgid "No default preservations specified for this service"
 msgstr "Geen verstekpreservering gespesifiseer vir hierdie diens"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Niks geselekteer"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Geen historiese aksies voldoen aan die navraag"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Geen items is gekies nie"
 
@@ -3330,7 +3308,7 @@ msgstr "Geen items is gekies nie"
 msgid "No items selected"
 msgstr "Niks geselekteer"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Geen nuwe items geskep"
 
@@ -3340,16 +3318,16 @@ msgstr "Geen nuwe items geskep"
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Geen verwysing monster gekies."
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Geen verslag gespesifiseer in versoek nie"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Geen monsters gevind in navrrag"
 
@@ -3367,25 +3345,22 @@ msgstr "Geen gebruiker bestaan vir ${kontak_fullname} en "
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Geen"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Nie Toegelaat"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Nie beskikbaar"
 
@@ -3405,19 +3380,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "Hoeveelheid kolomme"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Hoeveelheid ontledings"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Aantal ontledingsversoeke en ontledings "
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Aantal ontledingsversoeke en ontledings per kliënt"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3425,30 +3400,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Aantal ontledings "
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Aantal ontledings buite reikwydte vir tydsinterval"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Aantal ontledings verlang per ontledingsdiens"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Aantal ontledings verlang per ontledingstipe "
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Aantal ontledings hertoeds vir tydsinterval"
 
@@ -3456,15 +3431,15 @@ msgstr "Aantal ontledings hertoeds vir tydsinterval"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Aantal Ontledings gepubliseer per departement as % vam totaal"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Aantal versoeke"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3473,31 +3448,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Aantal Monsters"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Numeriese waarde wat die sortering van geprioritiseerde  voorwerpe aandui"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "Voorwerp ID"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Indien gepreserveer, moet die monster binne hierdie tydsbestek vernietig word. Indien ongespesifiseerd, sal die monster-restensietyd gebruik word."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3505,15 +3480,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Slegs lab bestuurders mag werkskaarte skep en bestuur"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Slegs vir leë of zero velde"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Oop"
@@ -3526,26 +3498,26 @@ msgstr ""
 msgid "Order"
 msgstr "Bestelling"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Bestellingsdatum"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "Bestelling ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Bestellingsnommer"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Bestellings"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Bestellings: ${orders}"
 
@@ -3553,7 +3525,7 @@ msgstr "Bestellings: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Organisasie verantwoordelik vir die uitreiking van die sertifikasie"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3565,8 +3537,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Ander produktiwiteit verslae"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Verjaar"
 
@@ -3578,16 +3550,13 @@ msgstr "Afvoer formaat"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Afdeling"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3608,8 +3577,8 @@ msgstr "Wagwoord"
 msgid "Password lifetime"
 msgstr "Wagwoord leeftyd"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pending"
@@ -3634,31 +3603,31 @@ msgstr "Uitgevoer deur"
 msgid "Period"
 msgstr "Periode"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Toegelate"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Toegelate Fout %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Foon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Foon (besigheid)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Foon (tuis)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Foon (mobiel)"
 
@@ -3671,8 +3640,8 @@ msgid "Photo of the instrument"
 msgstr "Foto van die instrument"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Fisiese adres"
 
@@ -3680,7 +3649,7 @@ msgstr "Fisiese adres"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Lys alle opsies vir die ontledingsuitslag indien u dit wil beperk tot spesifieke opsies, bv 'Positief', 'Negatief' en 'Onbepaald'. Die opsie se uitslagwaarde moet 'n syfer wees"
 
@@ -3688,19 +3657,19 @@ msgstr "Lys alle opsies vir die ontledingsuitslag indien u dit wil beperk tot sp
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Spesifiseer preservering wat verskil van die ontledingsdiens se verstekpreservering per monstertipe"
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Laai asb die logo toegelaat deur die akkreditasie instelling. Maksimum grote is 175  x 175 pixels"
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Punt van Monstering"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3709,13 +3678,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posisie"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Posadres"
 
@@ -3723,16 +3692,16 @@ msgstr "Posadres"
 msgid "Postal code"
 msgstr "Poskode"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Vooraf gepreserveer"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Hoeveelheid desimale "
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3760,7 +3729,7 @@ msgstr "Verkose wetenskaplike notasie vir verslae."
 msgid "Preferred scientific notation format for results"
 msgstr "Verkose wetenskaplike notasie vir resultate."
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Voorvoegsel"
 
@@ -3768,12 +3737,12 @@ msgstr "Voorvoegsel"
 msgid "Prefixes"
 msgstr "Voorvoegsels"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premium"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3785,17 +3754,17 @@ msgstr "Voorberei deur"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Preservering"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Preserverings kategorie"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3806,7 +3775,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Preserverings"
 
@@ -3816,14 +3785,14 @@ msgstr "Preserverings"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Preserveerder"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Voorkomend"
 
@@ -3831,34 +3800,34 @@ msgstr "Voorkomend"
 msgid "Preventive maintenance procedure"
 msgstr "Voorkomende onderhoud prosdure"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Prys"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Prys (BTW uitg)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Premium prys persentasie"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Prys BTW uitgeslote"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Pryslys vir"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Pryslys"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3873,13 +3842,13 @@ msgstr "Druk"
 msgid "Print date:"
 msgstr "Datum gedruk"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Prioriteit"
 
@@ -3896,34 +3865,34 @@ msgstr "Produktiwiteit"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "Professionele Oop Bron LIMS/LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profiel"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Profiel Ontledings"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Profiel Sleutel"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Profiel Sleutelwoord"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profiele"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (Nog nie Gefaktureer)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "Protokol ID"
 
@@ -3931,7 +3900,7 @@ msgstr "Protokol ID"
 msgid "Public. Lag"
 msgstr "Publieke. Terughou"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Publisering Spesifikasies"
 
@@ -3946,21 +3915,21 @@ msgstr "Publikasievoorkeur"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Gepubliseer"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Gepubliseerde ongefaktureerde ontledingsversoeke"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Gepubliseer deur"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Gepubiseerde resultate"
 
@@ -3973,8 +3942,8 @@ msgid "QC Analyses"
 msgstr "Kwaliteitsbeheer ontledings"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "Kwaliteitsbeheer monster ID"
 
@@ -3995,23 +3964,23 @@ msgstr "Hoeveelheid"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Bereik kommentaar"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Bereik kommentaar"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Bereik maks"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Bereik min"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Bereikspesifikasie"
 
@@ -4033,9 +4002,9 @@ msgstr "Ontvang"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Is Ontvang"
 
@@ -4043,11 +4012,11 @@ msgstr "Is Ontvang"
 msgid "Recept. Lag"
 msgstr "Ontvangs. Terughou"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Ontvangers"
 
@@ -4056,31 +4025,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Verwysing"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Verwysings Ontledings"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Verwysing Definisie"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Verwysing Definisies"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Verwysing monster"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Verwysing Monsters"
 
@@ -4088,16 +4057,16 @@ msgstr "Verwysing Monsters"
 msgid "Reference Supplier"
 msgstr "Verwysing verskaffer"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Verwysing Tipe"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Verwysings waardes"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Standaardontleding KB"
@@ -4106,7 +4075,7 @@ msgstr "Standaardontleding KB"
 msgid "Reference analysis quality control graphs"
 msgstr "Standaardontleding KB Grafieke"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Verwysing ontleding kwaliteit beheer grafieke"
 
@@ -4114,21 +4083,21 @@ msgstr "Verwysing ontleding kwaliteit beheer grafieke"
 msgid "Reference sample"
 msgstr "Verwysingsmonster"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Verwysing monster waardes is nul of 'leeg'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "Verwsyingsdefinisie verteenwoordig 'n Verwysingsdefinisie of monstertipe wat gebruik word vir kwaliteitsbeheertoetsing."
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Refs: ${references}"
 
@@ -4151,8 +4120,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4161,9 +4130,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Opmerkings"
 
@@ -4171,7 +4140,7 @@ msgstr "Opmerkings"
 msgid "Remarks to take into account before calibration"
 msgstr "Opmerkings voor kalibrasie"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Opemerkings voor taak"
 
@@ -4179,7 +4148,7 @@ msgstr "Opemerkings voor taak"
 msgid "Remarks to take into account before validation"
 msgstr "Opmerkings voor validasie"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Opemerkings voor onderhoud"
 
@@ -4188,8 +4157,8 @@ msgstr "Opemerkings voor onderhoud"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Herstel"
 
@@ -4198,7 +4167,7 @@ msgid "Repeated analyses"
 msgstr "Herhaalde ontledings"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Rapporteer"
 
@@ -4212,14 +4181,14 @@ msgstr "Verslag Datum"
 msgid "Report ID"
 msgstr "Verslag ID"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Verslagtipe"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Rapporteer as Droe Materiaal"
 
@@ -4244,7 +4213,7 @@ msgstr "Hoeveelheid ontledings gepubliseer uitgedruk as % van alle ontledings ve
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Hoeveelheid Ontledingsversoeke en totaal vir die periode"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Verslagtipe"
 
@@ -4252,7 +4221,7 @@ msgstr "Verslagtipe"
 msgid "Report upload"
 msgstr "Verslag oplaai"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Verslae"
 
@@ -4261,15 +4230,15 @@ msgstr "Verslae"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Versoek"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "Versoek ID"
 
@@ -4277,26 +4246,26 @@ msgstr "Versoek ID"
 msgid "Request new analyses"
 msgstr "Versoek new Ontledings"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Verlang"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Versoeke"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Vereis"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Vereiste volume"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "Vereiste velde het geen waardes: ${field_names}"
 
@@ -4304,13 +4273,13 @@ msgstr "Vereiste velde het geen waardes: ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Beperk kategorië"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultaat"
 
@@ -4318,15 +4287,15 @@ msgstr "Resultaat"
 msgid "Result Footer"
 msgstr "Resultaat voetskrif"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Resultaat Keuses"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Resultaat Value"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4344,11 +4313,11 @@ msgstr "Resultaat buite toegelate bereik"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Resultaat Interpretasie"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Resultaat interpretasie"
 
@@ -4356,7 +4325,7 @@ msgstr "Resultaat interpretasie"
 msgid "Results attachments permitted"
 msgstr "Resultaat aanhangsels toegelaat"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Resultate teruggetrek"
 
@@ -4364,11 +4333,11 @@ msgstr "Resultate teruggetrek"
 msgid "Results interpretation"
 msgstr "Resultaat interpretasie"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Resultate per monsterpunt"
@@ -4377,14 +4346,14 @@ msgstr "Resultate per monsterpunt"
 msgid "Results per samplepoint and analysis service"
 msgstr "Resultate per monsterpunt en ontledingsdiens"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Retensieperiode"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Herontleed"
@@ -4403,11 +4372,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "Teruggetrekte ontledings"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Terugtrek verslag onbeskikbaar"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Terugtrekkings"
 
@@ -4423,12 +4392,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "SWIFT kode."
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Aanspreekvorm"
 
@@ -4436,19 +4405,19 @@ msgstr "Aanspreekvorm"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Dieselfde as hier bo, maar dit is die verstekwaarde vir ontledingsdienste. Dit kan individueel per ontledingsdiens opgestel word op hul eie blaaie"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Monster"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Monster Toestand"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Monster Toestand"
 
@@ -4457,8 +4426,8 @@ msgid "Sample Due"
 msgstr "Monster Verwag"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "Monster ID"
 
@@ -4470,12 +4439,12 @@ msgstr "Monster ID Kussing"
 msgid "Sample ID Sequence Start"
 msgstr "Eerste Monster ID"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Monster matrikse"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Monstermatriks"
 
@@ -4485,52 +4454,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Monsterafdelings"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Monster Punt"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Monster Punte"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Monster Tipe"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Monster Tipe Voorvoegsel"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Monster Tipe Spesifikasies (Kliënt)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Monster Tipe Spesifikasies (Lab)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Monster Tipes"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Monster toestand"
 
@@ -4540,9 +4509,9 @@ msgstr "Monster toestand"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Monsterpunt"
 
@@ -4570,17 +4539,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Monster verwante verslae"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Monstertipe"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Monster matriks"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Monster tipe"
 
@@ -4590,30 +4559,30 @@ msgstr "Monster tipe"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Monsternemer"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Monsters"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Monsters van hierdie tipe moet as gevaarlik beskou word"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Monsters ontvang teenoor verslag gedoen"
@@ -4622,62 +4591,62 @@ msgstr "Monsters ontvang teenoor verslag gedoen"
 msgid "Samples received vs. samples reported"
 msgstr "Monsters ontvang teenoor monsters verslag gedoen"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Monsters: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Monstering Datum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Monsterafwyking"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Monsterafwykings"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Monstering Reelmaat"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4687,9 +4656,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Stoor"
 
@@ -4702,17 +4671,17 @@ msgstr "Stoor opmerkings"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Geskeduleerde taak"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Wetenskaplike naam"
 
@@ -4720,16 +4689,16 @@ msgstr "Wetenskaplike naam"
 msgid "Search"
 msgstr "Soek"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Sekondes"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4741,11 +4710,11 @@ msgstr "Kies 'Registreer' indien u outomaties etikette wil druk wanneer nuwe OV'
 msgid "Select AR Templates to include"
 msgstr "Kies OV Templaat on in te sluit"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Kies 'n data koppelvlak"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Kies 'n verstek preservering vir hierdie ontleding. Indine die preservering van die monster tipe afhang, spesifiseer die preservering per monster tipe in die tabel benede"
 
@@ -4753,11 +4722,11 @@ msgstr "Kies 'n verstek preservering vir hierdie ontleding. Indine die preserver
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Kies 'n posisie en die ontledingsversoek om te dupliseer"
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Kies 'n bestuurder uit die bestaande personeel onder die 'lab kontakte' opstelling.  Afdelingsbestuurders word na verwys op analise resultaatsverslae wat analises per afdeling bevat."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Kies 'n monster 'n sekondêre OV te skep"
 
@@ -4769,7 +4738,7 @@ msgstr "Kies Alle items"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Kies ontledings vir insluiting in hierdie templaat "
 
@@ -4781,11 +4750,11 @@ msgstr "Kies Ontleder"
 msgid "Select existing file"
 msgstr "Kies bestaande legger"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Spesifiseer of die ontledings uitgesluit moet word op fakture"
 
@@ -4793,19 +4762,19 @@ msgstr "Spesifiseer of die ontledings uitgesluit moet word op fakture"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Kies as 'n interne kalibrasie sertifikaat"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Kies die beskrywings wat ingesluit moet word"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4831,7 +4800,7 @@ msgstr "Kies die verstek land vir die stelsel"
 msgid "Select the currency the site will use to display prices."
 msgstr "Kies geldeenheid waarin pryse vertoon word"
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Kies die verstekhouer om te gebruik vir hierdie ontledingsdiens. Spesifiseer die houer in die monstertipe tabel hieronder as die houer afhang van die monstertipe en preserveringskombinasie."
 
@@ -4843,7 +4812,7 @@ msgstr "Kies die verstek bestemming bladsy. Dit word gebruik wanneer 'n kliënt 
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Kies die voorkeur instrument"
 
@@ -4851,7 +4820,7 @@ msgstr "Kies die voorkeur instrument"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4875,7 +4844,7 @@ msgstr "Kies om monster-versameling werksvloei stappe te aktiveer"
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Kies die ontledings om in te sluit op die Werkskaart"
 
@@ -4891,7 +4860,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Kies watter etiket om te druk as outomatiese druk gestel is"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4903,7 +4872,7 @@ msgstr "Stuur epos"
 msgid "Separate"
 msgstr "Afsonderlik"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Afsonderlike houer"
 
@@ -4911,32 +4880,28 @@ msgstr "Afsonderlike houer"
 msgid "Serial No"
 msgstr "Reeksnommer"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Diens"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "Diens is ingeslote in die ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Dienste"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Sluit die onderhoud taak"
 
@@ -4944,31 +4909,31 @@ msgstr "Sluit die onderhoud taak"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Stel die maksimum aantal ontledingsversoeke per epos. Te veel kolomme per epos maak hul moeilik om te lees en sommige kliënte verkies minder resultate per epos"
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Stel die spesifikasie om te gebruik voor publikasie van 'n OV."
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Stel die laboratorium ontledingsdiens op"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Rak Kode"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Rak Beskrywing"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Rak Titel"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Verskepingsadres"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Kort titel"
 
@@ -4984,7 +4949,7 @@ msgstr "Vertoon Gehaltebeheer Ontledings"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Vertoon slegs verkose kategorië in kliënte skerms"
 
@@ -4996,29 +4961,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Handtekening"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Werf Kode"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Werf Beskrywing"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Werf Titel"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Grootte"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Klein Ikoon"
 
@@ -5026,14 +4987,14 @@ msgstr "Klein Ikoon"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Sorteer Orde"
 
@@ -5041,41 +5002,41 @@ msgstr "Sorteer Orde"
 msgid "Specification"
 msgstr "Spesifikasie"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Spesifikasies"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Spesifiseer die grootte van die werksblad, bv ooreenkomstig spesifieke instrumente se laaigrootte. Kies dan 'n analise-tipe per werksbladposisise. Waar KB monsters gekies is, kies ook watter verwysingsmonster gebruik behoort te word. As 'n duplikaatanalise gekies is, dui aan watter van monsterposisie dit 'n duplikaat moet wees. "
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Begin datum"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Staat"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Status"
 
@@ -5083,33 +5044,33 @@ msgstr "Status"
 msgid "Sticker templates"
 msgstr "Plakker template"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Stoorplek"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Stoorplekke"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Subgroep"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Subgroepe"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Handig In"
 
@@ -5117,37 +5078,34 @@ msgstr "Handig In"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotaal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Verskaffer"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Verskaffers"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Bestelling"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Van"
 
@@ -5167,11 +5125,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Taak"
 
@@ -5180,20 +5138,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Taak tipe"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Tegniese beskrywing en instruksies vir ontleders"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatuur"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5211,35 +5169,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Die Ontledingsprofiel vir hierdie templaat"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr " Die ID deur die lab toegeken aan die kliënt se ontledingsversoek"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr " Die ID deur die lab toegeken aan die kliënt se monster"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Die laboratorium se web adres"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Die akkreditasie standaard van toepassing, bv. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Die ontledings ingeslote in hierdie profiel, per kategorie gegroepeer"
 
@@ -5251,7 +5209,7 @@ msgstr "Die ontleding om te gebruik vir die bepaling van droë resultate."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Die tegnikus of agent verantwoordelik vir die kalibrasie"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Die tegnikus of agent verantwoordelik vir die onderhoud"
 
@@ -5259,12 +5217,12 @@ msgstr "Die tegnikus of agent verantwoordelik vir die onderhoud"
 msgid "The analyst responsible of the validation"
 msgstr "Die analis verantwoordelik vir die validasie"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Die aanhegsels verwant aan ontledingsversoek"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Die kategorie waaraan die ontleding behoort"
 
@@ -5272,19 +5230,19 @@ msgstr "Die kategorie waaraan die ontleding behoort"
 msgid "The date the instrument was installed"
 msgstr "Datum tot wanneer die instrument ge-installeer was"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Die desimale teken in die Bika opstelling sal gebruik word"
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Verstek houertipe. Nuwe monsterafdelings kry outomaties 'n houer van hierdie tipe, tensy dit gespesifiseer is in meer besonderhede per ontledingsdiens"
 
@@ -5296,7 +5254,7 @@ msgstr "Die afslagpersentasie wat hier ingevoer word, word toegepas op kliënte 
 msgid "The full URL: http://URL/path:port"
 msgstr "Die voledige URL: htto://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Die hoogte of diepte waarop die monster geneem is"
 
@@ -5313,24 +5271,24 @@ msgstr "Die instrument se modelnommer"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Die laboratorium is nie ge-akkrediteer nie, of die akkreditasie opstelling is nog nie gedoen nie."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Die laboratorium departement"
@@ -5347,27 +5305,27 @@ msgstr "Die hoeveelheid zeros vir monster IDs"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Die hoeveelheid nulle gebruik on die ontledingsversoek nommer in ontledingsversoek ID te vul tot standaard lengte"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Die lys monsterpunte waarvanaf hierdie monstertipe versamel kan word. Indien geen monsterpunte gekies is nie, is alle  monsterpunte beskikbaar."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Die lys monstertipes wat by hierdie monsterpunt versamel kan word. Indien geen monstertipes gekies is nie, is alle  monstertipes beskikbaar."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Die meet eenheid vir die ontleding resultate, bv. mg/l, ppm, mV ens."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Die mimimum monstervolume nodig vir analise bv. '10 ml' of '1 kg'"
 
@@ -5391,7 +5349,7 @@ msgstr "Die hoeveelheid dae voor 'n wagwoord verval. 'n Waarde van 0 verhoed dat
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Die aantal dae voordat 'n monster verval en nie meer ontleed kan word nie. Hierdie verstelling kan oorskryf word per enkele monstertipe in die monstertipe opstelling."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5408,11 +5366,11 @@ msgstr "Aantal requests en Ontledings"
 msgid "The number of requests and analyses per client"
 msgstr "Aantal requests en Ontledings"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Die tydperk waarvoor ongepreserveerde monsters van hierdie tipe behou kan word voordat hulle verval en nie verder ontleed kan word nie."
 
@@ -5429,19 +5387,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "Die prys per ontleding vir kliënte wat vir volume afslag kwalifiseer"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "Die profiel se sleutelwoord word gebruik om dit uniek te identifiseer in invoerlêers. Dit moet uniek wees, en mag nie dieselfde as enige Berekenings tydelike veld ID wees nie."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Die akkreditasie verwysingsnommer aan die laboratorium"
 
@@ -5449,11 +5407,11 @@ msgstr "Die akkreditasie verwysingsnommer aan die laboratorium"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Die veld ontleding resultate word gemeet wanneer die monster geneem word, bv. die temperatuur van 'n water monster in die rivier waar die monster geneem word. Laboratorium ontledings word in die laboratorium self gedoen"
 
@@ -5461,7 +5419,7 @@ msgstr "Die veld ontleding resultate word gemeet wanneer die monster geneem word
 msgid "The room and location where the instrument is installed"
 msgstr "Vertrek en Plek waar die instrument ge-installeer is"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5473,11 +5431,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Die instrument se unieke volgnommer (serial number)"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5485,19 +5443,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "Die stelsel verstek waarde wat aandui of aanhangsels toegelaat, verplig is of nie vir ontledingsversoeke"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Die omkeertyd vir ontledings"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "Die omkeertyd vir ontledings gestip oor tyd"
 
@@ -5509,7 +5467,7 @@ msgstr "Die Omkeertye van Ontledings"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "Die omkeertye vir ontledings gestip oor tyd"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "Die unieke sleutel woorde word gebruik om ontledings te identifiseer in invoer resultate geproduseer deur laboratorium instrumente. Dit word ook gebruik om afhanklike ontledings in formules vir berekende resulate te identifiseer"
 
@@ -5521,37 +5479,37 @@ msgstr "Daar is geen uitslae nie"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Kan as droëstof rapporteer word"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Hierdie Ontleding Service kan nie aktiveer word nie"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Hierdie Ontleding Service kan nie deaktiveer word nie"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5563,7 +5521,7 @@ msgstr "Hierdie diens vereis nie 'n afsonderlike afdeling nie"
 msgid "This service requires a separate container."
 msgstr "Hierdie diens vereis 'n afsonderlike houer."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5571,13 +5529,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "Hierdie teks word aan resultaat verslae geheg."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Hierdie waarde word onder aan alle gepubliseerde resulate vertoon"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5591,63 +5545,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Titel"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Stoorplek"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Titel vir die rak"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Titel vir die werf"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Tot"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Om gepreserveer te word"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Om gemonster te word"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Te Bevestig"
 
@@ -5659,13 +5613,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Totaal"
 
@@ -5673,22 +5627,22 @@ msgstr "Totaal"
 msgid "Total Lag"
 msgstr "Totale agterstand"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Totale Prys"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Ontleding totaal"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Totale aantal datapunte"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Totale Prys"
 
@@ -5700,11 +5654,11 @@ msgstr "Totaal:"
 msgid "Traceability"
 msgstr "Navolgbaarheid"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5712,61 +5666,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Omkeertyd (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipe"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Tipe fout"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Tipe plek"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Kan nie die templaat laai nie"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nie toegeken"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Onsekerheid"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Onsekerheid value"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Ongedefinieerd"
 
@@ -5774,13 +5722,13 @@ msgstr "Ongedefinieerd"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Eenheid"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5805,17 +5753,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Ongepubliseer"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Onbekenede legger formaat ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Onherkenbare legger formaat ${file_format}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5827,11 +5775,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Laai 'n geskandeerde handtekening om op gedrukte resultaat verslae in te sluit. 'n Ideale grote is 250 by 150 'pixels'"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5839,7 +5787,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Gebruik Verstek formule"
 
@@ -5851,13 +5799,13 @@ msgstr "Gebruik eksterne ID bediener"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Gebruik hierdie veld om arbitrêre parameters aan die in en uitvoer modules te gee."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Gebruiker"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Gebruikersnaam"
@@ -5870,7 +5818,7 @@ msgstr "Gebruiker geskiedenis"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Gebruiker geskiedenis"
@@ -5879,27 +5827,27 @@ msgstr "Gebruiker geskiedenis"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Om 'n klein hoeveelheid data te gebruik maak nie statisties sin nie. Stel hier die aanvaarbare minimum hoeveelheid resultate waarmee statistieke berekeninge gemaak en geplot kan word"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "BTW"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "BTW %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "BTW Amount"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "BTW totaal"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "BTW nommer"
 
@@ -5907,11 +5855,11 @@ msgstr "BTW nommer"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Geldig vanaf"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Geldig tot"
 
@@ -5919,181 +5867,181 @@ msgstr "Geldig tot"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validasie"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Validasie het misluk:'${keyword}': duplikaat sleutelwoord"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Validasie het misluk: '${title}': Hierdie sleutelwoord word reeds gebruik deur die  '${used_by}' berekening"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Validasie het misluk: '${title}': Hierdie sleutelwoord word reeds gebruik deur die  '${used_by}' ontleding"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Validasie het misluk: '${title}': Duplikaat titel"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Validasie het misluk: '${value}' is nie uniek nie"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Validasie Misluk: Rigting moet O/W wees"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Validasie Misluk: Rigting moet N/S wees"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Validasie het gefaal: Foutpersentasie moet tussen 0 en 100 wees"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Validasie het gefaal: Waardes moet groter as 0 wees"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Validasie het gefaal: Maks waardes moet syfers wees"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Validasie het gefaal: Verwagte waardes moet tussen Min en Maks wees"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Validasie het gefaal: Verwagte waardes moet syfers wees"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Validasie het misluk: Sleutelwoord '${keyword}' is ongeldig"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Validasie het gefaal: Maksimum waarde moet groter wees as minimum"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Validasie het gefaal: Maks waardes moet syfers wees"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Validasie het gefaal: Min waardes moet syfers wees"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Validasie het gefaal: Persentasie foutwaardes moet tussen 0 en 100 wees"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Validasie het gefaal: Persentasiewaardes moet syfers wees"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Validasie het gefaal: Vooraf preserveerde houers moet 'n preservering reeds gekies hê"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Validasie het gefaal: Leë waardes is ongeldig"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Validasie Misluk: Resultaatwaardes moet tuseen -180 en 180 wees"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Validasie het misluk: Die keuse vereis die kategorieë: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Validasie het gefaal: Waardes moet syfers wees"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Validasie het misluk: Die kolom hoof '${title}' moet oor die sleutelwoord  '${keyword}' beskik"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Validasie fout: grade is 180, minute moet 0 wees"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Validasie fout: grade is 180, sekondes moet 0 wees"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Validasie fout: grade is 90, minute moet 0 wees"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Validasie fout: grade is 90, sekondes moet 0 wees"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Validasie fout: grade moet tussen 0 en 180 wees"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Validasie Misluk: grade moet -180 to 180 wees"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Validasie Misluk: grade moet numeries wees"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Validasie het misluk: Sleutelwoord  '${keyword}' se kolom hoof moet '${title}' wees"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Validasie Misluk: sleutelwoord het ongeldige karakters"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Validasie het gefaal: Sleutelwoord kort"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Validasie Misluk: minute moet binne 0-59 wees"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Validasie Misluk: minute moet numeries wees"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Validasie het gefaal: Persentasie foutwaardes moet tussen 0 en 100 wees"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Validasie het gefaal: Persentasiewaardes moet syfers wees"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Validasie Misluk: Sekondes moet 0-59 wees"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Validasie Misluk: Sekondes moet numeries wees"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Validasie het gefaal: Titel kort"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6101,7 +6049,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "Validasie verslag datum"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Valideerder"
@@ -6112,12 +6060,12 @@ msgstr "Valideerder"
 msgid "Value"
 msgstr "Waarde"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Bevestig"
@@ -6128,7 +6076,7 @@ msgstr "Bevestig"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Weergawe"
 
@@ -6138,11 +6086,11 @@ msgstr "Weergawe"
 msgid "Volume"
 msgstr "Volume"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Web adres vir die akkreditasie organisasie"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Webwerf."
 
@@ -6150,24 +6098,24 @@ msgstr "Webwerf."
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Hoeveelheis weke voor verval datum"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Wanneer die resultate op 'n werkskaart van duplikaat ontledings op dieselfde monster, verskil met meer as hierdie persentasie, sal 'n alert vertoon word"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Werk Uitgevoer"
@@ -6178,25 +6126,25 @@ msgstr "Taak vloei"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Werksblad"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Werksblad Uitleg"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Werksblad Template"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Werksblaaie"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6204,9 +6152,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Ja"
 
@@ -6218,7 +6166,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6226,11 +6174,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Kies 'n instrument"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "aksie"
 
@@ -6246,15 +6194,15 @@ msgstr "ontledig"
 msgid "analysis requests selected"
 msgstr "ontledingsversoeke gekies"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "en andere"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "kommentaar"
 
@@ -6283,37 +6231,9 @@ msgstr "kommentaar"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "data lyn"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6324,7 +6244,7 @@ msgstr "de-aktiveer"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6372,19 +6292,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6392,19 +6312,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "herhalend elke"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "herhaal periode"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6423,19 +6343,8 @@ msgstr "Opsomming inhoudslys"
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6447,7 +6356,7 @@ msgstr ""
 msgid "to"
 msgstr "tot"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6455,7 +6364,7 @@ msgstr ""
 msgid "type"
 msgstr "tipe"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "tot"
 
@@ -6480,7 +6389,7 @@ msgstr "waarde"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6492,6 +6401,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ar/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ar/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/bikalabs/bika-lims/language/ar/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -96,15 +96,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -116,15 +116,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -137,7 +137,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -211,17 +205,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -229,54 +223,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -324,11 +318,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -336,16 +326,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -358,26 +348,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -389,7 +379,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -480,7 +470,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -493,27 +483,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -521,52 +511,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -641,46 +631,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -688,12 +678,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -709,17 +699,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -740,7 +730,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -814,25 +804,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -922,7 +912,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -930,7 +920,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -938,63 +928,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1002,8 +996,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1016,11 +1010,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1032,12 +1026,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1069,18 +1063,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1097,17 +1091,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1208,59 +1202,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1269,39 +1263,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1309,21 +1303,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1347,8 +1341,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1357,48 +1351,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1432,18 +1426,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1451,7 +1445,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1468,12 +1462,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1786,9 +1780,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1815,7 +1809,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1851,16 +1845,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1881,8 +1875,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1891,54 +1885,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2034,7 +2028,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2161,19 +2155,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2226,19 +2216,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2277,18 +2267,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2452,7 +2442,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2461,8 +2451,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2487,30 +2477,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2764,12 +2748,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2778,47 +2762,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3016,31 +3000,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3164,27 +3142,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3225,17 +3203,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3678,7 +3647,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3721,16 +3690,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3814,14 +3783,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4041,11 +4010,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4169,7 +4138,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4259,15 +4228,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4779,11 +4748,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4849,7 +4818,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5447,11 +5405,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,12 +5527,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "العنوان"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "إلى"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr "إلى:"
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "الكلى"
 
@@ -5671,22 +5625,22 @@ msgstr "الكلى"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "السعر الكلي"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "السعر الكلي"
 
@@ -5698,11 +5652,11 @@ msgstr "المجموع:"
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "نوع"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "وحدة"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr "غير مُختار"
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "مستخدم"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "اسم المستخدم"
@@ -5868,7 +5816,7 @@ msgstr "تاريخ المستخدم"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "تواريخ المستخدم"
@@ -5877,27 +5825,27 @@ msgstr "تواريخ المستخدم"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5905,11 +5853,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5917,181 +5865,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr "القيمة"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6126,7 +6074,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6136,11 +6084,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr "سنويناً"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "نعم"
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "اجراء"
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "تعليق"
 
@@ -6281,36 +6229,8 @@ msgstr "تعليق"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr "الغى التفعيل"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "طور التفعيل"
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr "من"
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr "أفتح"
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr "أوضاع_أخرى"
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr "نُشر"
 
@@ -6390,19 +6310,19 @@ msgstr "نُشر"
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "إعادة كل"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "وقت الاعادة"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr "العينة_كافية"
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr "العينة_أستقبلت"
 
@@ -6421,20 +6341,9 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
 msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
-msgstr "شكل_الوقت"
 
 #. Default: "Required"
 #: bika/lims/browser/templates/header_table.pt:39
@@ -6445,7 +6354,7 @@ msgstr "العنوان_مطلوب"
 msgid "to"
 msgstr "إلى"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr "إلى_أن_يتأكد"
 
@@ -6453,7 +6362,7 @@ msgstr "إلى_أن_يتأكد"
 msgid "type"
 msgstr "النوع"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "حتى"
 
@@ -6478,7 +6387,7 @@ msgstr "القيمة"
 msgid "verification(s) pending"
 msgstr "التأكيد موقف مؤقتاً"
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr "تم تأكيده"
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/bg_BG/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/bg_BG/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bulgarian (Bulgaria) (http://www.transifex.com/bikalabs/bika-lims/language/bg_BG/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/bika.pot
+++ b/bika/lims/locales/bika.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,49 +21,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -79,7 +79,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -93,15 +93,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -113,15 +113,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -143,32 +143,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -179,16 +173,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -200,7 +194,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -208,17 +202,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -226,54 +220,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -287,21 +281,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -321,11 +315,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -333,16 +323,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -355,26 +345,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -386,7 +376,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -394,15 +384,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -410,11 +400,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -422,48 +412,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -477,7 +467,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -490,27 +480,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -518,52 +508,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -571,65 +561,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -638,46 +628,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -685,12 +675,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -706,17 +696,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -725,7 +715,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -737,7 +727,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -755,15 +745,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -781,27 +771,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -811,25 +801,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -841,7 +831,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -858,27 +848,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -887,31 +877,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -919,7 +909,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -927,7 +917,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -935,63 +925,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -999,8 +993,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1013,11 +1007,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1029,12 +1023,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1048,9 +1042,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1066,18 +1060,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1086,7 +1080,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1094,17 +1088,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1117,31 +1111,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1149,7 +1143,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1165,19 +1159,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1185,19 +1179,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1205,59 +1199,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1266,39 +1260,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1306,21 +1300,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1329,13 +1323,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1344,8 +1338,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1354,48 +1348,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1411,12 +1405,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1429,18 +1423,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1448,7 +1442,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1456,8 +1450,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1465,12 +1459,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1483,7 +1477,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1497,88 +1491,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1594,7 +1588,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1612,7 +1606,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1621,11 +1615,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1637,17 +1631,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1655,49 +1649,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1706,11 +1700,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1734,11 +1728,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1746,7 +1740,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1754,11 +1748,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1766,16 +1760,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1783,9 +1777,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1798,13 +1792,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1812,7 +1806,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1820,19 +1814,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1840,7 +1834,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1848,16 +1842,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1869,7 +1863,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1878,8 +1872,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1888,54 +1882,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1948,20 +1942,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1970,20 +1964,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1995,35 +1989,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2031,7 +2025,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2051,14 +2045,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2070,16 +2064,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2087,15 +2081,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2103,7 +2097,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2111,45 +2105,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2158,19 +2152,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2178,44 +2172,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2223,19 +2213,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2255,16 +2245,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2274,18 +2264,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2295,7 +2285,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2307,37 +2297,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2346,8 +2336,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2355,31 +2345,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2391,7 +2381,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2399,27 +2389,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2427,7 +2417,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2440,7 +2430,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2449,7 +2439,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2458,8 +2448,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2468,7 +2458,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2476,7 +2466,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2484,30 +2474,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2531,7 +2518,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2544,17 +2531,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2567,16 +2554,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2584,19 +2571,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2640,9 +2627,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2666,7 +2653,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2682,24 +2669,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2707,43 +2691,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2753,7 +2737,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2761,12 +2745,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2775,47 +2759,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2835,13 +2819,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2851,7 +2835,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2873,11 +2857,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2889,7 +2873,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2901,41 +2885,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2960,35 +2944,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2996,16 +2980,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3013,31 +2997,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3046,14 +3024,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3061,30 +3039,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3093,22 +3071,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3120,9 +3098,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3130,17 +3108,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3152,8 +3130,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3161,27 +3139,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3195,7 +3173,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3207,13 +3185,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3222,17 +3200,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3248,18 +3226,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3271,23 +3249,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3295,7 +3273,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3307,17 +3285,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3325,7 +3303,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3335,16 +3313,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3362,25 +3340,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3400,19 +3375,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3420,30 +3395,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3451,15 +3426,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3468,31 +3443,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3500,15 +3475,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3521,26 +3493,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3548,7 +3520,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3560,8 +3532,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3573,16 +3545,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3603,8 +3572,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3629,31 +3598,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3666,8 +3635,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3675,7 +3644,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3683,19 +3652,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3704,13 +3673,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3718,16 +3687,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3755,7 +3724,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3763,12 +3732,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3780,17 +3749,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3801,7 +3770,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3811,14 +3780,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3826,34 +3795,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3868,13 +3837,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3891,34 +3860,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3926,7 +3895,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3941,21 +3910,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3968,8 +3937,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3990,23 +3959,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4028,9 +3997,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4038,11 +4007,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4051,31 +4020,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4083,16 +4052,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4101,7 +4070,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4109,21 +4078,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4146,8 +4115,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4156,9 +4125,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4166,7 +4135,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4174,7 +4143,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4183,8 +4152,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4193,7 +4162,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4207,14 +4176,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4239,7 +4208,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4247,7 +4216,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4256,15 +4225,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4272,26 +4241,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4299,13 +4268,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4313,15 +4282,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4339,11 +4308,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4351,7 +4320,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4359,11 +4328,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4372,14 +4341,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4398,11 +4367,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4418,12 +4387,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4431,19 +4400,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4452,8 +4421,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4465,12 +4434,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4480,52 +4449,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4535,9 +4504,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4565,17 +4534,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4585,30 +4554,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4617,62 +4586,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4682,9 +4651,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4697,17 +4666,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4715,16 +4684,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4736,11 +4705,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4748,11 +4717,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4764,7 +4733,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4776,11 +4745,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4788,19 +4757,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4826,7 +4795,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4838,7 +4807,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4846,7 +4815,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4870,7 +4839,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4886,7 +4855,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4898,7 +4867,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4906,32 +4875,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4939,31 +4904,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4979,7 +4944,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4991,29 +4956,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5021,14 +4982,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5036,41 +4997,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5078,33 +5039,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5112,37 +5073,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5162,11 +5120,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5175,20 +5133,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5206,35 +5164,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5246,7 +5204,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5254,12 +5212,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5267,19 +5225,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5291,7 +5249,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5308,24 +5266,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5342,27 +5300,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5386,7 +5344,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5403,11 +5361,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5424,19 +5382,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5444,11 +5402,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5456,7 +5414,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5468,11 +5426,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5480,19 +5438,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5504,7 +5462,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5516,37 +5474,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5558,7 +5516,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5566,12 +5524,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5586,63 +5540,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5654,13 +5608,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5668,22 +5622,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5695,11 +5649,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5707,61 +5661,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5769,13 +5717,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5800,17 +5748,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5822,11 +5770,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5834,7 +5782,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5846,13 +5794,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5865,7 +5813,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5874,27 +5822,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5902,11 +5850,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5914,181 +5862,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6096,7 +6044,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6107,12 +6055,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6123,7 +6071,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6133,11 +6081,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6145,24 +6093,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6173,25 +6121,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6199,9 +6147,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6213,7 +6161,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6221,11 +6169,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6241,15 +6189,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6267,7 +6215,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6275,37 +6223,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Default: "yy-mm-dd"
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6317,7 +6236,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6363,19 +6282,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6383,19 +6302,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6414,19 +6333,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6438,7 +6346,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6446,7 +6354,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6468,7 +6376,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6480,6 +6388,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/bn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/bn/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Bengali (http://www.transifex.com/bikalabs/bika-lims/language/bn/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ca/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ca/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Catalan (http://www.transifex.com/bikalabs/bika-lims/language/ca/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "En/na ${contact_fullname} pot entrar al LIMS utilitzant ${contact_username} com a nom d'usuari. És convenient que els contactes modifiquin la seva contrasenya. En cas que l'usuari perdi la seva contrasenya, sempre podrà sol·licitar-ne una de nova des del formulari d'accés."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "No ha indicat la persona encarregada de la conservació o la data de conservació per als elements següents: ${items}"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} pendents de ser conservats."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} pendents de ser recepcionats."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "S'han descartat els elements següents: ${items}."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "Els serveis d'anàlisi ${items} s'han creat amb èxit."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: particions pendents de ser recepcionades."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "No ha indicat la persona encarregada de la conservació o la data de conservació per a ${item}"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} pendent de conservació."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} pendent de ser recepcionat."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "El servei d'anàlisi ${item} s'ha creat amb èxit."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} pendent de ser recepcionat."
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Error"
 
@@ -96,15 +96,15 @@ msgstr "% Realitzat/des"
 msgid "% Published"
 msgstr "% Publicats/des"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "No existeix la columna '%s' per a %s"
 
@@ -116,15 +116,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "L'opció 'Classic' indica que s'importaran les sol·licituds d'anàlisis per mostra i servei d'anàlisi. Si escull l'opció 'Perfils', les claus de perfil d'anàlisi s'utilitzaran per seleccionar múltiples serveis d'anàlisi de forma conjunta."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blanc)"
@@ -137,7 +137,7 @@ msgstr "(Control)"
 msgid "(Duplicate)"
 msgstr "(Duplicat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Perillós)"
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr "(Obligatori)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Icona de 16x16 píxels que indica la prioritat de l'element en les llistes."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Icona de 32x32 píxels que indica la prioritat de l'element en les llistes."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Màx"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "Sol·licitud d'Anàlisi ${ar_number}"
 
@@ -203,7 +197,7 @@ msgstr "Opcions de fitxers adjunts en sol·licituds d'anàlisis"
 msgid "AR ID Padding"
 msgstr "Mida de l'ID de les sol·licituds d'anàlisis"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importació de sol·licituds d'anàlisis"
 
@@ -211,17 +205,17 @@ msgstr "Importació de sol·licituds d'anàlisis"
 msgid "AR Import options"
 msgstr "Opcions per a la importació de sol·licituds d'anàlisis"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Plantilles de sol·licituds d'anàlisis"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Sol·licitud d'anàlisis de repetició"
 
@@ -229,54 +223,54 @@ msgstr "Sol·licitud d'anàlisis de repetició"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "Sol·licituds d'anàlisis: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nom de compte"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número de compte"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipus de compte"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Acreditació"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviació de l'entitat acreditadora"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Adreça URL de l'entitat acreditadora"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logotip de l'acreditació"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referència de l'acreditació"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Acreditat"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr "Accions que han realitzat els usuaris (o un usuari determinat) durant un
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Actius"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Afegeix"
 
@@ -324,11 +318,7 @@ msgstr "Afegeix un control de referència"
 msgid "Add Duplicate"
 msgstr "Afegeix un duplicat"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Afegeix una plantilla"
 
@@ -336,16 +326,16 @@ msgstr "Afegeix una plantilla"
 msgid "Add a remarks field to all analyses"
 msgstr "Afegeix un camp de comentaris per a totes les analítiques"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Afegeix"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Comentaris addicionals:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adreça"
@@ -358,26 +348,26 @@ msgstr "Afegeix els dos dígits de l'any després del prefix de l'identificador"
 msgid "Administrative Reports"
 msgstr "Informes administratius"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agència"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Tot"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Es mostren tots els anàlisis acreditats."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Totes les anàlisis assignades"
 
@@ -389,7 +379,7 @@ msgstr "Totes les anàlisis del tipus"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "A les fulles de treball només hi poden accedir els analistes assignats"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Càlcul alternatiu"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Expandeix sempre les categories seleccionades a les vistes de client"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Quantitat"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Anàlisis"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Anàlisis dins del rang d'error"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Anàlisis fora de rang"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Anàlisis per servei d'anàlisi"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Anàlisis per tipus de mostra"
@@ -480,7 +470,7 @@ msgstr "Anàlisis per servei"
 msgid "Analyses performed and published as % of total"
 msgstr "Percentatge d'anàlisis efectuades i publicades respecte del total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Percentatge d'anàlisis efectuades respecte del total"
 
@@ -493,27 +483,27 @@ msgstr "Informes d'analítiques"
 msgid "Analyses repeated"
 msgstr "Anàlisis repetides"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Els resultats de les anàlisis estan fora de rang"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Anàlisis reprocessats"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Resum d'anàlisis agrupats per departament"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Anàlisis que han estat reprocessats"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Anàlisi"
 
@@ -521,52 +511,52 @@ msgstr "Anàlisi"
 msgid "Analysis Attachment Option"
 msgstr "Opció de fitxers adjunts per a l'anàlisi"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categories d'anàlisi"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoria d'anàlisi"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Identificador de l'anàlisi"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Perfil d'anàlisi"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Perfils de sol·licitud d'anàlisis"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Sol·licitud d'anàlisis"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Identificador de la sol·licitud d'anàlisis"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importacions de sol·licituds d'anàlisis"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Prioritats en sol·licituds d'anàlisis"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Especificacions de sol·licitud d'anàlisis"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Sol·licituds d'anàlisis"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Servei d'anàlisi"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Serveis d'anàlisi"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Especificacions d'anàlisi"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificacions d'anàlisi"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Estat de l'anàlisi"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipus d'anàlisi"
@@ -641,46 +631,46 @@ msgstr "Tipus d'anàlisi"
 msgid "Analysis category"
 msgstr "Categoria d'anàlisis"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "La sol·licitud d'anàlisis ${AR} s'ha creat satisfactòriament"
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Les sol·licituds d'anàlisis ${ARs} s'han creat satisfactòriament"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Sol·licituds d'anàlisis i les anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Sol·licituds d'anàlisis i anàlisis per client"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Sol·licituds d'anàlisis no facturades"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Resultat d'anàlisi dintre del rang d'error"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Resultats d'anàlisis"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Resultats d'anàlisis per a ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Resultats d'anàlisi per punt de mostreig i servei d'anàlisi"
 
@@ -688,12 +678,12 @@ msgstr "Resultats d'anàlisi per punt de mostreig i servei d'anàlisi"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Els resultats de l'anàlisi estan fora del rang especificat pel laboratori o client. Això pot trigar uns minuts"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Servei d'anàlisi"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Reestabliment de les especificacions d'anàlisi als valors per defecte del laboratori."
 
@@ -709,17 +699,17 @@ msgstr "Temps de resposta per a l'anàlisi"
 msgid "Analysis turnaround time over time"
 msgstr "Anàlisi fora de temps"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Temps de resposta dels anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Anàlisis fora de temps"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr "Ha d'indicar un analista."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Qualsevol"
 
@@ -740,7 +730,7 @@ msgstr "Aplica els canvis"
 msgid "Apply template"
 msgstr "Aplica plantilla"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Aplica els canvis a tot"
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Assignat"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Assignat a full de treball"
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Adjunta a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Fitxer adjunt"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Claus d'adjunt"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Fitxers adjunts"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipus de fitxer adjunt"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipus de fitxers adjunts"
 
@@ -814,25 +804,25 @@ msgstr "Tipus de fitxers adjunts"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "No es permeten adjuncions"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Adjuncions obligatòries"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipus de fitxer adjunt"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Fitxers adjunts"
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Omple automàticament"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Importació automàtica"
 
@@ -861,27 +851,27 @@ msgstr "Impressió automàtica d'enganxines"
 msgid "Available templates"
 msgstr "Plantilles disponibles"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "TAT promig"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Promig anticipat"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Promig de retràs"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Oficina bancària"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nom del banc"
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lot"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID Lot"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etiquetes per a lots"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lots"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Retard"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Abans de ${start_date}"
 
@@ -922,7 +912,7 @@ msgstr "Abans de ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Icona gran"
 
@@ -930,7 +920,7 @@ msgstr "Icona gran"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuració de Bika LIMS"
 
@@ -938,63 +928,67 @@ msgstr "Configuració de Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Adreça de facturació"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blanc"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Anàlisis de QC per a mostres blanc"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Descompte per volum admès"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Preu amb descompte per volum (sense IVA)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Telèfon del negoci"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Per"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "Contactes amb còpia"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Correus"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calcula la precisió en base als valors d'incertesa"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Càlcul"
 
@@ -1002,8 +996,8 @@ msgstr "Càlcul"
 msgid "Calculation Formula"
 msgstr "Fórmula de càlcul"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Camps de càlcul provisionals"
@@ -1016,11 +1010,11 @@ msgstr "Càlcul: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Càlcul: cap"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Càlculs"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibració"
 
@@ -1032,12 +1026,12 @@ msgstr "Certificats de calibratge"
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancel·lat"
 
@@ -1069,18 +1063,18 @@ msgstr "No s'ha pogut desactivar el càlcul perquè hi ha serveis d'anàlisi act
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Un mateix usuari no pot introduïr resultats i verificar-los després"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacitat"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturat"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número del catàleg"
 
@@ -1097,17 +1091,17 @@ msgstr "Número del catàleg"
 msgid "Categorise analysis services"
 msgstr "Agrupa els serveis d'anàlisi en categories"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "No es pot desactivar la categoria perquè té serveis d'anàlisi associats"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Número de certificat"
 
@@ -1120,31 +1114,31 @@ msgstr "Codi de certificat"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Marqueu aquesta casella si el servei d'anàlisi està en procés d'acreditació"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Marqueu aquesta casella si les mostres recollides en aquest punt de mostreig s'han de considerar en conjunt (composició). Per exemple, les mostres recollides en punts diferents de la riba d'una bassa s'acostumen a mesclar per a que siguin una mostra representativa de la totalitat de la bassa"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Marqueu la casella de verificació si el contenidor ja està sota conservació, això farà que el sistema ometi el circuit de preservació per a les mostres del contenidor."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Nivell de prioritat per defecte"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Marqueu la casella si el laboratori està acreditat"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Marqueu aquesta casella si voleu utilitzar un contenidor de mostra separat per aquest servei d'anàlisi"
 
@@ -1152,7 +1146,7 @@ msgstr "Marqueu aquesta casella si voleu utilitzar un contenidor de mostra separ
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Marqueu si voleu utilitzar un ID server diferent. Podeu configurar els prefixos individualment per a cada lloc Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr "Ciutat"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clàssic"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Feu clic sobre les capçaleres de categories d'anàlisi (amb fons gris) per veure els serveis d'anàlisi que contenen cada una d'elles. Introduïu els valors mínim i màxim per indicar el rang vàlid del resultats. Si el resultat es troba fora d'aquest rang, el sistema mostrarà una alerta. El camp % Error li permet indicar el percentatge d'incertesa que ha de tenir en compte el sistema en avaluar els resultats enfront del rang indicat. Si un resultat fora de rang passa a ser vàlid quan el sistema té en compte el percentatge d'incertesa, l'alerta del sistema serà menys severa."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Feu clic sobre les capçaleres de les categories d'anàlisi (amb fons gris) per veure els serveis d'anàlisi que conté cada una d'elles. Introduïu els valors mínim i màxim per indicar el rang vàlid del resultats. Si el resultat es troba fora d'aquest rang, el sistema mostrarà una alerta. El camp \"% Error\" li permet indicar el percentatge d'incertesa que ha de tenir en compte el sistema en avaluar els resultats enfront del rang indicat. Si un resultat, tot i estar fora de rang, té un valor dins del percentatge d'incertesa, l'alerta del sistema serà menys severa."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Feu clic sobre les capçaleres de les categories d'anàlisi (amb fons gris) per veure els serveis d'anàlisi que conté cada una d'elles. Introduïu els valors mínim i màxim per indicar el rang vàlid del resultats. Si el resultat es troba fora d'aquest rang, el sistema mostrarà una alerta. El camp \"% Error\" li permet indicar el percentatge d'incertesa que ha de tenir en compte el sistema en avaluar els resultats enfront del rang indicat. Si un resultat, tot i estar fora de rang, té un valor dins del percentatge d'incertesa, l'alerta del sistema serà menys severa. Si el resultat està per sota del valor indicat al camp \"< Min\", el resultat es mostrarà com a \"< [min]\". El mateix criteri s'aplica per a resultats per sobre del valor indicat al camp \"> Màx\""
 
@@ -1188,19 +1182,19 @@ msgstr "Feu clic sobre les capçaleres de les categories d'anàlisi (amb fons gr
 msgid "Click to download"
 msgstr "Descarrega"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Client"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID de Lot del Client"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID de client"
 
@@ -1208,59 +1202,59 @@ msgstr "ID de client"
 msgid "Client Landing Page"
 msgstr "Pàgina d'entrada del client"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nom del client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Comanda de client"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Número de comanda del client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. del client"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referència del client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "ID de la mostra del client"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "ID de mostra assignat pel client"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Per a poder tramitar una sol·licitud d'anàlisis cal que el client tingui, com a mínim, un contacte associat"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clients"
 
@@ -1269,39 +1263,39 @@ msgstr "Clients"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Tancats"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Codi d'ubicació"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Codi del lloc"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Codi del prestatge"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Coma (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentaris"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Comentaris o interpretació de resultats"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1309,21 +1303,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composició"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "% Nivell de confiança"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configuració de les particions de mostres i mètodes de conservació assignats a la plantilla. Podeu assignar anàlisis a diferents particions des de la pestanya de plantilla d'anàlisis."
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "Confirmeu la paraula de pas"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Consideracions"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contacte"
@@ -1347,8 +1341,8 @@ msgstr "Contacte"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contactes"
@@ -1357,48 +1351,48 @@ msgstr "Contactes"
 msgid "Contacts to CC"
 msgstr "Contactes amb còpia - CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Contenidor"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipus de contenidor"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipus de contenidors"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Contenidors de mostres"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipus de contingut"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipus de contingut"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Control"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Anàlisi de QC per a mostres control"
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Còpia de"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Fes una còpia"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Recompte"
 
@@ -1432,18 +1426,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Crea una nova mostra d'aquest tipus"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creat"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creat per"
 
@@ -1451,7 +1445,7 @@ msgstr "Creat per"
 msgid "Created by:"
 msgstr "Creat per:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Creat per"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criteri"
 
@@ -1468,12 +1462,12 @@ msgstr "Criteri"
 msgid "Currency"
 msgstr "Moneda"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "En curs"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Caràcter de puntuació decimal personalitzat"
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr "Interfície de dades"
 msgid "Data Interface Options"
 msgstr "Opcions d'interfície de dades"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Registre d'entrada diària de dades"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Data de creació"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Data d'enviament"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Data d'exclusió"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Data de caducitat"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Data d'importació"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Data de càrrega"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Data d'obertura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Data de conservació"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Data de publicació"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Data de recepció"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Data de sol·licitud"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Data de mostreig"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr "Data d'inici de validesa del certificat de calibratge"
 msgid "Date from which the instrument is under calibration"
 msgstr "Data d'inici de calibratge de l'instrument"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Data d'inici de manteniment de l'instrument"
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr "Data de fi de validesa del certificat de calibratge"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Data fins que l'instrument no estarà disponible"
@@ -1624,11 +1618,11 @@ msgstr "Data fins que l'instrument no estarà disponible"
 msgid "Date when the calibration certificate was granted"
 msgstr "Data d'expedició del certificat de calibratge"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dies"
 
@@ -1640,17 +1634,17 @@ msgstr "Desactiva l'instrument fins al pròxim test intern de calibratge"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Caràcter de puntuació decimal que cal utliitzar en els informes de resultats per aquest client."
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Per defecte"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Càlcul per defecte"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Contenidor per defecte"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tipus de contenidor per defecte"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Instrument per defecte"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Mètode per defecte"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Mètode de conservació per defecte"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Prioritat per defecte"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "El càlcul per defecte s'obté del mètode seleccionat per defecte. Pot canviar el càlcul per defecte desde la vista d'edició del mètode."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categories per defecte"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Contenidor per defecte per a noves particions de mostra"
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Contenidors per defecte: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Caràcter de puntuació decimal per defecte"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr "Notació científica per defecte en els informes de resultats"
 msgid "Default scientific notation format for results"
 msgstr "Notació científica per defecte en resultats"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valor per defecte"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Número de decimals a utilitzar per aquest resultat"
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Precisió a partir de la qual s'ha d'utilitzar notació exponencial. El valor per defecte és 7."
 
@@ -1769,16 +1763,16 @@ msgstr "Precisió a partir de la qual s'ha d'utilitzar notació exponencial. El 
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Graus"
 
@@ -1786,9 +1780,9 @@ msgstr "Graus"
 msgid "Delete attachment"
 msgstr "Elimina el fitxer adjunt"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Departament"
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Anàlisis dependents"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Descripció del mètode en llenguatge planer. Aquesta informació estarà disponible als clients del laboratori."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descripció"
 
@@ -1815,7 +1809,7 @@ msgstr "Descripció"
 msgid "Description of the actions made during the calibration"
 msgstr "Descripció de les accions realitzades durant el procés de calibratge"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Descripció de les accions realitzades durant el procés de manteniment"
 
@@ -1823,19 +1817,19 @@ msgstr "Descripció de les accions realitzades durant el procés de manteniment"
 msgid "Description of the actions made during the validation"
 msgstr "Descripció de les accions realitzades durant la validació"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Descripció de la ubicació"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Descripció del prestatge"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Descripció del lloc"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Descompte %"
 
@@ -1851,16 +1845,16 @@ msgstr "Descompte %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviat"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Valor a mostrar"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr "Mostra una alerta quan hi hagi disponible una nova versió de Bika LIMS"
 msgid "Display individual sample partitions "
 msgstr "Mostra les particions de mostra de manera individual"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Data d'eliminació"
 
@@ -1881,8 +1875,8 @@ msgstr "Data d'eliminació"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminats"
@@ -1891,54 +1885,54 @@ msgstr "Eliminats"
 msgid "District"
 msgstr "Regió"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Divisió per zero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Document"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inactius"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Punt (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "No disponible desde"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "No disponible fins"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Descàrrega"
 
@@ -1951,20 +1945,20 @@ msgstr "Dessecar"
 msgid "Dry matter analysis"
 msgstr "Anàlisi de matèria seca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Venciment"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Data de venciment"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Var. dup."
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplicat"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicat de"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Anàlisis de QC per a duplicats"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "% de variació entre duplicats"
 
@@ -1998,35 +1992,35 @@ msgstr "QC de duplicat d'anàlisi"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Gràfics de control de qualitat per anàlisis duplicats"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Durada"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "P. ex. ENAC, Applus, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Precocitat"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Recent"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Elevació"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Correu electrònic"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Adreça de correu electrònic"
 
@@ -2034,7 +2028,7 @@ msgstr "Adreça de correu electrònic"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Assumpte"
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Data de finalització"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Millores"
 
@@ -2073,16 +2067,16 @@ msgstr "Introduïu un nom d'usuari, que normalment és similar a 'jgarcia'. No i
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Introduïu una adreça de correu electrònic. Això és necessari en cas de pèrdua de la contrasenya. La vostra privacitat està garantida i no donarem la vostra adreça a tercers ni tampoc la farem pública enlloc."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Introduïu el percentatge de descompte"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Introduïu un percentatge, p. ex. 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introduïu un percentatge, p. ex. 14.0. Aquest percentatge s'aplicarà a tot el sistema però el podreu sobreescriure individualment a cada element."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Introduïu un percentatge, p. ex. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Introduïu la latitud del punt de mostreig en graus (de 0 a 90), minuts (de 0 a 59), segons (0 a 59) i orientació N/S"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Introduïu la longitud del punt de mostreig en graus (de 0 a 90), minuts (0 a 59), segons (0 a 59) i orientació E/W"
 
@@ -2106,7 +2100,7 @@ msgstr "Introduïu la longitud del punt de mostreig en graus (de 0 a 90), minuts
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Introdueix els detalls de cada una de les anàlisis que desitgeu copiar."
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr "Entitat"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Exclou de la factura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Resultat esperat"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Valors esperats"
 
@@ -2161,19 +2155,19 @@ msgstr "Valors esperats"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Caducats"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Data de caducitat"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Precisió en format exponencial"
 
@@ -2181,44 +2175,40 @@ msgstr "Precisió en format exponencial"
 msgid "Exponential format threshold"
 msgstr "Llindar en format exponencial"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (negoci)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Dona"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Camp"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Anàlisis de camp"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Camp de preservació"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Títol del camp"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Fitxer"
 
@@ -2226,19 +2216,19 @@ msgstr "Fitxer"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nom del fitxer"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Nom"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Fórmula"
 
@@ -2277,18 +2267,18 @@ msgstr "Fórmula"
 msgid "From"
 msgstr "Desde"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Desde ${start_date} fins a ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Mostra amb futura assignació de data"
 
@@ -2298,7 +2288,7 @@ msgstr "Mostra amb futura assignació de data"
 msgid "Generate report"
 msgstr "Genera l'informe"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Títol de cortesia, com p. ex. Sr., Sra. o Dr."
 
@@ -2310,37 +2300,37 @@ msgstr "Podeu agrupar els serveis d'anàlisi en categories des de la pàgina de 
 msgid "Group by"
 msgstr "Agrupa per"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Periode d'agrupació"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Perillós"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Camp ocult"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Hores"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2349,8 +2339,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "URL del servidor d'IDs"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "Servidor d'IDs no disponible"
 
@@ -2358,31 +2348,31 @@ msgstr "Servidor d'IDs no disponible"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Si està activat, el nom de l'anàlisi es mostrarà en cursiva"
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Si és necessari, seleccioneu el càlcul associat a l'anàlisi. Podeu configurar els càlculs des de l'apartat 'Càlculs'"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Seleccioneu el càlcul associat a l'anàlisi si és necessari. Podeu configurar els càlculs des de l'apartat 'Càlculs'"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Mètode de conservació del contenidor."
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importació"
@@ -2452,7 +2442,7 @@ msgstr "Importació"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importats"
@@ -2461,8 +2451,8 @@ msgstr "Importats"
 msgid "In-lab calibration procedure"
 msgstr "Procediment de calibratge intern"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Desactivats"
@@ -2471,7 +2461,7 @@ msgstr "Desactivats"
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Inclou les descripcions"
 
@@ -2487,30 +2477,27 @@ msgstr "Inclou les descripcions"
 msgid "Include year in ID prefix"
 msgstr "Inclou l'any en el prefix de l'ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Resultat indeterminat"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indica si és necessari l'adjunció de documents per aquest anàlisi i, per tant, si la opció de càrrega de fitxer estarà disponible en les pantalles de captura de dades."
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisió inicial"
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instruccions"
@@ -2547,17 +2534,17 @@ msgstr "Instrucccions per a les rutines regulars de calibratge intern efectuades
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instruccions per a les rutines de manteniment regular i preventiu efectuades pels analistes"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Equip"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Calibratges de l'equip"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr "Importació des d'equip"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Manteniment de l'equip"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Tasques programades per a l'equip"
 
@@ -2587,19 +2574,19 @@ msgstr "Tasques programades per a l'equip"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Tipus d'equips"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validacions de l'equip"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr "Tipus d'equip"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Equips"
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Proves de calibratge intern"
 
@@ -2685,24 +2672,21 @@ msgstr "Interpolació"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "No vàlides"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Factura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Data de factura"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Exclòs de facturació"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "L'element està desactivat."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Elements que han de ser inclosos a l'assumpte del correu electrònic"
 
@@ -2756,7 +2740,7 @@ msgstr "Elements que han de ser inclosos a l'assumpte del correu electrònic"
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Càrrec"
 
@@ -2764,12 +2748,12 @@ msgstr "Càrrec"
 msgid "Key"
 msgstr "Clau"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Identificador"
@@ -2778,47 +2762,47 @@ msgstr "Identificador"
 msgid "Keywords"
 msgstr "Paraules clau"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratori"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Anàlisis del laboratori"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contactes del laboratori"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Departaments del laboratori"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Preservació en el Laboratori"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Productes del laboratori"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL del laboratori"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etiqueta"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratori"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratori acreditat"
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Última modificació"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Amb retard"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Anàlisis amb retard"
@@ -2854,7 +2838,7 @@ msgstr "Anàlisis amb retard"
 msgid "Late Analysis"
 msgstr "Anàlisi amb retard"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitud"
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Mostra enllaçada"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr "Llista les mostres rebudes entre un rang de dates"
 msgid "Load Setup Data"
 msgstr "Càrrega de les dades inicials"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Carregueu aquí els documents que descriuen el mètode"
 
@@ -2904,41 +2888,41 @@ msgstr "Carrega des d'un fitxer"
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Carregat"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Registre"
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitud"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Número de lot"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Adreça d'enviament de correus electrònics"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Responsable del manteniment"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Tipus de manteniment"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Home"
 
@@ -2999,16 +2983,16 @@ msgstr "Home"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Correu electrònic del responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telèfon del responsable"
 
@@ -3016,31 +3000,25 @@ msgstr "Telèfon del responsable"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabricant"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Fabricant"
 
@@ -3049,14 +3027,14 @@ msgstr "Fabricant"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Temps màxim"
 
@@ -3064,30 +3042,30 @@ msgstr "Temps màxim"
 msgid "Maximum columns per results email"
 msgstr "Número màxim de columnes als resultats per correu electrònic"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Mida o volum màxims admesos per mostra"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Temps màxim permès per a la consecució d'un anàlisi. El sistema mostrarà una alerta pels anàlisis en retard"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Temps màxim de resposta"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "% de descompte per a clients habituals"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Aplicar descompte de client habitual"
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Mètode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Document del mètode"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instruccions del mètode"
 
@@ -3123,9 +3101,9 @@ msgstr "Mètode: ${method_name}"
 msgid "Method: None"
 msgstr "Mètode: cap"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Mètodes"
 
@@ -3133,17 +3111,17 @@ msgstr "Mètodes"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Mètodes que està previst que siguin acreditats properament per ${accreditation_body}. Els comentaris i observacions no estan acreditats."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3155,8 +3133,8 @@ msgstr "Mine"
 msgid "Minimum 5 characters."
 msgstr "Mida mínima de 5 caràcters."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volum mínim"
 
@@ -3164,27 +3142,27 @@ msgstr "Volum mínim"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínim de resultats pels càlculs estadístics de QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minuts"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Telèfon mòbil"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Data de modificació"
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr "Més"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nom"
 
@@ -3225,17 +3203,17 @@ msgstr "Nom"
 msgid "New"
 msgstr "Nou"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "No"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "No s'ha trobat cap sol·licitud d'anàlisis per al criteri de cerca indicat"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "No heu seleccionat cap anàlisi"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "No s'han trobat anàlisis per als criteris de consulta indicats"
 
@@ -3274,23 +3252,23 @@ msgstr "No s'ha afegit cap anàlisi"
 msgid "No analyses were added to this worksheet."
 msgstr "No s'ha afegit cap anàlisi a aquesta fulla de treball."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "No heu seleccionat cap servei d'anàlisi"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Sense canvis."
 
@@ -3298,7 +3276,7 @@ msgstr "Sense canvis."
 msgid "No control type specified"
 msgstr "No heu indicat el tipus de control"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr "No heu especificat cap contenidor per defecte pel servei"
 msgid "No default preservations specified for this service"
 msgstr "No heu especificat cap protocol de conservació pel servei"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "No s'ha trobat cap acció en l'històric per al criteri de cerca indicat"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "No heu seleccionat cap element"
 
@@ -3328,7 +3306,7 @@ msgstr "No heu seleccionat cap element"
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "No heu seleccionat cap mostra de referència"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "No s'ha trobat cap mostra per al criteri de cerca indicat"
 
@@ -3365,25 +3343,22 @@ msgstr "El contacte ${contact_fullname} no té registrades credencials d'accés 
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Cap"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "No està permès"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Número de sol·licituds d'anàlisis i anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Número de sol·licituds d'anàlisis i anàlisis per client"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Número d'anàlisis"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Número d'anàlisis fora de rang per periode"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Número d'anàlisis sol·licitats per servei d'anàlisi"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Número d'anàlisis sol·licitats per tipus de mostra"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Número d'anàlisis reprocessats per periode"
 
@@ -3454,15 +3429,15 @@ msgstr "Número d'anàlisis reprocessats per periode"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Número i percentatge d'anàlisis sol·licitades i publicades per departament respecte del total d'anàlisis realitzades"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Número de sol·licituds"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Número de mostres"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "La mostra es descartarà durant el període de temps indicat tan bon punt s'estableixi en estat de conservació. Si no s'especifica res, s'utilitzarà el període de retenció per tipus de mostra."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Obert"
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr "Comanda"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Data de comanda"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID de comanda"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Número de comanda"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Comandes"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Altres informes de productivitat"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr "Format de sortida"
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Partició"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr "Paraula de pas"
 msgid "Password lifetime"
 msgstr "Temps de vida de les contrasenyes"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pendent"
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr "Període"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Permès"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "% d'error permès"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telèfon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telèfon (negoci)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telèfon (casa)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telèfon (mòbil)"
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Adreça postal"
 
@@ -3678,7 +3647,7 @@ msgstr "Adreça postal"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Des d'aquí podeu restringir els resultats de l'anàlisi a opcions específiques. Per exemple, si només voleu que es puguin escollir com a resultat alguna de les opcions 'Positiu', 'Negatiu' o 'Indeterminat'. El valor de l'opció ha de ser un numèric."
 
@@ -3686,19 +3655,19 @@ msgstr "Des d'aquí podeu restringir els resultats de l'anàlisi a opcions espec
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Pengeu el logotip que la entitat acreditadora us ha autoritzat a utilitzar a la vostra web i als informes de resultats. La mida màxima és de 175x175 píxels."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Punt de mostreig"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posició"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Adreça postal"
 
@@ -3721,16 +3690,16 @@ msgstr "Adreça postal"
 msgid "Postal code"
 msgstr "Codi postal"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "En pre-conservació"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Precisió en número de decimals"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefix"
 
@@ -3766,12 +3735,12 @@ msgstr "Prefix"
 msgid "Prefixes"
 msgstr "Prefixos"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Conservació"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Categoria de conservació"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Conservacions"
 
@@ -3814,14 +3783,14 @@ msgstr "Conservacions"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Conservant"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Preventiu"
 
@@ -3829,34 +3798,34 @@ msgstr "Preventiu"
 msgid "Preventive maintenance procedure"
 msgstr "Procediment de manteniment preventiu"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Import"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Import (sense IVA)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Import sense IVA"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Llista de preus"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr "Data d'impressió:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr "Informes de productivitat"
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Perfil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Perfils d'anàlisi"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Identificador del perfil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Clau d'identificació del perfil"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Perfils"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr "Retard publicació"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr "Preferències"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publicat"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Sol·licituds d'anàlisis publicades que estan pendents de facturar"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr "Quantitat"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Llindar màxim"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Llindar mínim"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Especificació de rang"
 
@@ -4031,9 +4000,9 @@ msgstr "Rep"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Rebuda"
 
@@ -4041,11 +4010,11 @@ msgstr "Rebuda"
 msgid "Recept. Lag"
 msgstr "Retard recepció"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referència"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Definició de referència"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Definicions de referència"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Mostra de referència"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Mostres de referència"
 
@@ -4086,16 +4055,16 @@ msgstr "Mostres de referència"
 msgid "Reference Supplier"
 msgstr "Proveïdor de mostres de referència"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Tipus de referència"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valors de referència"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Anàlisis de control de qualitat QC estàndar"
@@ -4104,7 +4073,7 @@ msgstr "Anàlisis de control de qualitat QC estàndar"
 msgid "Reference analysis quality control graphs"
 msgstr "Gràfics d'anàlisis de control de qualitat estàndar"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Gràfics de control de qualitat d'anàlisis de referència"
 
@@ -4112,21 +4081,21 @@ msgstr "Gràfics de control de qualitat d'anàlisis de referència"
 msgid "Reference sample"
 msgstr "Mostra de referència"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Els valors per a les mostres de referència són zero o 'blanc'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition representa una definició de referència o un tipus de mostra que s'utilitza per a les proves de control de qualitat"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Comentaris"
 
@@ -4169,7 +4138,7 @@ msgstr "Comentaris"
 msgid "Remarks to take into account before calibration"
 msgstr "Aspectes a tenir en compte abans de realitzar el calibratge"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Aspectes a tenir en compte abans de realitzar la tasca"
 
@@ -4177,7 +4146,7 @@ msgstr "Aspectes a tenir en compte abans de realitzar la tasca"
 msgid "Remarks to take into account before validation"
 msgstr "Aspectes a tenir en compte abans d'efectuar la validació"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Aspectes a tenir en compte en el procés de manteniment"
 
@@ -4186,8 +4155,8 @@ msgstr "Aspectes a tenir en compte en el procés de manteniment"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Reparació"
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr "Anàlisis repetits"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Informe"
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Tipus d'informe"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Informa com a matèria seca"
 
@@ -4242,7 +4211,7 @@ msgstr "Informe comparatiu entre número de mostres rebudes i el número de resu
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Sol·licituds d'anàlisis tramitades durant un període de temps concret"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Tipus d'informe"
 
@@ -4250,7 +4219,7 @@ msgstr "Tipus d'informe"
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Informes"
 
@@ -4259,15 +4228,15 @@ msgstr "Informes"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Sol·licitud"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID de la sol·licitud"
 
@@ -4275,26 +4244,26 @@ msgstr "ID de la sol·licitud"
 msgid "Request new analyses"
 msgstr "Sol·licita noves anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Sol·licitats"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Sol·licituds"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Camp obligatori"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volum necessari"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Restringeix les categories"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultat"
 
@@ -4316,15 +4285,15 @@ msgstr "Resultat"
 msgid "Result Footer"
 msgstr "Peu de pàgina"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opcions per a resultats"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valor del resultat"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr "El resultat està fora de rang"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Resultats per punt de mostreig"
@@ -4375,14 +4344,14 @@ msgstr "Resultats per punt de mostreig"
 msgid "Results per samplepoint and analysis service"
 msgstr "Resultats per punt de mostreig i servei d'anàlisi"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Període de retenció"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Prova repetida"
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Tractament"
 
@@ -4434,19 +4403,19 @@ msgstr "Tractament"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Com en el cas anterior, però estableix el valor per defecte en serveis d'anàlisi. Podeu modificar aquesta propietat per a un anàlisi específic des de la seva pàgina de configuració"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Mostra"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr "Mostra pendent"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID de mostra"
 
@@ -4468,12 +4437,12 @@ msgstr "Mida de l'ID de la mostra"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Suports per a mostres"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Categoria del tipus de mostra"
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Particions de mostres"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Punt de mostreig"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Punts de mostreig"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Tipus de mostra"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefix del tipus de mostra"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Tipus de mostres"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Punt de mostreig"
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Informes de mostres"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Tipus de mostra"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Mostrejador"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Mostres"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Aquest tipus de mostres són perilloses"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Mostres rebudes respecte de mostres amb resultat publicat"
@@ -4620,62 +4589,62 @@ msgstr "Mostres rebudes respecte de mostres amb resultat publicat"
 msgid "Samples received vs. samples reported"
 msgstr "Mostres rebudes respecte de mostres amb resultat publicat"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Data de mostreig"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Origen del mostreig"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Origens de mostreig"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Freqüència de mostreig"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Guarda"
 
@@ -4700,17 +4669,17 @@ msgstr "Guarda els comentaris"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Tasca programada"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr "Cerca"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Segons"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Seleccioneu una interfície de dades"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Seleccioneu un mètode de preservació per defecte pel servei d'anàlisi. Si el mètode de preservació depèn de la combinació de tipus de mostres, especifiqueu un mètode de preservació per tipus de mostra de la taula de sota."
 
@@ -4751,11 +4720,11 @@ msgstr "Seleccioneu un mètode de preservació per defecte pel servei d'anàlisi
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Seleccioneu el destí i la sol·licitud d'anàlisis que voleu duplicar."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Seleccioneu algun dels responsables que estan registrats a l'apartat 'Contactes del laboratori. El sistema inclou els noms dels responsables de departament a tots els informes d'anàlisis que en pertanyen."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr "Selecciona tots els elements"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Seleccioneu els anàlisis que voleu incloure en aquesta plantilla"
 
@@ -4779,11 +4748,11 @@ msgstr "Selecciona l'analista"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Indiqueu si l'anàlisi s'ha d'excloure de la factura"
 
@@ -4791,19 +4760,19 @@ msgstr "Indiqueu si l'anàlisi s'ha d'excloure de la factura"
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Indiqueu si cal incloure les descripcions"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccioneu la moneda que s'ha de mostrar en els imports."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Seleccioneu el contenidor per defecte que cal utilitzar per aquest servei d'anàlisi. Si el contenidor depèn de la combinació de tipus de mostra i del mètode de conservació, especifiqueu el contenidor específic pel tipus de mostra."
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Seleccioneu l'equip preferit"
 
@@ -4849,7 +4818,7 @@ msgstr "Seleccioneu l'equip preferit"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr "Marqueu la casella per activa el flux de treball per a la recol·lecció
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Seleccioneu quins anàlisis voleu incloure a la fulla de treball."
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr "Separa"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Contenidor separat"
 
@@ -4909,32 +4878,28 @@ msgstr "Contenidor separat"
 msgid "Serial No"
 msgstr "Nº de serie"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Servei"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "El servei està acreditat per ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Serveis"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Tanca la tasca de manteniment"
 
@@ -4942,31 +4907,31 @@ msgstr "Tanca la tasca de manteniment"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Número màxim de resultats de sol·licituds d'anàlisis per correu electrònic. Tingueu en compte que massa columnes de resultats en un correu electrònic pot comprometre la llegibilitat."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Configura les especificacions del laboratori per als resultats del servei d'anàlisi"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Adreça d'enviament"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Només mostra les categories seleccionades a les vistes de client"
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Signatura"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Mida"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Especificacions"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Mida de la fulla de treball, com per exemple el nombre de posicions per a mostres d'un equip concret. Si seleccioneu mostres de QC, seleccioneu també quines mostres de referència han d'utilitzar-se. Si heu escollit un anàlisi duplicat, indiqueu també en quina posició es troba el duplicat"
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Estat"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Estat"
 
@@ -5081,33 +5042,33 @@ msgstr "Estat"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Tramet"
 
@@ -5115,37 +5076,34 @@ msgstr "Tramet"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Proveïdor"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Proveïdors"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Cognoms"
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Tasca"
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Tipus de tasca"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripció tècnica i instruccions pels analistes"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Perfil de sol·licitud d'anàlisis per a la plantilla"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "ID assignat pel laboratori a la sol·licitud del client"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "ID assignat pel laboratori a la mostra del client"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Adreça web del laboratori"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Normativa de l'acreditació, p. ex. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Anàlisis del perfil, agrupats per categoria"
 
@@ -5249,7 +5207,7 @@ msgstr "L'anàlisi que cal utilitzar per determinar la matèria seca"
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Analista o agent responsable del calibratge"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Analista o agent responsable del manteniment"
 
@@ -5257,12 +5215,12 @@ msgstr "Analista o agent responsable del manteniment"
 msgid "The analyst responsible of the validation"
 msgstr "Analitza responsable de la validació"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Els fitxers adjunts enllaçats a les sol·licituds d'anàlisis i a les anàlisis"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Categoria a la que pertany el servei d'anàlisi"
 
@@ -5270,19 +5228,19 @@ msgstr "Categoria a la que pertany el servei d'anàlisi"
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "El tipus de contenidor per defecte. Per a les noves particions de mostres s'assignarà aquest contenidor per defecte excepte si heu indicat un contenidor específic pel servei d'anàlisi."
 
@@ -5294,7 +5252,7 @@ msgstr "Aquest percentatge de descompte només s'aplicarà als clients que estig
 msgid "The full URL: http://URL/path:port"
 msgstr "L'adreça URL completa: http://URL/ruta:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Alçada o profunditat de mostreig"
 
@@ -5311,24 +5269,24 @@ msgstr "Número de model de l'equip"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "El laboratori no està acreditat o no s'ha configurat."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Departament del laboratori"
@@ -5345,27 +5303,27 @@ msgstr "Número de zeros de farciment pels identificadors de mostra."
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Número de zeros de farciment pel número i identificador d'una sol·licitud d'anàlisis"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Llista de punts de mostreig des d'on es poden recollir mostres. Si no selecciona cap punt de mostreig, estaran disponibles tots els punts de mostreig."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Llista de tipus de mostres que es poden recollir en aquest punt de mostreig. Si no selecciona cap tipus de mostra, estaran disponibles tots els tipus de mostra."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Les unitats de mesura pel resultat d'aquest servei d'anàlisi, com mg/l, ppm, dB, mV, etc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Volum mínim de mostra necessari per efectuar l'anàlisi (per exemple, '10 ml' o '1 kg')."
 
@@ -5389,7 +5347,7 @@ msgstr "Número de dies abans que caduqui la contrasenya. Si desitja que la cont
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de dies abans que caduqui la mostra, sense que pugui ser posteriorment analitzada. Aquesta propietat es pot sobreescriure individualment per a cada tipus de mostra a la pàgina de configuració de tipus de mostres."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr "El número de sol·licituds i d'anàlisis"
 msgid "The number of requests and analyses per client"
 msgstr "El número de sol·licituds i d'anàlisis per client"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Període de temps durant el qual es poden mantenir les mostres en un estat de no conservació abans que no caduquin i no puguin ser analitzades."
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "El preu per anàlisi que s'aplicarà als clients que tinguin assignat 'descompte per volum'"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "La paraula clau del perfil s'utilitza per a identificar-lo unívocament en els fitxers d'importació. Ha de ser únic, i no pot ser igual a cap dels identificadors utilitzats en els camps d'entrada per a càlculs."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Codi de referència que l'entitat acreditadora ha concedit al laboratori."
 
@@ -5447,11 +5405,11 @@ msgstr "Codi de referència que l'entitat acreditadora ha concedit al laboratori
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Els resultats per al camp d'anàlisi es capturaran durant el mostreig. Per exemple, la temperatura d'una mostra d'aigua del riu d'on s'ha recollit."
 
@@ -5459,7 +5417,7 @@ msgstr "Els resultats per al camp d'anàlisi es capturaran durant el mostreig. P
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de sèrie que identifica unívocament l'equip"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "La configuració per defecte del sistema respecte de si els fitxers adjunts a una sol·licitud d'anàlisis són un requisit, estan permesos o no. "
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "El temps de resposta dels anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "El temps de resposta dels anàlisis en funció del temps"
 
@@ -5507,7 +5465,7 @@ msgstr "El temps de resposta de les anàlisis"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "Els temps de resposta dels anàlisis en funció del temps"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "La paraula clau única utilitzada per identificar el servei d'anàlisi en els fitxers d'importació per a sol·licituds d'anàlisis i importacions de resultats des d'equips."
 
@@ -5519,37 +5477,37 @@ msgstr "No s'han trobat resultats."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "No s'ha pogut activar el servei d'anàlisi perquè el càlcul associat està desactivat."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "No s'ha pogut desactivar el servei d'anàlisi perquè com a mínim hi ha un càlcul activat que en depèn."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr "Aquest servei no necessita d'una partició per separat"
 msgid "This service requires a separate container."
 msgstr "Per aquest servei és necessari utilitzar un contenidor separat."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,13 +5527,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "El text s'inclourà com a peu de pàgina als informes de resultats"
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "El valor s'indica al capdavall de tots els resultats publicats"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Títol"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Fins"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "A conservar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Pendent de mostreig"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Pendent de verificar"
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5671,22 +5625,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr "Retard total"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Import total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Total d'anàlisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Total de punts de dades"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Import total"
 
@@ -5698,11 +5652,11 @@ msgstr "Total:"
 msgid "Traceability"
 msgstr "Traçabilitat"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Temps de resposta (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipus"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sense assignar"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incertesa"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valor d'incertesa"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Indefinit"
 
@@ -5772,13 +5720,13 @@ msgstr "Indefinit"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unitat"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "No publicat/da"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Carrega una firma digitalitzada per a que sigui impresa en els informes de resultats. Les dimensions recomanades són 250px d'amplada per 150px d'alçada"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr "Utilitza un ID server extern"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Utilitzeu aquests camps per passar paràmetres arbitraris als mòdul d'importació i d'exportació."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Usuari"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nom d'usuari"
@@ -5868,7 +5816,7 @@ msgstr "Historial d'usuari"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Històric d'accions dels usuaris"
@@ -5877,27 +5825,27 @@ msgstr "Històric d'accions dels usuaris"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Tingueu present que l'ús d'un número baix de punts de dades sol implicar que els resultats de càlcul estadístic no tinguin sentit. Establiu un número mínim acceptable de resultats abans que s'executin els càlculs estadístics de Control de Qualitat (QC)"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "CIF"
 
@@ -5905,11 +5853,11 @@ msgstr "CIF"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Vàlid des de"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Validesa fins"
 
@@ -5917,181 +5865,181 @@ msgstr "Validesa fins"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validació"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Error de validació: '${keyword}': paraula clau duplicada"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Error de validació: '${title}': La paraula clau ja està en ús pel càlcul '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Error de validació: '${title}': La paraula clau ja es troba en ús pel servei '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Error de validació:  '${title}': títol duplicat"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Error de validació: '${value}' no és únic"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Error de validació: l'orientació ha de ser E/W (Est/Oest)"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Error de validació: l'orientació ha de ser N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Error de validació: el percentatfe d'error ha de tenir un valor entre 0 i 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Error de validació: els valors esperats han d'estar dins del rang de valors mínim (Min) i màxim (Max)"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Error de validació: els valors esperats han de ser de tipus numèric"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Error de validació: la paraula clau '${keyword}' no és vàlida"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Error de validació: els valors màxims (Max) han de ser més grans que els valors mínims (Min)"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Error de validació: els valors màxims (Max) han de ser de tipus numèric"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Error de validació: els valors mínims (Min) han de ser de tipus numèric"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Error de validació: els percentatges d'error han de tenir un valor entre 0 i 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Error de validació: els percentatges d'error han de ser de tipus numèric"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Error de validació: els contenidors per a la pre-conservació han de tenir un mètode de conservació associat."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Error de validació: el valors resultat han de ser de tipus numèric"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Error de validació: és imprescindible que seleccioneu les categories següents: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Error de validació: la columna títol '${title}' ha de tenir la paraula clau '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Error de validació: els graus són 180; el valor per a minuts ha de ser zero"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Error de validació: els graus són 180; el valor de segons ha de ser zero"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Error de validació: els graus són 90; el valor de minuts ha de ser zero"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Error de validació: els graus són 90; el valor de segons ha de ser zero"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Error de validació: el valor dels graus ha de ser entre 0 i 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Error de validació: els graus han d'estar entre 0 i 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Error de validació: els graus han de ser de tipus numèric"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Error de validació: la paraula clau '${keyword}' ha de tenir '${title}' com a títol de columna"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Error de validació: hi han caràcters no vàlids en l'identificador"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Error de validació: no heu indicat la paraula clau"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Error de validació: els minuts han d'estar entre 0 i 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Error de validació: els minuts han de ser de tipus numèric"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Error de validació: els segons han d'estar entre 0 i 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Error de validació: els segons han de ser de tipus numèric"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Error de validació: no heu indicat el títol"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Validador"
@@ -6110,12 +6058,12 @@ msgstr "Validador"
 msgid "Value"
 msgstr "Valor"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Els valors que introdueixi aquí sobreescriuràn aquells valors que es troben especificats per defecte en els paràmetres del càlcul"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificat"
@@ -6126,7 +6074,7 @@ msgstr "Verificat"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versió"
 
@@ -6136,11 +6084,11 @@ msgstr "Versió"
 msgid "Volume"
 msgstr "Volum"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Adreça de correu electrònic de l'entitat acreditadora"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Si la diferència percentual entre els resultats d'una rèplica d'anàlisis en la fulla de treball per a la mateixa mostra i anàlisis, el sistema ho notificarà mitjançant una alerta"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Feina realitzada"
@@ -6176,25 +6124,25 @@ msgstr "Flux de treball"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Full de treball"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Disseny de la fulla de treball"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Plantilles per a fulles de treball"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Fulles de treball"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Sí"
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Heu de seleccionar un equip "
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "acció"
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "comentari"
 
@@ -6281,36 +6229,8 @@ msgstr "comentari"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr "desactiva"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "es repeteix cada"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "període de repetició"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr "summary_content_listing"
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr "fins"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "fins"
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/cs/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/cs/LC_MESSAGES/bika.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Czech (http://www.transifex.com/bikalabs/bika-lims/language/cs/)\n"
@@ -26,49 +26,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Chyba"
 
@@ -98,15 +98,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -118,15 +118,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Prázdná položka)"
@@ -139,7 +139,7 @@ msgstr "(Kontrolní)"
 msgid "(Duplicate)"
 msgstr "(Duplicitní)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -148,32 +148,26 @@ msgid "(Required)"
 msgstr "(Požadováno)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -184,16 +178,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgstr "AR Volby příloh"
 msgid "AR ID Padding"
 msgstr "AR ID balení"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "AR Import"
 
@@ -213,17 +207,17 @@ msgstr "AR Import"
 msgid "AR Import options"
 msgstr "AR Volby importu"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -231,54 +225,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Jméno účtu"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Číslo účtu"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Typ účtu"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akreditace"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Zkratka akreditačního orgánu"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL akreditačního orgánu"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Označení akreditace"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akreditováno"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -292,21 +286,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktivní"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Vložit"
 
@@ -326,11 +320,7 @@ msgstr "Vlož kontrolní vzorek"
 msgid "Add Duplicate"
 msgstr "Vlož duplicitní vzorek"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -338,16 +328,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -360,26 +350,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Vše"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Všechny vázané analýzy"
 
@@ -391,7 +381,7 @@ msgstr "Všechny analýzy typu"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -399,15 +389,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -415,11 +405,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -427,48 +417,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analýzy"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analýza mimo rozsah"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analýzy typu vzorku"
@@ -482,7 +472,7 @@ msgstr "Analýzy zakázky"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -495,27 +485,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Opakované analýzy"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analýzy"
 
@@ -523,52 +513,52 @@ msgstr "Analýzy"
 msgid "Analysis Attachment Option"
 msgstr "Volby přiložených analýz"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Kategorie analýz"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Kategorie analýzy"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Klíčové slovo analýzy"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Profil analýzy"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID požadavku analýzy"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importy analytických požadavků"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -576,65 +566,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Analytické požadavky"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Analytická služba"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Analytické služby"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Specifikace analýz"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Typ analýze"
@@ -643,46 +633,46 @@ msgstr "Typ analýze"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Požadavky analýz a analýzy"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Požadavky analýz a analýzy na klienta"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Požadavky analýz nefakturovány"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -690,12 +680,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -711,17 +701,17 @@ msgstr "Analytický čas"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analytik"
 
@@ -730,7 +720,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Jakýkoli"
 
@@ -742,7 +732,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Použij šablonu"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -760,15 +750,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Přiděleno"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -786,27 +776,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Připojit k"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Příloha"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Klíče příloh"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Volby příloh"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Typ přílohy"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Typy příloh"
 
@@ -816,25 +806,25 @@ msgstr "Typy příloh"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Přílohy"
 
@@ -846,7 +836,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -863,27 +853,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Pobočka banky"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Jméno banky"
 
@@ -892,31 +882,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Ložisko"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -924,7 +914,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -932,7 +922,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -940,63 +930,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Fakturační adresa"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blank"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Značka"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Služební telefon"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "V kopii"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Výpočet"
 
@@ -1004,8 +998,8 @@ msgstr "Výpočet"
 msgid "Calculation Formula"
 msgstr "Výpočetní vztah"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Výpočetní pole"
@@ -1018,11 +1012,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Výpočty"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1034,12 +1028,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1053,9 +1047,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Zrušen"
 
@@ -1071,18 +1065,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1091,7 +1085,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalogové číslo"
 
@@ -1099,17 +1093,17 @@ msgstr "Katalogové číslo"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Kategorie nemůže být daktivována v důsledku probíhající analýzy"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1122,31 +1116,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1154,7 +1148,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1170,19 +1164,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Typický"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1190,19 +1184,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Zákazník"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID zákazníka"
 
@@ -1210,59 +1204,59 @@ msgstr "ID zákazníka"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Jméno zákazníka"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Objednávka zákazníka"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. zákazníka"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Reference zákazníka"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Zákaznické SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Před přijetím požadavku zákazníka je vyžadován kontakt"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Klienti"
 
@@ -1271,39 +1265,39 @@ msgstr "Klienti"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1311,21 +1305,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Složení"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Konfidenční interval %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1334,13 +1328,13 @@ msgid "Confirm password"
 msgstr "Potvrzení hesla"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontakt"
@@ -1349,8 +1343,8 @@ msgstr "Kontakt"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontakty"
@@ -1359,48 +1353,48 @@ msgstr "Kontakty"
 msgid "Contacts to CC"
 msgstr "Kontakty v CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Nádoba"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Typ obsahu"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrola"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1416,12 +1410,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1434,18 +1428,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1453,7 +1447,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1461,8 +1455,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1470,12 +1464,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Aktuální"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1488,7 +1482,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1502,88 +1496,88 @@ msgstr "Datové rozhraní"
 msgid "Data Interface Options"
 msgstr "Volby datového rozhraní"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Datum"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Datum odeslání"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Dohodnutý termín"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Prodleva termínu"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Datum importu"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Datum příjmu"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Datum otevření"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Datum vydání"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Datum doručení"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Datum vyhotovení"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Datum odběru"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1599,7 +1593,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1617,7 +1611,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1626,11 +1620,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dny"
 
@@ -1642,17 +1636,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1660,49 +1654,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1711,11 +1705,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1739,11 +1733,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Implicitní hodnota"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1751,7 +1745,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1759,11 +1753,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1771,16 +1765,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Stupně"
 
@@ -1788,9 +1782,9 @@ msgstr "Stupně"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Oddělení"
 
@@ -1803,13 +1797,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Závislé analýzy"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Popis"
 
@@ -1817,7 +1811,7 @@ msgstr "Popis"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1825,19 +1819,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1845,7 +1839,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Sleva %"
 
@@ -1853,16 +1847,16 @@ msgstr "Sleva %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Odesláno"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Zobrazená hodhota"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1874,7 +1868,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1883,8 +1877,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Uspořádaný"
@@ -1893,54 +1887,54 @@ msgstr "Uspořádaný"
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Nevyužitý"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1953,20 +1947,20 @@ msgstr "Suchý"
 msgid "Dry matter analysis"
 msgstr "Analýza suchého vzorku"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1975,20 +1969,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -2000,35 +1994,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2036,7 +2030,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2056,14 +2050,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2075,16 +2069,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2092,15 +2086,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2108,7 +2102,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2116,45 +2110,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2163,19 +2157,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2183,44 +2177,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2228,19 +2218,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2260,16 +2250,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2279,18 +2269,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2300,7 +2290,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2312,37 +2302,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2351,8 +2341,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2360,31 +2350,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2396,7 +2386,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2404,27 +2394,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2432,7 +2422,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2445,7 +2435,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2454,7 +2444,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2463,8 +2453,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2473,7 +2463,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2481,7 +2471,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2489,30 +2479,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2536,7 +2523,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2549,17 +2536,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2572,16 +2559,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2589,19 +2576,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2645,9 +2632,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2671,7 +2658,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2687,24 +2674,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2712,43 +2696,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2758,7 +2742,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2766,12 +2750,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2780,47 +2764,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2840,13 +2824,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2856,7 +2840,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2878,11 +2862,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2894,7 +2878,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2906,41 +2890,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2965,35 +2949,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -3001,16 +2985,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3018,31 +3002,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3051,14 +3029,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3066,30 +3044,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3098,22 +3076,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3125,9 +3103,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3135,17 +3113,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3157,8 +3135,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3166,27 +3144,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3200,7 +3178,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3212,13 +3190,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3227,17 +3205,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3253,18 +3231,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3276,23 +3254,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3300,7 +3278,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3312,17 +3290,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3330,7 +3308,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3340,16 +3318,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3367,25 +3345,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3405,19 +3380,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3425,30 +3400,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3456,15 +3431,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3473,31 +3448,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3505,15 +3480,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3526,26 +3498,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3553,7 +3525,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3565,8 +3537,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3578,16 +3550,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3608,8 +3577,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3634,31 +3603,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3671,8 +3640,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3680,7 +3649,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3688,19 +3657,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3709,13 +3678,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3723,16 +3692,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3760,7 +3729,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3768,12 +3737,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3785,17 +3754,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3806,7 +3775,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3816,14 +3785,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3831,34 +3800,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3873,13 +3842,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3896,34 +3865,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3931,7 +3900,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3946,21 +3915,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3973,8 +3942,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3995,23 +3964,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4033,9 +4002,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4043,11 +4012,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4056,31 +4025,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4088,16 +4057,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4106,7 +4075,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4114,21 +4083,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4151,8 +4120,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4161,9 +4130,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4171,7 +4140,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4179,7 +4148,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4188,8 +4157,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4198,7 +4167,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4212,14 +4181,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4244,7 +4213,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4252,7 +4221,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4261,15 +4230,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4277,26 +4246,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4304,13 +4273,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4318,15 +4287,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4344,11 +4313,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4356,7 +4325,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4364,11 +4333,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4377,14 +4346,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4403,11 +4372,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4423,12 +4392,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4436,19 +4405,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4457,8 +4426,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4470,12 +4439,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4485,52 +4454,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4540,9 +4509,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4570,17 +4539,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4590,30 +4559,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4622,62 +4591,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4687,9 +4656,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4702,17 +4671,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4720,16 +4689,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4741,11 +4710,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4753,11 +4722,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4769,7 +4738,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4781,11 +4750,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4793,19 +4762,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4831,7 +4800,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4843,7 +4812,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4851,7 +4820,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4875,7 +4844,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4891,7 +4860,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4903,7 +4872,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4911,32 +4880,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4944,31 +4909,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4984,7 +4949,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4996,29 +4961,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5026,14 +4987,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5041,41 +5002,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5083,33 +5044,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5117,37 +5078,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5167,11 +5125,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5180,20 +5138,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5211,35 +5169,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5251,7 +5209,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5259,12 +5217,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5272,19 +5230,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5296,7 +5254,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5313,24 +5271,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5347,27 +5305,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5391,7 +5349,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5408,11 +5366,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5429,19 +5387,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5449,11 +5407,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5461,7 +5419,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5473,11 +5431,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5485,19 +5443,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5509,7 +5467,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5521,37 +5479,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5563,7 +5521,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5571,12 +5529,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5591,63 +5545,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5659,13 +5613,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5673,22 +5627,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5700,11 +5654,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5712,61 +5666,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5774,13 +5722,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5805,17 +5753,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5827,11 +5775,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5839,7 +5787,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5851,13 +5799,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5870,7 +5818,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5879,27 +5827,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5907,11 +5855,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5919,181 +5867,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6101,7 +6049,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6112,12 +6060,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6128,7 +6076,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6138,11 +6086,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6150,24 +6098,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6178,25 +6126,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6204,9 +6152,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6218,7 +6166,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6226,11 +6174,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6246,15 +6194,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6283,36 +6231,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6324,7 +6244,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6372,19 +6292,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6392,19 +6312,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6423,19 +6343,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6447,7 +6356,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6455,7 +6364,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6480,7 +6389,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6492,6 +6401,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/da_DK/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/da_DK/LC_MESSAGES/bika.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Danish (Denmark) (http://www.transifex.com/bikalabs/bika-lims/language/da_DK/)\n"
@@ -26,49 +26,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Fejl"
 
@@ -98,15 +98,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -118,15 +118,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "\"Classic\" angiver importere analyse requests pr prøve og analyse service valg. Med 'Profiler', er analyse profil søgeord bruges til at vælge flere analyser sammen"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blank)"
@@ -139,7 +139,7 @@ msgstr "(Kontrol)"
 msgid "(Duplicate)"
 msgstr "(Dublet)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -148,32 +148,26 @@ msgid "(Required)"
 msgstr "(Påkrævet)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -184,16 +178,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgstr "AR Attachment Option"
 msgid "AR ID Padding"
 msgstr "AR ID Padding"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "AR Import"
 
@@ -213,17 +207,17 @@ msgstr "AR Import"
 msgid "AR Import options"
 msgstr "AR Import options"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "AR Templates"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -231,54 +225,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Konto Navn"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Kontotype"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akkreditering"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akkrediteringsorganet Forkortelse"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akkrediteringsorganet URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akkreditering logo"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akkreditering reference"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "akkrediteret"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -292,21 +286,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktiv"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Tilføj"
 
@@ -326,11 +320,7 @@ msgstr "Tilføj Kontrol reference"
 msgid "Add Duplicate"
 msgstr "Tilføj Dublet"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -338,16 +328,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -360,26 +350,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Alle"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Alle tildelte analyser"
 
@@ -391,7 +381,7 @@ msgstr "Alle analyser af typen"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -399,15 +389,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -415,11 +405,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -427,48 +417,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analyser"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analyse uden for område"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analyser pr prøvetype"
@@ -482,7 +472,7 @@ msgstr "Analyser per tjenester"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -495,27 +485,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Analyse gentaget"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analyse"
 
@@ -523,52 +513,52 @@ msgstr "Analyse"
 msgid "Analysis Attachment Option"
 msgstr "Analyse Bilag Option"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Analyse kategorier"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Analyse Kategori"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Analyse Søgeord"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Analyse Profil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Analyseprofiler"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Analyse Request-ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Analyse Request Import"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -576,65 +566,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Analysis Requests"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Analyse service"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Analyse Services"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Analyse Specifikationer"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Analysetype"
@@ -643,46 +633,46 @@ msgstr "Analysetype"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Analyse requests og analyser"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Analyse requests og analyser per klient"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Analyse requests ikke faktureret"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -690,12 +680,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -711,17 +701,17 @@ msgstr "Analyse turnaround tid"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analytiker"
 
@@ -730,7 +720,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Alle"
 
@@ -742,7 +732,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Anvend template"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -760,15 +750,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Tildelt"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -786,27 +776,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Vedhæft til"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "bilag"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "vedhæftede filer nøgler"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Attachment Option"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Bilag Type"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Bilagstyper"
 
@@ -816,25 +806,25 @@ msgstr "Bilagstyper"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Vedhæftede filer ikke tilladt"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Vedhæftede filer kræves"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Bilag"
 
@@ -846,7 +836,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -863,27 +853,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Bankfilial"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Banknavn"
 
@@ -892,31 +882,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Bearing"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -924,7 +914,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -932,7 +922,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -940,63 +930,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Faktura adresse"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blank"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Mærke"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Bulk pris (excl. moms)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Business Phone"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Beregning"
 
@@ -1004,8 +998,8 @@ msgstr "Beregning"
 msgid "Calculation Formula"
 msgstr "Beregning formel"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Beregning foreløbige felter"
@@ -1018,11 +1012,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Beregninger"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1034,12 +1028,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1053,9 +1047,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Annulleret"
 
@@ -1071,18 +1065,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Kapacitet"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1091,7 +1085,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalognummer"
 
@@ -1099,17 +1093,17 @@ msgstr "Katalognummer"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategori"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Kategori kan ikke deaktiveres, fordi den indeholder Analysis Services"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1122,31 +1116,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Marker dette felt, hvis analysen er inkluderet i laboratoriets tidsplan for akkrediterede analyser"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Markér dette felt, hvis dit laboratorium er akkrediteret"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1154,7 +1148,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1170,19 +1164,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klassisk"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1190,19 +1184,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Kunde"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Kunde ID"
 
@@ -1210,59 +1204,59 @@ msgstr "Kunde ID"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Kunde Navn"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Kunde Ordre"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Kunde ref"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Kunde reference"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Kunde SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Kundekontakt kræves før anmodning kan indsendes"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Kunder"
 
@@ -1271,39 +1265,39 @@ msgstr "Kunder"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1311,21 +1305,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Sammensat"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Confidence Level %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1334,13 +1328,13 @@ msgid "Confirm password"
 msgstr "Bekæft password"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontakt"
@@ -1349,8 +1343,8 @@ msgstr "Kontakt"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontaktpersoner"
@@ -1359,48 +1353,48 @@ msgstr "Kontaktpersoner"
 msgid "Contacts to CC"
 msgstr "Kontakter to CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Beholder"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Beholdertype"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Beholdertyper"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Indholdstype"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrol"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1416,12 +1410,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1434,18 +1428,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1453,7 +1447,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1461,8 +1455,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1470,12 +1464,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "aktuelle"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1488,7 +1482,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1502,88 +1496,88 @@ msgstr "Data Interface"
 msgid "Data Interface Options"
 msgstr "Data Interface Options"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Dato"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Dato afsendt"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Dato for bortskaffes"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Udløbsdato"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Dato Importeret"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Dato indlæst"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Dato Åbnet"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Offentliggjort den"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Modtagedato"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Dato mangler"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Dato for sampling"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1599,7 +1593,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1617,7 +1611,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1626,11 +1620,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dage"
 
@@ -1642,17 +1636,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1660,49 +1654,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1711,11 +1705,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1739,11 +1733,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Default værdi"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1751,7 +1745,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1759,11 +1753,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1771,16 +1765,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Grader"
 
@@ -1788,9 +1782,9 @@ msgstr "Grader"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Afdelingen"
 
@@ -1803,13 +1797,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Afhængige analyser"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Beskrives metoden i almindeligt sprog. Disse oplysninger gøres tilgængelige for labkunder"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -1817,7 +1811,7 @@ msgstr "Beskrivelse"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1825,19 +1819,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1845,7 +1839,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Rabat %"
 
@@ -1853,16 +1847,16 @@ msgstr "Rabat %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "afsendt"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Display værdi"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1874,7 +1868,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1883,8 +1877,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Placeret"
@@ -1893,54 +1887,54 @@ msgstr "Placeret"
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Dvale"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1953,20 +1947,20 @@ msgstr "Tør"
 msgid "Dry matter analysis"
 msgstr "Tørstof analyse"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Forfald"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Forfaldsdato"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Dup Var"
 
@@ -1975,20 +1969,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Dupliker"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicate af"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Duplicate Variation %"
 
@@ -2000,35 +1994,35 @@ msgstr "Duplicate analyse QC"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Duplicate analyse kvalitetskontrol grafer"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Varighed"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "E.g. SANAS, APLAC, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Tidlighed"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Højde"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Emailadresse"
 
@@ -2036,7 +2030,7 @@ msgstr "Emailadresse"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Email emne linie"
 
@@ -2056,14 +2050,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2075,16 +2069,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Indtast rabat procentværdi"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Indtast procentværdi f.eks. 14,0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2092,15 +2086,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Angiv procentværdi fx. 14,0. Denne procentsats anvendes i hele systemet, men kan overskrives på den enkelte vare"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2108,7 +2102,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2116,45 +2110,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Udelad fra faktura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Forventet resultat"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2163,19 +2157,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "udløbet"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Udløbsdato"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2183,44 +2177,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (business)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Kvinde"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Felt"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Felt analyse"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Felt titel"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Sag"
 
@@ -2228,19 +2218,19 @@ msgstr "Sag"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Sagsnavn"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2260,16 +2250,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Fornavn"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formel"
 
@@ -2279,18 +2269,18 @@ msgstr "Formel"
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Fulde navn"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2300,7 +2290,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2312,37 +2302,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Farlige - Hazardous"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Timer"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2351,8 +2341,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID Server URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID Server unavailable"
 
@@ -2360,31 +2350,31 @@ msgstr "ID Server unavailable"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2396,7 +2386,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2404,27 +2394,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2432,7 +2422,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2445,7 +2435,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Import"
@@ -2454,7 +2444,7 @@ msgstr "Import"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importeret"
@@ -2463,8 +2453,8 @@ msgstr "Importeret"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2473,7 +2463,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2481,7 +2471,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Inkluderer beskrivelser"
 
@@ -2489,30 +2479,27 @@ msgstr "Inkluderer beskrivelser"
 msgid "Include year in ID prefix"
 msgstr "Inkluderer år i ID præfiks"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Første revision"
 
@@ -2536,7 +2523,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2549,17 +2536,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Instrument"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2572,16 +2559,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2589,19 +2576,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2645,9 +2632,9 @@ msgstr "Instrument type"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Instrumenter"
 
@@ -2671,7 +2658,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2687,24 +2674,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2712,43 +2696,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Faktura udeladt"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Item er inactiv"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2758,7 +2742,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Titel"
 
@@ -2766,12 +2750,12 @@ msgstr "Titel"
 msgid "Key"
 msgstr "Nøgle"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Nøgleord"
@@ -2780,47 +2764,47 @@ msgstr "Nøgleord"
 msgid "Keywords"
 msgstr "Nøgleorderne"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Lab"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Lab analyser"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Lab Kontakter"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Lab-afdeling"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Lab-produkter"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "laboratorie"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorium akkrediteret"
 
@@ -2840,13 +2824,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Sidst ændret"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Sen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Sene analyser"
@@ -2856,7 +2840,7 @@ msgstr "Sene analyser"
 msgid "Late Analysis"
 msgstr "Sen analyse"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Breddegrad - Latitude"
 
@@ -2878,11 +2862,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Forbundet prøve"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2894,7 +2878,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2906,41 +2890,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Log"
@@ -2965,35 +2949,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Længdegrad - Longitude"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Lotnummer"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Postardesse"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Mand"
 
@@ -3001,16 +2985,16 @@ msgstr "Mand"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Manager"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Manager email"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Manager telefon"
 
@@ -3018,31 +3002,25 @@ msgstr "Manager telefon"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Producent"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3051,14 +3029,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Max tid"
 
@@ -3066,30 +3044,30 @@ msgstr "Max tid"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maksimale ekspeditionstid TAT"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Medlem rabat%"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Medlem rabat gælder"
 
@@ -3098,22 +3076,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Metode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Metode dokument"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Metode instruktioner"
 
@@ -3125,9 +3103,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Metoder"
 
@@ -3135,17 +3113,17 @@ msgstr "Metoder"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Metoder inkluderet i $ {accreditation_body} liste over akkreditering for dette laboratorium. Analyse bemærkninger er ikke akkrediteret"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3157,8 +3135,8 @@ msgstr "Mine"
 msgid "Minimum 5 characters."
 msgstr "Minimum 5 tegn."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3166,27 +3144,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minuter"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Mobil telefon"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3200,7 +3178,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3212,13 +3190,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Navn"
 
@@ -3227,17 +3205,17 @@ msgstr "Navn"
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3253,18 +3231,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Ingen analyser er valgt"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3276,23 +3254,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3300,7 +3278,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr "Ingen kontrol type angivnet"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3312,17 +3290,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3330,7 +3308,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3340,16 +3318,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3367,25 +3345,22 @@ msgstr "Der findes ingen bruger for $ {contact_fullname} og han / hun vil ikke v
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Intet"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Ikke tilladt"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3405,19 +3380,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3425,30 +3400,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3456,15 +3431,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3473,31 +3448,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Antal af prøver"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3505,15 +3480,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Åben"
@@ -3526,26 +3498,26 @@ msgstr ""
 msgid "Order"
 msgstr "Ordre"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Ordre dato"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "Ordre ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Ordre Nummer"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Ordrer"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3553,7 +3525,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3565,8 +3537,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3578,16 +3550,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3608,8 +3577,8 @@ msgstr "Password"
 msgid "Password lifetime"
 msgstr "Password levetid"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Afventer"
@@ -3634,31 +3603,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Tilladt"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Tilladt Fejl%"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefon (business)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefon (hjem)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefon (mobil)"
 
@@ -3671,8 +3640,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Fysisk adresse"
 
@@ -3680,7 +3649,7 @@ msgstr "Fysisk adresse"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3688,19 +3657,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Opsamlingsted"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3709,13 +3678,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Position"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Postadresse"
 
@@ -3723,16 +3692,16 @@ msgstr "Postadresse"
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3760,7 +3729,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3768,12 +3737,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr "Præfikser"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3785,17 +3754,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "konservering"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3806,7 +3775,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "konserveringer"
 
@@ -3816,14 +3785,14 @@ msgstr "konserveringer"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3831,34 +3800,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Pris"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Pris (excl. moms)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Pris excl. moms"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Pris for"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3873,13 +3842,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3896,34 +3865,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Profile analyse"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Profil keys"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Profil keyword"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profiler"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3931,7 +3900,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3946,21 +3915,21 @@ msgstr "Offentliggørelse præference"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Offentliggjort"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3973,8 +3942,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3995,23 +3964,23 @@ msgstr "Mængde"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Område max"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Område min"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4033,9 +4002,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Modtaget"
 
@@ -4043,11 +4012,11 @@ msgstr "Modtaget"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4056,31 +4025,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Reference"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Reference Definition"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Reference Definitioner"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Referenceprøver"
 
@@ -4088,16 +4057,16 @@ msgstr "Referenceprøver"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Reference Type"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4106,7 +4075,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4114,21 +4083,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4151,8 +4120,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4161,9 +4130,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Bemærkninger"
 
@@ -4171,7 +4140,7 @@ msgstr "Bemærkninger"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4179,7 +4148,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4188,8 +4157,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4198,7 +4167,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Rapport"
 
@@ -4212,14 +4181,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Rapporter som tørstof"
 
@@ -4244,7 +4213,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4252,7 +4221,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Rapporter"
 
@@ -4261,15 +4230,15 @@ msgstr "Rapporter"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "Request ID"
 
@@ -4277,26 +4246,26 @@ msgstr "Request ID"
 msgid "Request new analyses"
 msgstr "Request ny analyser"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Requests"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Kræves"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4304,13 +4273,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultat"
 
@@ -4318,15 +4287,15 @@ msgstr "Resultat"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Resultat options"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Resultat værdi"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4344,11 +4313,11 @@ msgstr "Resultat out of range"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4356,7 +4325,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4364,11 +4333,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4377,14 +4346,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Restested"
@@ -4403,11 +4372,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4423,12 +4392,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Tiltale"
 
@@ -4436,19 +4405,19 @@ msgstr "Tiltale"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Prøve"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4457,8 +4426,8 @@ msgid "Sample Due"
 msgstr "Sample Due"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "PrøveID"
 
@@ -4470,12 +4439,12 @@ msgstr "Prøve ID Padding"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Prøvematrices"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Prøvematrix"
 
@@ -4485,52 +4454,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Sample Partitions"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "prøvepunkt"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "prøvepunkter"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Prøvetype"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prøve type præfiks"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "prøvetyper"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4540,9 +4509,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4570,17 +4539,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4590,30 +4559,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Prøver"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4622,62 +4591,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Prøveudtagningensdato"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Sampling Afvigelse"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Sampling Afvigelser"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Prøveudtagningen frekvens"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4687,9 +4656,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Gem"
 
@@ -4702,17 +4671,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4720,16 +4689,16 @@ msgstr ""
 msgid "Search"
 msgstr "Søg"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Sekunder"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4741,11 +4710,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4753,11 +4722,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4769,7 +4738,7 @@ msgstr "Vælg alle elementer"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4781,11 +4750,11 @@ msgstr "Vælg analytiker"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4793,19 +4762,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4831,7 +4800,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4843,7 +4812,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4851,7 +4820,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4875,7 +4844,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4891,7 +4860,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4903,7 +4872,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4911,32 +4880,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "Serial Nr."
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Service"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Services"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4944,31 +4909,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Opsætning af laboratorieanalyse service resulterer specifikationer"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Forsendelse adresse"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4984,7 +4949,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4996,29 +4961,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Signature"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Størrelse"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5026,14 +4987,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5041,41 +5002,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Tilstand"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Status"
 
@@ -5083,33 +5044,33 @@ msgstr "Status"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Indsend"
 
@@ -5117,37 +5078,34 @@ msgstr "Indsend"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Leverandør"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Efternavn"
 
@@ -5167,11 +5125,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5180,20 +5138,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5211,35 +5169,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5251,7 +5209,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5259,12 +5217,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "De vedhæftede filer er tilknyttet analyser requests og analyser"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5272,19 +5230,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5296,7 +5254,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5313,24 +5271,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5347,27 +5305,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5391,7 +5349,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5408,11 +5366,11 @@ msgstr "Antallet af requests og analyser"
 msgid "The number of requests and analyses per client"
 msgstr "Antallet af requests og analyser pr. kunde"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5429,19 +5387,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5449,11 +5407,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5461,7 +5419,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5473,11 +5431,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5485,19 +5443,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5509,7 +5467,7 @@ msgstr "Ekspeditionstid af analyser"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5521,37 +5479,37 @@ msgstr "Der er ingen resultater."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Denne analyse service kan ikke aktiveres, fordi det beregning er inaktiv."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Denne analyse service kan ikke deaktiveres, da en eller flere aktive beregninger liste det som en afhængighed"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5563,7 +5521,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5571,12 +5529,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5591,63 +5545,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Titel"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "To Be Preserved"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "To be verified"
 
@@ -5659,13 +5613,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5673,22 +5627,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Total pris"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Total pris"
 
@@ -5700,11 +5654,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5712,61 +5666,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Type"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Ikke tildelt"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Usikkerhed"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Usikkerhed værdi"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5774,13 +5722,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Enhed"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5805,17 +5753,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5827,11 +5775,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5839,7 +5787,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5851,13 +5799,13 @@ msgstr "Brug ekstern ID server"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Bruger"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Brugernavn"
@@ -5870,7 +5818,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5879,27 +5827,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "Moms"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "Moms%"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Momsbeløb"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "CVR nummer"
 
@@ -5907,11 +5855,11 @@ msgstr "CVR nummer"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Gyldig fra"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5919,181 +5867,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Validering mislykkedes: Bearing skal være E / W"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Validering mislykkedes: Bearing skal være N / S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Validering mislykkedes: Søgningen Værdier skal være tal"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Validering mislykkedes: grader, skal være 0-90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Validering mislykkedes: grader, skal være numerisk"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Validering mislykkedes: søgeord indeholder ugyldige tegn"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Validering mislykkedes: minutter skal være 0-59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Validering mislykkedes: minutter skal være numerisk"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Validering mislykkedes : sekunder skal være 0-59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Validering mislykkedes: sekunder skal være numerisk"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6101,7 +6049,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6112,12 +6060,12 @@ msgstr ""
 msgid "Value"
 msgstr "Værdi"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "verificeret"
@@ -6128,7 +6076,7 @@ msgstr "verificeret"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Version"
 
@@ -6138,11 +6086,11 @@ msgstr "Version"
 msgid "Volume"
 msgstr "Volumen"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6150,24 +6098,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6178,25 +6126,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Arbejdsark"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Arbejdsark layout"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Arbejdsark Templates"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Arbejdsark"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6204,9 +6152,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6218,7 +6166,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6226,11 +6174,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Du skal vælge et instrument"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6246,15 +6194,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6283,36 +6231,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6324,7 +6244,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6372,19 +6292,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6392,19 +6312,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6423,19 +6343,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6447,7 +6356,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6455,7 +6364,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6480,7 +6389,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6492,6 +6401,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/de/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/de/LC_MESSAGES/bika.po
@@ -30,7 +30,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:45+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: German (http://www.transifex.com/bikalabs/bika-lims/language/de/)\n"
@@ -48,49 +48,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} kann sich mit dem Benutzernamen ${contact_username} anmelden. Benutzer müssen ihr Passwort selbst ändern. Bei Verlust des Passworts kann der Benutzer im Anmeldeformular ein neues Passwort anfordern."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} fehlendes Einlagerungsdatum oder Einlagerung nicht deaktiviert."
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} müssen eingelagert werden."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} müssen angemeldet werden."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} gesperrt."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} wurden erfolgreich angelegt."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: Teile müssen noch angemeldet werden."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} fehlendes Einlagerungsdatum oder Einlagerung nicht deaktiviert."
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} wartet auf Einlagerung."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} muss angemeldet werden."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} wurde erfolgreich erstellt."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} muss angemeldet werden."
 
@@ -106,7 +106,7 @@ msgstr "${nr_items} Einträge"
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Fehler"
 
@@ -120,15 +120,15 @@ msgstr "% durchgeführt"
 msgid "% Published"
 msgstr "% veröffentlicht"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr "%s kann nicht geändert werden."
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s wurde abgelehnt"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "% hat keine '%' Spalte."
 
@@ -140,15 +140,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Klassisch' zeigt an , dass Analyseanfragen pro Probe und Analyseart ausgewählt werden. Mit 'Profil', werden die Analyseprofilschlüsselworte genutzt um mehrere Analysearten gemeinsam auszuwählen"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr "Das 'Probenahmedatum' und die 'Zuweisung des Probenehmers für die geplante Probenahme' müssen vollständig gepeichert werden, um eine Probe zu planen."
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr "Das 'Probenahmedatum' und die 'Zuweisung des Probenehmers für die geplante Probenahme' müssen vollständig gepeichert werden, um eine Probe zu planen. Element: %s"
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blindprobe)"
@@ -161,7 +161,7 @@ msgstr "(Kontrollprobe)"
 msgid "(Duplicate)"
 msgstr "(Wiederholungsmessung)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Gefahrstoff)"
 
@@ -170,33 +170,27 @@ msgid "(Required)"
 msgstr "(Erforderlich)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "16x16 Pixel Icon, dass für eilige Proben in Auflistungen verwendet werden soll."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "32x32 Pixel Icon, dass für eilige Proben in Auflistungen verwendet werden soll."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
 msgstr "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Andere"
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr "<p>${service} benötigt die folgenden ausgewählten Dienste: </p><br/><p>${deps}</p><br/><p>Wollen Sie diese Auswahl zuweisen?</p>"
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
-msgstr "<p>Die folgenden Dienste hängen von ${service} ab, und werden deselektiert wenn Sie fortfahren:</p><br/><p>${deps}</p><br/><p>Wollen Sie die Auswahl jetzt löschen?</p>"
 
 #: bika/lims/content/calculation.py:84
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -211,16 +205,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr "<span>x</span> <span class=\"formHelp\">x</span>"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr "Ein Kurzname, der die Probenrunde beschreibt, so dass sie leicht in Formularen und Selektionsmenüs gefunden werden kann."
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "Analyseauftrag ${ar_number}"
 
@@ -232,7 +226,7 @@ msgstr "Analyseauftrag Anhang Optionen"
 msgid "AR ID Padding"
 msgstr "Analyseauftrag ID Markierung"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Analyseauftrag Import"
 
@@ -240,17 +234,17 @@ msgstr "Analyseauftrag Import"
 msgid "AR Import options"
 msgstr "Analyseauftrag Import Optionen"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr "Analyseauftrag Vorlagetitel"
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Analyseauftrag Vorlagen"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Analyseauftrag für Wiederholungsmessungen"
 
@@ -258,54 +252,54 @@ msgstr "Analyseauftrag für Wiederholungsmessungen"
 msgid "ARs"
 msgstr "Analyseaufträge"
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "Analyseaufträge: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Kontenname"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Kontonummer"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Kontentyp"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akkreditierung"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akkreditierungsstelle - Kürzel"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akkreditierungsstelle - URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akkreditierungslogo"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akkreditierungszeichen"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Akkreditierung Briefkopf"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akkredidiert"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -319,21 +313,21 @@ msgstr "Von Nutzern in bestimmten Zeitintervallen durchgeführte Arbeitsschritte
 msgid "Activate"
 msgstr "Aktivieren"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktiv"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Sofort"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -353,11 +347,7 @@ msgstr "Kontrollstandard hinzufügen"
 msgid "Add Duplicate"
 msgstr "Wiederholungsmessung hinzufügen"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Bemerkung hinzufügen"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Vorlage hinzufügen"
 
@@ -365,16 +355,16 @@ msgstr "Vorlage hinzufügen"
 msgid "Add a remarks field to all analyses"
 msgstr "Bemerkungsfeld zu allen Analysen hinzufügen"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Neu hinzufügen"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Zusätzliche Bemerkungen:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adresse"
@@ -387,26 +377,26 @@ msgstr "Fügt eine zweistellige Jahreszahl nach dem ID-Präfix hinzu"
 msgid "Administrative Reports"
 msgstr "Administrative Berichte"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Nach ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Geschäftsstelle"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Alle"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Hier sind alle akkreditierten Analyseleistungen aufgelistet."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Alle zugeordneten Analysen"
 
@@ -418,7 +408,7 @@ msgstr "Alle Analysen des Typs"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Laboranten erlauben Kunden anzulegen und zu bearbeiten."
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Manuelle Eingabe der Erfassungsgrenze erlauben."
 
@@ -426,15 +416,15 @@ msgstr "Manuelle Eingabe der Erfassungsgrenze erlauben."
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Nur zugewiesenen Labormitarbeitern Zugriff zum Arbeitsblatt gewähren"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Manuelle Eingabe der Messunsicherheit erlauben."
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr "Erlaube dem gleichen Benutzer mehrfaches verifizieren"
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Erlaube dem gleichen Benutzer mehrfaches verifizieren, jedoch nicht aufeinanderfolgend"
 
@@ -442,11 +432,11 @@ msgstr "Erlaube dem gleichen Benutzer mehrfaches verifizieren, jedoch nicht aufe
 msgid "Allow self-verification of results"
 msgstr "Erlaube Selbstverifizierung der Ergebnisse"
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Labormitarbeitern manuelle Eingabe von oberen und unteren Erfassungsgrenzen (LDL and UDL) bei der Erfassung erlauben."
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Labormitarbeitern manuelle Eingabe der Messunsicherheit erlauben."
 
@@ -454,48 +444,48 @@ msgstr "Labormitarbeitern manuelle Eingabe der Messunsicherheit erlauben."
 msgid "Allow users to filter datas by department."
 msgstr "Erlaube Benutzern die Daten nach Abteilung zu filtern"
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Alternative Berechnung"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Die ausgewählten Kategorien in Kundenansichten immer expandieren"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr "Umgebungsbedingungen"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Menge"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analysen"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Analysen im Toleranzbereich"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analysen im Fehlerbereich"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr "Analyse ausstehend"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Analysen je Analyseleistung"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analysen je Probentyp"
@@ -509,7 +499,7 @@ msgstr "Analysen je Analyseleistung"
 msgid "Analyses performed and published as % of total"
 msgstr "Durchgeführte und als % von Gesamt berichtete Analysen "
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Als % von Gesamt durchgeführte Analysen"
 
@@ -522,27 +512,27 @@ msgstr "Analysebezogene Berichte"
 msgid "Analyses repeated"
 msgstr "Wiederholte Analysen"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Analyseergebnisse außerhalb des festgelegten Grenzwerts"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Wiederholte Analysen"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Analysezusammenfassung nach Bereich"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Wiederholte Analysen"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analyse"
 
@@ -550,52 +540,52 @@ msgstr "Analyse"
 msgid "Analysis Attachment Option"
 msgstr "Analyseanhangoption"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Analysekategorien"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Analysekategorie"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Analyseschlüsselwort"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Analyseprofil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Analyseprofile"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Analyseauftrag"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Analyseauftrags-ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Analyseauftragimporte"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Analyseauftragprioritäten"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Analyseauftragspezifikationen"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr "Auftragsvorlagen für Analysen"
 
@@ -603,65 +593,65 @@ msgstr "Auftragsvorlagen für Analysen"
 msgid "Analysis Request rejection reporting form"
 msgstr "Analyseauftrag Ablehnungbrichtsformular"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr "Zu konservierende Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr "Zu veröffentlichende Analsenaufträge"
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr "Zu liefernde Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr "Zu beprobende Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr "Zu prüfende Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Analyseaufträge mit ausstehenden Ergebnissen"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr "Analyseaufträge mit geplanter Probenahme"
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Analyseleistung"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Analyseleistungen"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Analysespezifikation"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Analysespezifikationen"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Analysestatus"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Analysetyp"
@@ -670,46 +660,46 @@ msgstr "Analysetyp"
 msgid "Analysis category"
 msgstr "Analysekategorie"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Analyseauftrag ${AR} wurde erfolgreich erstellt."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr "Analyseauftragsvorlagen, welche in Probenrundenvorlagen eingebunden werden sollen"
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Analyseaufträge ${ARs} wurden erfolgreich erstellt."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Analyseaufträge und Analysen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Analyseaufträge und Analysen je Kunde"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Nicht in Rechnung gestellte Analyseaufträge"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Analyseergebnis innerhalb des Fehlerbereichs"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Analyseergebnisse"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Analyseergebnisse für ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Analyseergebnisse je Probe und Analysenservice"
 
@@ -717,12 +707,12 @@ msgstr "Analyseergebnisse je Probe und Analysenservice"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Ergebnisse außerhalb des vom Labor oder vom Kunden vorgegebenen Bereichs. Achtung - dies kann mehrere Minuten dauern."
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Analyseleistung"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Analysespezifikationen auf Labor-Standardwerte zurücksetzen."
 
@@ -738,17 +728,17 @@ msgstr "Analysebearbeitungszeit"
 msgid "Analysis turnaround time over time"
 msgstr "Übersicht der Analysebearbeitungszeit"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Analysebearbeitungszeiten"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Übersicht der Analysebearbeitungszeiten"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analytiker"
 
@@ -757,7 +747,7 @@ msgid "Analyst must be specified."
 msgstr "Analytiker muss angegeben werden"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Alle"
 
@@ -769,7 +759,7 @@ msgstr "Anwenden"
 msgid "Apply template"
 msgstr "Vorlage anwenden"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Global anwenden"
 
@@ -787,15 +777,15 @@ msgstr "Prüfmittelnummer"
 msgid "Assign"
 msgstr "Zuweisen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Zugewiesen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Zugewiesen an Arbeitsblatt"
 
@@ -813,27 +803,27 @@ msgstr "Anfügen"
 msgid "Attach to"
 msgstr "Anhängen an"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Anhang"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Anhang-Schlüssel"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Anhang - Option"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Anhang Gruppe"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Anhang Gruppen"
 
@@ -843,25 +833,25 @@ msgstr "Anhang Gruppen"
 msgid "Attachment due"
 msgstr "Anhang ausstehend"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Anhang nicht erlaubt"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Anhang erforderlich"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Anhang Gruppe"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Anhänge"
 
@@ -873,7 +863,7 @@ msgstr "Genehmigt von"
 msgid "Autofill"
 msgstr "Automatisch ausfüllen"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Automatisch importieren"
 
@@ -890,27 +880,27 @@ msgstr "Automatischer Etikettdruck"
 msgid "Available templates"
 msgstr "Verfügbare Beispiele"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Durchschnittliche Bearbeitungszeit"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Schnellste Bearbeitungszeit"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Längste Bearbeitungszeit"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Formel-Syntax entspricht nicht der Konvention: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Bankfiliale"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Bankname"
 
@@ -919,31 +909,31 @@ msgid "Basis"
 msgstr "Basis"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Batch"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Batch ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Batchetiketten"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Batches"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Lager"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Vor ${start_date}"
 
@@ -951,7 +941,7 @@ msgstr "Vor ${start_date}"
 msgid "Biannual"
 msgstr "Halbjährlich"
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Großes Symbol"
 
@@ -959,7 +949,7 @@ msgstr "Großes Symbol"
 msgid "Bika LIMS"
 msgstr "Bika LIMS"
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "LIMS Konfiguration"
 
@@ -967,63 +957,67 @@ msgstr "LIMS Konfiguration"
 msgid "Bika LIMS front-page"
 msgstr "Bika LIMS Startseite"
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Rechnungsadresse"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blindprobe"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Blindproben QC Analysen"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marke"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr "Mengenrabatt"
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Großkundenrabatt anwenden"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Mengenpreis (ohne MwSt.)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Telefon (geschäftlich)"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Von"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC Kontakte"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC E-Mails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Berechne Präzision aus Unsicherheiten"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Berechnung"
 
@@ -1031,8 +1025,8 @@ msgstr "Berechnung"
 msgid "Calculation Formula"
 msgstr "Berechnungsformel"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Zwischenrechnungsfeld"
@@ -1045,11 +1039,11 @@ msgstr "Berechnung: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Berechnung: None"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Berechnungen"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Kalibrierung"
 
@@ -1061,12 +1055,12 @@ msgstr "Kalibrier-Zertifikate"
 msgid "Calibration report date"
 msgstr "Datum des Kalibrierberichts"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Kalibrator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1080,9 +1074,9 @@ msgstr "Wurde vom aktuellen Benutzer eingereicht und kann verifiziert werden"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Storniert"
 
@@ -1098,18 +1092,18 @@ msgstr "Berechnung kann nicht verwendet da sie von folgenden Service verwendet w
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr "Verifikation nicht möglich, da es durch den gleichen Benutzer zuvor eingereicht oder verifiziert wurde"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Verifizierung fehlgeschlagen: Übermittelt durch aktuellen Nutzer"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Kapazität"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Erfasst"
 
@@ -1118,7 +1112,7 @@ msgid "Cardinal"
 msgstr "Haupt"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalognummer"
 
@@ -1126,17 +1120,17 @@ msgstr "Katalognummer"
 msgid "Categorise analysis services"
 msgstr "Analyseleistungen kategorisieren"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Diese Kategorie kann nicht deaktiviert werden, da sie Analyseleistungen beinhaltet"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Zertifikat Nummer"
 
@@ -1149,31 +1143,31 @@ msgstr "Zertifikat Code"
 msgid "Changes saved."
 msgstr "Änderungen gespeichert."
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Methode auf Akkreditierung prüfen"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Ativieren Sie dieses Kontrollkästchen, wenn die Analyseleistung zu den akkreditierten Analysen des Labors zählt"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Ativieren Sie dieses Kontrollkästchen, wenn die Probe an dieser Probenahmestelle 'Gemisch' ist und aus mehr als einer Unterprobe besteht, z. B. verschieden Oberflächenproben eines Damms, die zusammengemischt wurden um eine repräsentative Probe des gesamten Damms zu erhalten.  Standardmäßig nicht ausgewählt, zeigt eine 'grab' Probe an"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Ativieren Sie dieses Kontrollkästchen, wenn dieser Behälter bereits konserviert ist. Dies hat zur Folge, dass der Konservierungsworkflow für Proben in diesem Behälter umgangen wird."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Aktivieren Sie das Kontrollkästchen wenn das Priorität ist"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Ativieren Sie dieses Kontrollkästchen, wenn Ihr Labor akkreditiert ist"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Ativieren Sie dieses Kontrollkästchen, um einen separaten Probenbehälter für diese Analyseleistung zu verwenden"
 
@@ -1181,7 +1175,7 @@ msgstr "Ativieren Sie dieses Kontrollkästchen, um einen separaten Probenbehält
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Ativieren Sie dieses Kontrollkästchen wenn Sie einen separaten ID Server verwenden wollen. Namensvorsätze werden separat in jeder LIMS Seite eingestellt"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Auswahl der Analyseauftrag Spezifikationswerte"
 
@@ -1197,19 +1191,19 @@ msgstr "Wählen Sie die Methode für mehrfache Prüfungen durch den selben Benut
 msgid "City"
 msgstr "Stadt"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klassisch"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Klicken Sie auf Analysekategorien (auf dem schattierten Hintergrund) um die Analyseleistungen in jeder Kategorie zu sehen. Geben Sie Mindest- und Höchstwerte ein, um den gültigen Ergebnisbereich festzulegen. Jedes Ergebnis außerhalb dieses Bereiches löst eine Warnung aus. Das % Fehler-Feld erlaubt es, eine prozentuale Unsicherheit zu berücksichtigen, wenn das Ergebnis mit den Mindest- und Höchstwerten verglichen wird. Ein Ergebnis, das außerhalb des Bereiches ist, aber immer noch innerhalb unter Berücksichtigung des % Fehlers, wird eine wenigere strenge Warnung erzeugen."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Klicken Sie auf Analysekategorien (auf dem schattierten Hintergrund) um die Analyseleistungen in jeder Kategorie zu sehen. Geben Sie Mindest- und Höchstwerte ein, um den gültigen Ergebnisbereich festzulegen. Jedes Ergebnis außerhalb dieses Bereiches löst eine Warnung aus. Das % Fehler-Feld erlaubt es, eine prozentuale Unsicherheit zu berücksichtigen, wenn das Ergebnis mit den Mindest- und Höchstwerten verglichen wird. Ein Ergebnis, das außerhalb des Bereiches ist, aber immer noch innerhalb unter Berücksichtigung des % Fehlers, wird eine wenigere strenge Warnung erzeugen."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Klicken Sie auf Analysekategorien (auf dem schattierten Hintergrund) um die Analyseleistungen in jeder Kategorie zu sehen. Geben Sie Mindest- und Höchstwerte ein, um den gültigen Ergebnisbereich festzulegen. Jedes Ergebnis außerhalb dieses Bereiches löst eine Warnung aus. Das % Fehler-Feld erlaubt es, eine prozentuale Unsicherheit zu berücksichtigen, wenn das Ergebnis mit den Mindest- und Höchstwerten verglichen wird. Ein Ergebnis, das außerhalb des Bereiches ist, aber immer noch innerhalb unter Berücksichtigung des % Fehlers, wird eine wenigere strenge Warnung erzeugen. Wenn das Ergebnis unterhalb '< Min' ist, wird das Ergebnis als '<[min]' angezeigt. Das Gleiche geschieht bei Ergebnissen oberhabl '> Max'"
 
@@ -1217,19 +1211,19 @@ msgstr "Klicken Sie auf Analysekategorien (auf dem schattierten Hintergrund) um 
 msgid "Click to download"
 msgstr "Zum Herunterladen klicken"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Kunde"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "Kunden Batch ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Kunden-ID"
 
@@ -1237,59 +1231,59 @@ msgstr "Kunden-ID"
 msgid "Client Landing Page"
 msgstr "Kunden Startseite"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Kunde - Name"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Kundenbestellung"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Kundenbestellnummer"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Kundenreferenz"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Kundenreferenz"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Kundennummer"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Kunden Proben-ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr "Kunden Probenrunden"
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr "Kundenkontakt war zum Zeitpunkt der Probenahme verantwortlich"
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Kundenkontakt erforderlich bevor ein Auftrag eingereicht werden kann"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr "Hauptansprechpartner zwischen Kunde und Labor"
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Kunden"
 
@@ -1298,39 +1292,39 @@ msgstr "Kunden"
 msgid "Close"
 msgstr "Schließen"
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Geschlossen"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Code für den Standort"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Code für das Grundstück"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Code für das Regal"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Komma (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Kommentare"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Kommentar- or Ergebnisinterpretation"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "HRG-Nr"
 
@@ -1338,21 +1332,21 @@ msgstr "HRG-Nr"
 msgid "Complete"
 msgstr "Vollständig"
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Gemisch"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr "Zusammengesetzt J/N"
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Vertrauensniveau %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr " Zusammenstellung der Probenteile und der konservierung für diesen Typ. Zuweisung der Analyseleistungen zu den unterschiedlichen Probentypen."
 
@@ -1361,13 +1355,13 @@ msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Zu beachten"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontakt"
@@ -1376,8 +1370,8 @@ msgstr "Kontakt"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr "Kontakt wurde deaktiviert. Die Verknüpfung zum Benutzer kann nicht aufgehoben oder geändert werden."
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontakte"
@@ -1386,48 +1380,48 @@ msgstr "Kontakte"
 msgid "Contacts to CC"
 msgstr "Kontakte in Kopie"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Behälter"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr "Behältername"
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Behältertyp"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Behältertypen"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr "Behältervolumen"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Probenbehälter"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Inhaltstyp"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Art des Inhalts"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrolle"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Kotrollanalysen zur Qualitätssicherung"
 
@@ -1443,12 +1437,12 @@ msgstr "Analyseleistungen kopieren"
 msgid "Copy from"
 msgstr "Kopieren von"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Kopie erzeugen"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Zahl"
 
@@ -1461,18 +1455,18 @@ msgstr "Land"
 msgid "Create a new User"
 msgstr "Einen neuen Benutzer anlegen"
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Neue Probe dieser Art erstellen"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Erstellt"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Erstellt von"
 
@@ -1480,7 +1474,7 @@ msgstr "Erstellt von"
 msgid "Created by:"
 msgstr "Erstellt von:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr "Objekte anlegen und initialisieren"
 
@@ -1488,8 +1482,8 @@ msgstr "Objekte anlegen und initialisieren"
 msgid "Creator"
 msgstr "Hersteller"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Kriterium"
 
@@ -1497,12 +1491,12 @@ msgstr "Kriterium"
 msgid "Currency"
 msgstr "Währung"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Aktuell"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Standard Dezimaltrenner"
 
@@ -1515,7 +1509,7 @@ msgstr "DL"
 msgid "Daily"
 msgstr "Täglich"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1529,88 +1523,88 @@ msgstr "Datenschnittstelle"
 msgid "Data Interface Options"
 msgstr "Datenschnittstelle - Optionen"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Laborbuch"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Datum"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Herstelldatum"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Versanddatum"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Entsorgungsdatum"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Verfallsdatum"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Importdatum"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Fülldatum"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Öffnungsdatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Konservierungsdatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Veröffentlichungsdatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Empfangsdatum"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Auftragsdatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Probenahmedatum"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr "Validierungsdatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr "Verifizierungsdatum"
 
@@ -1626,7 +1620,7 @@ msgstr "Datum ab dem das Kalibrierzertifikat gültig ist"
 msgid "Date from which the instrument is under calibration"
 msgstr "Datum an dem das Instrument validiert wird"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Datum an dem das Gerät gewartet wurde"
 
@@ -1644,7 +1638,7 @@ msgid "Date until the certificate is valid"
 msgstr "Gültigkeitsdatum des Zertifikats"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Datum bis das das Instrument gesperrt ist"
@@ -1653,11 +1647,11 @@ msgstr "Datum bis das das Instrument gesperrt ist"
 msgid "Date when the calibration certificate was granted"
 msgstr "Datum an dem das Kalibrierzertifikat freigegeben wurde"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr "Datum und Zeit der Probenahme"
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Tage"
 
@@ -1669,17 +1663,17 @@ msgstr "Bis zur nächsten Kalibrierung sperren"
 msgid "Deactivate"
 msgstr "Deaktivieren"
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Dezimaltrenner zur Verwendung für diesen Kunden"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Standardwert"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Standard Analyseauftragspezifikationen"
 
@@ -1687,49 +1681,49 @@ msgstr "Standard Analyseauftragspezifikationen"
 msgid "Default ARReport Template"
 msgstr "Standard Analyseauftragsvorlage"
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Standard Kalibrierung"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Standardbehälter"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Standard-Behälterart"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr "Standard Email Kopie-Empfänger, die für alle veröffentlichten Analyseanfragen für diesen Kunden verwendet werden"
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Vorgegebenes Gerät"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Vorgegebene Methode"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Standardkonservierung"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Standard Priorität"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Standard Berechnung die für Standard Methoden verwendet wird. Die Berechnung der Methode kann im Editiermodus zugewiesen werden."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Standardkategorien"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Standard Behälter für neue Probenteile"
 
@@ -1738,11 +1732,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Standardbehälter: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Standard Dezimaltrenner"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr "Standardgerät %s ist nicht gültig"
 
@@ -1766,11 +1760,11 @@ msgstr "Wissenschaftliche Standard-Schreibweise für Berichte"
 msgid "Default scientific notation format for results"
 msgstr "Wissenschaftliche Standard-Schreibweise für Ergebnisse"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Standardwert"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "Standard Analyseanfragenspezifikationen"
 
@@ -1778,7 +1772,7 @@ msgstr "Standard Analyseanfragenspezifikationen"
 msgid "Define a date range"
 msgstr "Definieren Sie den Datumsbereich"
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definieren Sie einen ID Code für die Methode. Die ID ist eindeutig zu wählen."
 
@@ -1786,11 +1780,11 @@ msgstr "Definieren Sie einen ID Code für die Methode. Die ID ist eindeutig zu w
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr "Definieren sie Interimfelder, wie z.B. Gefäßmaß oder Verdünnungsfaktor, falls Ihre Berechnung das erfordern sollte. Das Titelfeld wird als Spaltenüberschrift und Feldbezeichner verwendet, wo das Interimfeld verwendet wird. Wenn die Option 'Global anwenden' aktiviert ist, wird das Feld in einer Auswahlliste oberhalb eines Arbeitsblatts angezeigt, welches es erlaubt einen bestimmten Wert auf alle übereinstimmenden Felder auf dem Arbeitsblatt anzuwenden."
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Anzahl der Dezimalstellen."
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Anzahl der signifikaten Stellen der Exponentialschreibweise. Standard ist 7."
 
@@ -1798,16 +1792,16 @@ msgstr "Anzahl der signifikaten Stellen der Exponentialschreibweise. Standard is
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Definiert den Präfix der eindeutigen fortlaufenden IDs, die das System für Objekte vergibt. Im 'Padding' Feld ist die gewünschte Zahl der Stellen anzugeben. Z.B. ein Präfix 'WS' (für worksheet) mit einem Padding von 4 ergibt Nummern von WS-0001 bis WS-9999. Anm.: Beachten Sie, dass Proben und Analysenaufträge eine Abkürzung der Probenart als Präfix erhalten und nicht in dieser Tabelle konfiguriert werden - ihr Padding kann in den Feldern unten festgelegt werden."
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Definieren Sie den Probenehmer, welcher die Probe zum geplaten Termin entnehmen soll"
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr "Definieren Sie den Zeitraum, wann der Probenehmer die Proben entnehmen soll"
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Grad"
 
@@ -1815,9 +1809,9 @@ msgstr "Grad"
 msgid "Delete attachment"
 msgstr "Anhang löschen"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Abteilung"
 
@@ -1830,13 +1824,13 @@ msgstr "Abteilungen"
 msgid "Dependent Analyses"
 msgstr "Abhängige Analysen"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Beschreiben Sie die Methode allgemeinverständlich. Diese Information wird Ihren Kunden zur Verfügung gestellt"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -1844,7 +1838,7 @@ msgstr "Beschreibung"
 msgid "Description of the actions made during the calibration"
 msgstr "Maßnahmenbeschreibung während der Klaibirierung"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Maßnahmenbeschreibung während des Wartungsprozesses"
 
@@ -1852,19 +1846,19 @@ msgstr "Maßnahmenbeschreibung während des Wartungsprozesses"
 msgid "Description of the actions made during the validation"
 msgstr "Maßnahmenbeschreibung während der Validierung"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Beschreibung des Standorts"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Beschreibung des Regals"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Beschreibung der Einrichtung"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr "Deaktiviere mehrfaches verifizieren durch den gleichen Benutzer"
 
@@ -1872,7 +1866,7 @@ msgstr "Deaktiviere mehrfaches verifizieren durch den gleichen Benutzer"
 msgid "Disable the filtering by date"
 msgstr "Datumsfilter entfernen"
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Rabatt %"
 
@@ -1880,16 +1874,16 @@ msgstr "Rabatt %"
 msgid "Dispatch"
 msgstr "Ausliefern"
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Ausgeliefert"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Anzeigewert"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Zeige Auswahl für Erfassungsgrenzen"
 
@@ -1901,7 +1895,7 @@ msgstr "Zeige Benachrichtungen bei Aktualisierungen an."
 msgid "Display individual sample partitions "
 msgstr "Anzeige einzelner Probenbestandteile"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Entsorgungsdatum"
 
@@ -1910,8 +1904,8 @@ msgstr "Entsorgungsdatum"
 msgid "Dispose"
 msgstr "Entsorgen"
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Entsorgt"
@@ -1920,54 +1914,54 @@ msgstr "Entsorgt"
 msgid "District"
 msgstr "Bezirk"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Division durch Null"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Dokument"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr "Dokumenten ID"
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr "Dokumentenort"
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr "Dokumententyp"
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr "Dokumentenversion"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inaktiv"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Punkt (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Von"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Bis"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Herunterladen"
 
@@ -1980,20 +1974,20 @@ msgstr "Trocken"
 msgid "Dry matter analysis"
 msgstr "Trockenmasse-Bestimmung"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Fällig"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Fälligkeit"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Duplikat Variation"
 
@@ -2002,20 +1996,20 @@ msgid "Dup of"
 msgstr "Duplikat von"
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Kopie"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Kopie von"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Doppelte QC-Analyse"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Abweichung Doppelbestimmung %"
 
@@ -2027,35 +2021,35 @@ msgstr "QC Analyse kopieren"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Doppelbestimmung Abbildungen Qualitätskontrolle"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Dauer"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "z.B. SANAS, APLAC, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Frühzeitigeit"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Früh"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Erhöhung"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "E-Mail"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "E-Mail Adresse"
 
@@ -2063,7 +2057,7 @@ msgstr "E-Mail Adresse"
 msgid "Email notification on rejection"
 msgstr "E-Mail Benachrichtung bei Ablehnung"
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "E-Mail Betreffzeile"
 
@@ -2083,14 +2077,14 @@ msgstr "Funktionalität zur Planung von Probenahmen aktivieren"
 msgid "Enable the rejection workflow"
 msgstr "Ablehnung-Workflow aktivieren"
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Enddatum"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Verbesserung"
 
@@ -2102,16 +2096,16 @@ msgstr "Geben Sie einen Benutzernamen ein, in der Regel so etwas wie \"jschmid\"
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Geben Sie eine E-Mail-Adresse ein. Diese wird benötigt, falls das Passwort verloren geht. Wir respektieren Ihre Privatsphäre und geben ihre Adresse nicht an Dritte weiter."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Geben Sie den Rabatt in Prozent ein"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Geben Sie den Wert in Prozent ein, z.B. 19.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Bitte geben Sie den Prozentsatz ein, z. B. 14.0. Dieser Prozentsatz wird im gesamtem System angewendet, kann aber individuell an den verschiedenen Elementen überschrieben werden"
 
@@ -2119,15 +2113,15 @@ msgstr "Bitte geben Sie den Prozentsatz ein, z. B. 14.0. Dieser Prozentsatz wird
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Bitte geben Sie den Prozentsatz ein, z. B. 14.0. Dieser Prozentsatz wird im gesamtem System angewendet, kann aber individuell an den verschiedenen Elementen überschrieben werden"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Geben Sie den Wert in Prozent ein, z.B. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Geben Sie die geographische Breite der Probenahmestelle in Breitengrad (0-90), Winkelminute (0-59), Winkelsekunde (0-59) und Richtuingsangabe (N/S) an."
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Geben Sie die geographische Länge der Probenahmestelle in Längengrad (0-180), Winkelminute (0-59), Winkelsekunde (0-59) und Richtuingsangabe (O/W) an."
 
@@ -2135,7 +2129,7 @@ msgstr "Geben Sie die geographische Länge der Probenahmestelle in Längengrad (
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Geben Sie die Details jeder Analyseleistung ein, die Sie kopieren möchten"
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Geben Sie an dieser Stelle ihre Akkreditierung an. Folgende Felder sind verfügbar: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
@@ -2143,45 +2137,45 @@ msgstr "Geben Sie an dieser Stelle ihre Akkreditierung an. Folgende Felder sind 
 msgid "Entity"
 msgstr "Einheit"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr "Umweltbedingungen"
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr "Umweltbedingungen"
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Fehlerhaftes Ergebnis wurde publiziert von ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr "Fehler"
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr "Entwicklung der Analysen"
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr "Entwicklung der Analyseaufträge"
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr "Entwicklung der Arbeitsblätter"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Von der Rechnung ausschließen"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Voraussichtliches Ergebnis"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Erwatungswerte"
 
@@ -2190,19 +2184,19 @@ msgstr "Erwatungswerte"
 msgid "Expire"
 msgstr "Ablaufen lassen"
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Verfallsdatum"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Exponentielle Darstellung der Präzision"
 
@@ -2210,44 +2204,40 @@ msgstr "Exponentielle Darstellung der Präzision"
 msgid "Exponential format threshold"
 msgstr "Exponentielle Darstellung des Schwellwerts"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr "Erweiterungsprofil für Bika LIMS"
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (geschäftlich)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Weiblich"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Feld"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Feldanalysen"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Vor Ort Konservierung"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Titel des Felds"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Datei"
 
@@ -2255,19 +2245,19 @@ msgstr "Datei"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Dateianhänge werden bei Aktvierung der Berichterstattung per Email beigefügt"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr "Datei hochladen"
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Dateiname"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr "Dateien"
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr "Filter"
 
@@ -2287,16 +2277,16 @@ msgstr "Filtern nach:"
 msgid "Filter template analyses by client"
 msgstr "Filtervorlage Analyse nach Kunden"
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Vorname"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Gleitkommawert von 0.0 - 1000.0 um die Sortierreihenfolge zu setzen. Doppelte Werte werden alphabetisch sortiert."
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formel"
 
@@ -2306,18 +2296,18 @@ msgstr "Formel"
 msgid "From"
 msgstr "Von"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Von ${start_date} bin ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Vollständiger Name"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "In der Zukunft datierte Probe"
 
@@ -2327,7 +2317,7 @@ msgstr "In der Zukunft datierte Probe"
 msgid "Generate report"
 msgstr "Bericht erzeugen"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titel, z.B. Herr, Frau, Dr"
 
@@ -2339,37 +2329,37 @@ msgstr "Gruppiere Analyseleistungen nach Kategorien. Sinnvoll bei langen Listen.
 msgid "Group by"
 msgstr "Sortieren nach"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Gruppierungszeitraum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Gefährlich"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Verstecktes Feld"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Stunden"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2378,8 +2368,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID Server URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID Server nicht verfügbar"
 
@@ -2387,31 +2377,31 @@ msgstr "ID Server nicht verfügbar"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "WICHTIG: Verwenden Sie nicht \"Bika\" or \"BIKA\" als Name, weil diese Namen zu einem reservierten Namensbereich gehören. Wenn sie einen \"Site Error\" mit der Beschreibung \"AttributeError: adapters\" bekommen, ist dies wahrscheinlich der Fall."
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr "Bezeichner"
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr "Bezeichnungstyp"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr "Bezeichnungstypen"
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr "Bezeichner für dieses Objekt"
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Wenn die Option 'Instumentenerfassung von Ergebnissen' gewählt wurde, wird die Standardmethode des Instruments verwendet. Anderenfalls werden nur die gewählten Methoden dargestellt."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Wenn Proben an dieser Probenahmestelle regelmäßig entnommen werden, geben Sie an dieser Stelle die Häufigkeit an"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "Wenn ausgewählt, wird eine Liste in der Ergebnisübersicht angezeigt. LDL und UDL sind dann durch den Labormitarbeiter frei wählbar"
 
@@ -2423,7 +2413,7 @@ msgstr "Wenn ausgewählt, wird das Gerät bis zur nächsten gültigen Kalibrieru
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Wenn ausgewählt, wird ein Freitext neben jeder Analyse in der Ergebnisübersicht angezeigt"
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, auch dieses verfizieren. Diese Option gilt nur für die Benutzer mit der entsprechenden Rolle (standardmässig Administratoren, Laboradministratoren und Prüfer) und hat Vorrang vor der Einstellung in der Bika Einrichtung."
 
@@ -2431,27 +2421,27 @@ msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, a
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Wenn ausgewählt, darf der Benutzer, der das Ergebnis eingereicht hat, auch dieses verifizieren. Diese Option gilt nur für die Benutzer mit der entsprechenden Rolle (standardmäßig Administratoren, Laboradministratoren und Prüfer) und kann für jede Analyse im Bearbeitungsmodus der Analyseleistung überschrieben werden. Standardeinstellung ist deaktiviert."
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Wenn ausgewählt, wird die Bezeichnung der Analyse in Kursiv dargestellt."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "Wenn ausgewählt, wird die Analyse und die Ergebnisse nicht in Berichten angezeigt. Diese Einstellung kann in den Analyseprofilen und Analysenanfragen überschrieben werden."
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "Wenn kein Titelwert eingegeben wird, wird die Batch ID verwendet."
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Wenn nötig wählen Sie eine Berechnung der Analyseleistung aus. Berechnungen können im Bereich LIMS Setup eingestellt werden"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Falls erforderlich, wählen Sie hier eine Berechnung für die Analyse aus. Berechnungen können unter dem Menüpunkt 'Berechnungen' im LIMS-Setup konfiguriert werden"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Wenn hier Text eingetragen wird wird er anstelle des Titels in Listen als Überschrift verwendet. HTML tags kann verwendet werden."
 
@@ -2459,7 +2449,7 @@ msgstr "Wenn hier Text eingetragen wird wird er anstelle des Titels in Listen al
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "Wenn vorherige Messeegebnisse des Batch für diese Analyseanfrage vorliegen, werden diese dem Bericht angehangen."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Wenn der Behälter vorkonserviert ist, kann die Konservierungsart hier ausgewählt werden."
 
@@ -2472,7 +2462,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Wenn deaktiviert haben Assistenten Zugang zu allen Arbeitsblättern."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Import"
@@ -2481,7 +2471,7 @@ msgstr "Import"
 msgid "Import Analysis Request Data"
 msgstr "Importiere Analyseauftragsdaten"
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importiert"
@@ -2490,8 +2480,8 @@ msgstr "Importiert"
 msgid "In-lab calibration procedure"
 msgstr "Interlaboratorielle Kalibrierung"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -2500,7 +2490,7 @@ msgstr "Inaktiv"
 msgid "Include Previous Results From Batch"
 msgstr "Ergebnisse der vorherigen Messung dem Batch beifügen"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Alle Analyseaufträge die zu den gewählten Objekten gehören einschließen."
 
@@ -2508,7 +2498,7 @@ msgstr "Alle Analyseaufträge die zu den gewählten Objekten gehören einschlie�
 msgid "Include and display pricing information"
 msgstr "Preisinformationen anzeigen und hinzufügen"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Beschreibungen einbeziehen"
 
@@ -2516,30 +2506,27 @@ msgstr "Beschreibungen einbeziehen"
 msgid "Include year in ID prefix"
 msgstr "ID-Präfix soll das Jahr enthalten"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "Falsche IBAN Nr.: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "Falsche NIB Nr.: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Unbestimmtes Ergebnis"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Zeigt an, ob Dateianhänge, z. B. Mikroskopbilder, für diese Analyse erforderlich sind und ob die Dateiuploadfunktion auf der Datenerfassungsseite zur Verfügung steht"
 
-msgid "Info"
-msgstr "Info"
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Übernehmen von"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Erstüberprüfung"
 
@@ -2563,7 +2550,7 @@ msgstr "Zertifikat upload installieren"
 msgid "InstallationDate"
 msgstr "Installations-Datum"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Anweisungen"
@@ -2576,17 +2563,17 @@ msgstr "Anleitung zu interlaboratoriellen Kalibrierungsanweisungen für Analysen
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Anleitungen für standard Präventiv- und Wartungsanweisungen für Analysen"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Gerät"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Gerätekalibrierungen"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr "Gerätedateien"
 
@@ -2599,16 +2586,16 @@ msgstr "Geräteimport"
 msgid "Instrument Location"
 msgstr "Gerätestandort"
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr "Gerätestandorte"
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Gerätewartungen"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Geplante Aufgaben für das Gerät"
 
@@ -2616,19 +2603,19 @@ msgstr "Geplante Aufgaben für das Gerät"
 msgid "Instrument Type"
 msgstr "Gerätetyp"
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Gerätearten"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Gerätevalidierungen"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr "Gerätezuweisung erlaubt"
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr "Gerätezuweisung nicht erforderlich"
 
@@ -2672,9 +2659,9 @@ msgstr "Gerätetyp"
 msgid "Instrument's calibration certificate expired:"
 msgstr "Gerät Kalibrierungszertifikat abgelaufen:"
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Geräte"
 
@@ -2698,7 +2685,7 @@ msgstr "Geräte in Prüfung:"
 msgid "Instruments' calibration certificates expired:"
 msgstr "Geräte Kalibrierungszertifikate abgelaufen:"
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Interner Kalibrationstest"
 
@@ -2714,24 +2701,21 @@ msgstr "Interpolation"
 msgid "Interval"
 msgstr "Intervall"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "Ungültiger Analyseauftrag wiederholt"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr "Ungültige Geräte werden nicht angezeigt: %s"
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr "Ungültige Geräte nicht angezeigt: ${invalid_list}"
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Ungültige Wildcards gefunden: ${wildcards}"
 
@@ -2739,43 +2723,43 @@ msgstr "Ungültige Wildcards gefunden: ${wildcards}"
 msgid "Invalidate"
 msgstr "Annullieren"
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Rechnung"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Rechnungsdatum"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "von Rechnung ausschließen"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Rechnungsnummer"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "Rechnungs Batch hat kein Enddatum"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "RechnungsBatch hat kein Startdatum"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "RechnungsBatch hat keinen Titel"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr "Zusammengesetzte Probe"
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Eintrag ist inaktiv."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Angaben, die in E-Mail-Betreffzeilen stehen sollen"
 
@@ -2785,7 +2769,7 @@ msgstr "Angaben, die in E-Mail-Betreffzeilen stehen sollen"
 msgid "Job Title"
 msgstr "Berufsbezeichnung"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Berufsbezeichnung"
 
@@ -2793,12 +2777,12 @@ msgstr "Berufsbezeichnung"
 msgid "Key"
 msgstr "Schlüssel"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Schlüsselfehler"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Schlüsselwort"
@@ -2807,47 +2791,47 @@ msgstr "Schlüsselwort"
 msgid "Keywords"
 msgstr "Schlüsselwörter"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Labor"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Laboranalysen"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Labor-Kontakte"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Labor-Abteilungen"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Laborkonservierung"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Laborprodukte"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Labor URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etikett"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Labor"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Akkreditiertes Labor"
 
@@ -2867,13 +2851,13 @@ msgstr "Letztes Anmeldedatum"
 msgid "Last modified"
 msgstr "Zuletzt geändert"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Verspätet"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Verspätete Analysen"
@@ -2883,7 +2867,7 @@ msgstr "Verspätete Analysen"
 msgid "Late Analysis"
 msgstr "Verspätete Analyse"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Breite"
 
@@ -2905,11 +2889,11 @@ msgstr "Benutzer verknüpfen"
 msgid "Link an existing User"
 msgstr "Bestehenden Benutzer verknüpfen"
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Verknüpfte Probe"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr "Liste der Bezeichnertypen für mehrfache Bezeichnerdatensätze"
 
@@ -2921,7 +2905,7 @@ msgstr "Listet alle Proben, die innerhalb eines Zeitraums eingegangen sind"
 msgid "Load Setup Data"
 msgstr "Setup-Daten laden"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Hier können Sie die Dokumente hochladen, die die Methode beschreiben"
 
@@ -2933,41 +2917,41 @@ msgstr "Aus Datei laden"
 msgid "Load the certificate document here"
 msgstr "Zertifikat hier hochladen"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Geladen"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Standort-Code"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Standort-Beschreibung"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Standortname"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Art des Standorts"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Ort der Probenaufbewahrung"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Probenahmestelle"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr "Ort an dem das Dokument eingeordnet wurde"
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Protokoll"
@@ -2992,35 +2976,35 @@ msgstr "Anmeldung fehlgeschlagen. Ihr Benutzeraccount wurde deaktiviert. Bitte k
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr "Login Fehlgeschlagen. Ihr Benutzer ist mehreren Benutzern zugeordnet. Bitte kontaktieren Sie das Labor für weitere Informationen."
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Länge"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Losnummer"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Untere Erfassungsgrenze (LDL)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Postanschrift"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Durchführender der Wartung"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Art der Wartung"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Männlich"
 
@@ -3028,16 +3012,16 @@ msgstr "Männlich"
 msgid "Manage linked User"
 msgstr "Verknüpfte Benutzer verwalten"
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Leiter"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "E-Mail des Managers"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telefonnummer des Managers"
 
@@ -3045,31 +3029,25 @@ msgstr "Telefonnummer des Managers"
 msgid "Manual"
 msgstr "Manuell"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Manueller Eintrag"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Manuelle Ergebniserfassung"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr "Manuelle Ergebniserfassung ist für die Methode ${methodname} nicht erlaubt"
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr "Manuelle Ergebniseingabe ist für die Methode %s nicht erlaubt und es wurden keine gültigen Geräte gefunden: %s"
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr "Die manuelle Ergebniserfassung ist für die Methode {methodname} nicht erlaubt und es wurden keine gültigen Geräte gefunden: ${invalid_list}"
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Hersteller"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Hersteller"
 
@@ -3078,14 +3056,14 @@ msgstr "Hersteller"
 msgid "Margins (mm)"
 msgstr "Ränder (mm)"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max."
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Max Zeit"
 
@@ -3093,30 +3071,30 @@ msgstr "Max Zeit"
 msgid "Maximum columns per results email"
 msgstr "Maximum an Zeilen pro Ergebnis-E-Mail"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Maximal mögliche Größe oder Menge der Proben."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Maximal erlaubte Zeit, in der eine Analyse abgeschlossen sein muss. Ein Alarm für verspätete Analysen wird angezeigt, wenn die Zeit abgelaufen ist"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maximale Bearbeitungszeit"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr "Mitgliederrabatt"
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Mitgliederrabatt %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Mitgliederrabatt anwenden"
 
@@ -3125,22 +3103,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr "Benutzer wurde registriert und zu dem aktuellen Kontakt verknüpft."
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Methode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Methodendokument"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "Methoden ID"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Arbeitsanweisungen für die Methode"
 
@@ -3152,9 +3130,9 @@ msgstr "Methode: ${method_name}"
 msgid "Method: None"
 msgstr "Methode: Keine"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Methoden"
 
@@ -3162,17 +3140,17 @@ msgstr "Methoden"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Methoden, die in der ${accreditation_body} Akkreditierungslistefür dieses Labor aufgeführt sind. Hinweise zu den Analysen sind nicht akkreditiert"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Initialien Zuname"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Zuname"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3184,8 +3162,8 @@ msgstr "Mein"
 msgid "Minimum 5 characters."
 msgstr "Mindestens 5 Zeichen."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Mindestvolumen"
 
@@ -3193,27 +3171,27 @@ msgstr "Mindestvolumen"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimale Anzahl an Ergebnissen für QM-Statusberechnungen"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minuten"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr "Fehlender Probenehmer für geplante Probenahme oder fehlendes Datum für %s gefunden."
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Mobiltelefon"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modell"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Änderungsdatum"
 
@@ -3227,7 +3205,7 @@ msgstr "Monatlich"
 msgid "More"
 msgstr "Mehr"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr "Mehr als ein Prüfgerät kann in einer Prüfung dieses Analysetyps verwendet werden. Eine Auswahlliste mit den hier ausgewählten Prüfgeräten wird in der Ergebnisverwaltung der jeweiligen Prüfung dieses Analysetyps angezeigt. Die verfügbaren Prüfgeräte in dieser Auswahlliste ändern sich entsprechend der durch den Benutzer ausgewählten Methode in der Ergebnisverwaltung. Obwohl eine Methode mehr als ein Prüfgerät zugewiesen haben kann, wird die Auswahlliste nur mit den Prüfgeräten gefüllt, die sowohl hier ausgewählt sind, wie auch in der ausgewählten Methode erlaubt sind."
 
@@ -3239,13 +3217,13 @@ msgstr "Mehrfacher Verifikationstyp"
 msgid "Multi-verification required"
 msgstr "Mehrfache Prüfung erforderlich"
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "NIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Name"
 
@@ -3254,17 +3232,17 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Nein"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Keine Analyseaufträge passen zur Suche"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr "Keine Analyseleistungen definiert"
 
@@ -3280,18 +3258,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Keine Anweisung für Nutzer ${user} gefunden"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Es wurden keine Analysen ausgewählt"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Keine Analysen passen zur Suche"
 
@@ -3303,23 +3281,23 @@ msgstr "Es wurden keine Analysen hinzugefügt"
 msgid "No analyses were added to this worksheet."
 msgstr "Zu diesem Arbeitsblatt wurden keine Analysen hinzugefügt."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Keine Analyse ausgewählt"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Keine Analyseleistungen ausgewählt"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Keine Analyseleistungen ausgewählt"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Keine Änderungen vorgenommen."
 
@@ -3327,7 +3305,7 @@ msgstr "Keine Änderungen vorgenommen."
 msgid "No control type specified"
 msgstr "Kein Kontrolltyp angegeben"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr "Kein Datum gesetzt"
 
@@ -3339,17 +3317,17 @@ msgstr "Keine Standardbehälter für diese Dienstleistung angegeben"
 msgid "No default preservations specified for this service"
 msgstr "Keine Standardkonservierung für die Analyseleistung angegeben"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Keine Datei ausgewählt"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Keine vergangenen Aktionen passen zur Suche"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Nicht ausgewählt"
 
@@ -3357,7 +3335,7 @@ msgstr "Nicht ausgewählt"
 msgid "No items selected"
 msgstr "Nichts ausgewählt"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Es wurden keine neuen Elemente angelegt"
 
@@ -3367,16 +3345,16 @@ msgstr "Es wurden keine neuen Elemente angelegt"
 msgid "No preservation required"
 msgstr "Keine Konservierung erforderlich"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Es wurde keine Referenzprobe ausgewählt"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Kein Bericht der Abfrage zugewiesen"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Keine Probe entspricht Ihrer Abfrage"
 
@@ -3394,25 +3372,22 @@ msgstr "Es existiert kein Benutzer für ${contact_fullname} und er/sie wird sich
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr "Es konnte kein Benutzerprofil für den verknüpften Benutzer gefunden werden. Bitte kontaktieren Sie den Labor Administrator für weiteren Support oder versuchen Sie den Benutzer erneut zu verknüpfen."
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr "Keine gültigen Geräte verfügbar: %s "
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr "Keine gültigen Geräte gefunden: ${invalid_list}"
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "keine"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Nicht zulässig"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Nicht verfügbar"
 
@@ -3432,19 +3407,19 @@ msgstr "Nicht gesetzt"
 msgid "Num columns"
 msgstr "Num Spalten"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Anzahl der Analysen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Anzahl der Analyseanfragen und Analysen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Anzahl der Analyseanfragen und Analysen je Kunde"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr "Anzahl der Behälter"
 
@@ -3452,30 +3427,30 @@ msgstr "Anzahl der Behälter"
 msgid "Number of Positions"
 msgstr "Anzahl der Positionen"
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr "Anzahl der Probenahmestellen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Anzahl der Analysen"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Anzahl der Analysen außerhalb des Bereichs für Zeitraum"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Zahl der Analysen, die pro Analyseleistung beauftragt wurde"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Anzahl der Analysenaufträge je Probentyp"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Anzahl der wiederholten Analysen für Zeitraum"
 
@@ -3483,15 +3458,15 @@ msgstr "Anzahl der wiederholten Analysen für Zeitraum"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Anzahl der beauftragten und berichteten Analysen pro Bereich, ausgedrückt als Prozentsatz aller durchgeführten Analysen "
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr "Anzahl der Behälter"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Anzahl der Anfragen"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr "Anzahl der benötigten Prüfungen"
@@ -3500,31 +3475,31 @@ msgstr "Anzahl der benötigten Prüfungen"
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Anzahl der benötigten Prüfungen bevor ein Ergebnis als 'geprüft' gilt. Diese Einstellung kann pro Analyse einer Analyseleistung überschrieben werden. Der Standardwert ist 1."
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Anzahl der benötigten Prüfungen von unterschiedlichen Benutzern mit entsprechender Berechtigung, bis eine Analyse als 'geprüft' gilt. Diese Einstellung überschreibt den Wert in den Bika Einstellungen."
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Anzahl der Proben"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr "Anzahl der Probenahmestellen"
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Numerischer Wert für die Reihenfolge der Priorisierung der Objekte"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "Objekt-ID"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Einmal konserviert muss die Probe innerhalb dieser Zeit entsorgt werden. Wenn nicht anderst spezifiziert, wird die Probentypenlaufzeit eingesetzt"
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr "Nur die Geräteerfassung ist für diese Analyse erlaubt, aber es wurden keine Geräte zugewiesen"
 
@@ -3532,15 +3507,12 @@ msgstr "Nur die Geräteerfassung ist für diese Analyse erlaubt, aber es wurden 
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Nur Laborleiter können Arbeitsblätter erstellen und verwalten"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr "Nur die Analysen die das ausgewählte Gerät erlaubt werden automatisch hinzugefügt. "
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Nur für leere oder Null-Felder"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Offen"
@@ -3553,26 +3525,26 @@ msgstr "Webbasiertes Open Source Labor Informations Management System passend f�
 msgid "Order"
 msgstr "Bestellung"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Bestelldatum"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "Bestell ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Bestellnummer"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Bestellungen"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Bestellungen: ${orders}"
 
@@ -3580,7 +3552,7 @@ msgstr "Bestellungen: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Zuständige Prüfeinrichtung für die Kalibrierung"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr "Ursprünglicher Dateiname"
 
@@ -3592,8 +3564,8 @@ msgstr "Anderer Wert:"
 msgid "Other productivity reports"
 msgstr "Andere Produktivitätsberichte"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Veraltet"
 
@@ -3605,16 +3577,13 @@ msgstr "Ausgabeformat"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr "Übergeordnet"
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Teil"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr "Teil ID"
 
@@ -3635,8 +3604,8 @@ msgstr "Passwort"
 msgid "Password lifetime"
 msgstr "Lebensdauer des Passworts"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Unerledigt"
@@ -3661,31 +3630,31 @@ msgstr "Durchgeführt von"
 msgid "Period"
 msgstr "Dauer"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Zulässig"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Zulässiger Fehler %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefon (geschäftlich)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefon (privat)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefon (mobil)"
 
@@ -3698,8 +3667,8 @@ msgid "Photo of the instrument"
 msgstr "Bild des Instruments"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Besucheradresse"
 
@@ -3707,7 +3676,7 @@ msgstr "Besucheradresse"
 msgid "Please correct the indicated errors."
 msgstr "Bitte korrigieren Sie die angezeigten Fehler."
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Bitte führen Sie alle Optionen für das Analyseergebnis auf falls Sie eine Reduzierung auf bestimmte Optionen/Merkmalswerte beabsichtigen (z.B. Positiv/Negativ). Der Optionswert muss numerisch sein."
 
@@ -3715,19 +3684,19 @@ msgstr "Bitte führen Sie alle Optionen für das Analyseergebnis auf falls Sie e
 msgid "Please select a User from the list"
 msgstr "Bitte wählen Sie einen Benutzer aus der Liste"
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Bitte spezifizieren hier Sie abweichende Analysekonservierungen, die von der Standardkonservierung je Probentyp der Analyseleistung abweichen."
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Bitte laden Sie das Logo hoch, das die Akkreditierungsstelle Ihnen zur Verwendung auf Ihrer Webseite und Ihren Prüfberichten genehmigt hat. Maximalgröße 175 x 175 Pixel."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Zeitpunkt der Aufnahme"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr "Portaltypen"
 
@@ -3736,13 +3705,13 @@ msgid "Pos"
 msgstr "Position"
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Position"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Postanschrift"
 
@@ -3750,16 +3719,16 @@ msgstr "Postanschrift"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Vorkonservierung"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Genauigkeit als Anzahl der Dezimalstellen"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Präzision als Zahl der signifikanten Stellen gemäß der Unsicherheit. Die Dezimalstelle ist durch die erste Zahl die nicht Null ist gegeben und entsprechend von dort durch das System gerundet. Zum Beispiel wird ein Ergebnis von 5.243 un einer Unsicherheit von 0.22 auf 5.2+/-0.2 gerundet. Wenn keine Unsicherheit angegeben wurde nutzt das System ein 'fixed precision set'."
 
@@ -3787,7 +3756,7 @@ msgstr "Wissenschaftliche Notation in Berichten bevorzugt"
 msgid "Preferred scientific notation format for results"
 msgstr "Wissenschaftliche Notation in Ergebnissen bevorzugt"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Präfix"
 
@@ -3795,12 +3764,12 @@ msgstr "Präfix"
 msgid "Prefixes"
 msgstr "Präfixe"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premium"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr "Konservierungs Workflow"
 
@@ -3812,17 +3781,17 @@ msgstr "Vorbereitet von"
 msgid "Prepublish"
 msgstr "Vorveröffentlichen"
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Konservierung"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Konservierungskategorie"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr "Konservierungsmethode"
 
@@ -3833,7 +3802,7 @@ msgid "Preservation required"
 msgstr "Konservierung benötigt"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Konservierungen"
 
@@ -3843,14 +3812,14 @@ msgstr "Konservierungen"
 msgid "Preserve"
 msgstr "Aufbewahren"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Konservierer"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Präventiv"
 
@@ -3858,34 +3827,34 @@ msgstr "Präventiv"
 msgid "Preventive maintenance procedure"
 msgstr "Präventive Wartungsprozedur"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Preis"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Preis (ohne MwSt.)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Preis Premium in Prozent"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Preis ohne MwSt."
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Preisliste für"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Preisliste"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr "Hauptkontakt"
 
@@ -3900,13 +3869,13 @@ msgstr "Drucken"
 msgid "Print date:"
 msgstr "Datum des Drucks"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr "Drucke Probenblätter"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Priorität"
 
@@ -3923,34 +3892,34 @@ msgstr "Produktivitätsbericht"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "Professionelles Open Source LIMS/LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Analyseprofile"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Profil-Schlüssel"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Profil-Schlüsselwort"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profile"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (noch nicht in Rechnung gestellt)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "Protokoll ID"
 
@@ -3958,7 +3927,7 @@ msgstr "Protokoll ID"
 msgid "Public. Lag"
 msgstr "Verzögerung der Veröffentlichung"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Publizierte Spezifikation"
 
@@ -3973,21 +3942,21 @@ msgstr "Veröffentlichungspräferenz"
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Veröffentlichte Analyseaufträge die noch nicht in Rechnung gestellt wurden"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Veröffentlicht von"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Veröffentlichte Ergebnisse"
 
@@ -4000,8 +3969,8 @@ msgid "QC Analyses"
 msgstr "QC Analysen"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "QC Proben-ID"
 
@@ -4022,23 +3991,23 @@ msgstr "Menge"
 msgid "Quarterly"
 msgstr "Vierteljährlich"
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Bereichskommentar"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Bereichs-Kommentar"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Bereich max"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Bereich min"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Spezifikationsbereich"
 
@@ -4060,9 +4029,9 @@ msgstr "Empfangen"
 msgid "Receive sample"
 msgstr "Proben empfangen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Empfangen"
 
@@ -4070,11 +4039,11 @@ msgstr "Empfangen"
 msgid "Recept. Lag"
 msgstr " Verzögerung Empfang"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr "Empfang ausstehend"
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Empfänger"
 
@@ -4083,31 +4052,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "Wähle <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\"> Erstellung neuer Report Vorlagen</a> Dokumentation auf der Bika LIMS Wiki Seite um mehr Berichte zu erhalten oder eigene Vorlagen zu entwickeln. "
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referenz"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Referenzanalyse"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Referenz-Definition"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Referenz-Definitionen"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Referenzprobe"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Referenzproben"
 
@@ -4115,16 +4084,16 @@ msgstr "Referenzproben"
 msgid "Reference Supplier"
 msgstr "Referenzlieferant"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Referenztyp"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Referenzwert"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Standardanalyse QC"
@@ -4133,7 +4102,7 @@ msgstr "Standardanalyse QC"
 msgid "Reference analysis quality control graphs"
 msgstr "Referenzanalysen Qualitätskontroll-Graphen"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Referenzanalysen Qualitätskontroll-Graphen"
 
@@ -4141,21 +4110,21 @@ msgstr "Referenzanalysen Qualitätskontroll-Graphen"
 msgid "Reference sample"
 msgstr "Referenzprobe"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Referenzprobenwerte sind Null oder 'blind'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "Referenz Analyse Gruppen ID"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenzDefinition steht für eine definierte Referenz oder einen Probentyp, der für Qualitätskontrollen eingesetzt wird"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Refs: ${references}"
 
@@ -4178,8 +4147,8 @@ msgstr "Wiedereinstellen"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr "Abgelehnt"
@@ -4188,9 +4157,9 @@ msgstr "Abgelehnt"
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Relativer Differenzanteil, ${variation_here} %, außerhalb des gütligen Bereichs (${variation} %)"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Bemerkungen"
 
@@ -4198,7 +4167,7 @@ msgstr "Bemerkungen"
 msgid "Remarks to take into account before calibration"
 msgstr "Wichtige Bemerkungen vor Kalibrierung"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Wichtige Bemerkungen vor Durchführung"
 
@@ -4206,7 +4175,7 @@ msgstr "Wichtige Bemerkungen vor Durchführung"
 msgid "Remarks to take into account before validation"
 msgstr "Wichtige Bemerkungen vor Validierung"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Bemerkungen für den Wartungsprozess"
 
@@ -4215,8 +4184,8 @@ msgstr "Bemerkungen für den Wartungsprozess"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Reparatur"
 
@@ -4225,7 +4194,7 @@ msgid "Repeated analyses"
 msgstr "Wiederholte Analysen"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Bericht"
 
@@ -4239,14 +4208,14 @@ msgstr "Berichtsdatum"
 msgid "Report ID"
 msgstr "Bericht ID"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Berichtsart"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Berichten als auf Trockensubstanz bezogen"
 
@@ -4271,7 +4240,7 @@ msgstr "Bericht über einen Zeitraums über die Anzahl empfangener Proben und ve
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Bericht über Analyseanfragen und der Gesamtzahl in Auftrag gegebenen Aufträgen innerhalb einer Zeitperiode"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Berichtsart"
 
@@ -4279,7 +4248,7 @@ msgstr "Berichtsart"
 msgid "Report upload"
 msgstr "Bericht hochladen"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Berichte"
 
@@ -4288,15 +4257,15 @@ msgstr "Berichte"
 msgid "Republish"
 msgstr "Wiederveröffentlichen"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Anfrage"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "Auftrags ID"
 
@@ -4304,26 +4273,26 @@ msgstr "Auftrags ID"
 msgid "Request new analyses"
 msgstr "Neue Analyse anfordern"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Angefragt"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Aufträge"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Erforderlich"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Gefordertes Volumen"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "Benötigte Felder ohne Werte: ${field_names}"
 
@@ -4331,13 +4300,13 @@ msgstr "Benötigte Felder ohne Werte: ${field_names}"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Kategorien einschränken"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Ergebnis"
 
@@ -4345,15 +4314,15 @@ msgstr "Ergebnis"
 msgid "Result Footer"
 msgstr "Ergebnis Fusszeile"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Ergebnis-Optionen"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Ergebniswert"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr "Das Ergebnis für ${analysis} konnte nicht gespeichert werden, weil es bereits von einem anderen Benutzer eingereicht wurde."
 
@@ -4371,11 +4340,11 @@ msgstr "Ergebnis außerhalb des Bereichs"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Ergebniswerte mit mehr als der genannten Anzahl signifikanter Stellen werden in der Exponentialschreibweise dargestellt. Die Präzision wird in den einzelnen Analysenservices konfiguriert."
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Ergebnisinterpretation"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Ergebnisinterpretation"
 
@@ -4383,7 +4352,7 @@ msgstr "Ergebnisinterpretation"
 msgid "Results attachments permitted"
 msgstr "Anhänge bei Ergebnissen erlaubt"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Ergebnisse wurden zurückgezogen"
 
@@ -4391,11 +4360,11 @@ msgstr "Ergebnisse wurden zurückgezogen"
 msgid "Results interpretation"
 msgstr "Ergebnisinterpretation"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr "Ausstehende Ergebnisse"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Ergebnisse je Probenpunkt"
@@ -4404,14 +4373,14 @@ msgstr "Ergebnisse je Probenpunkt"
 msgid "Results per samplepoint and analysis service"
 msgstr "Ergebnisse je Probenpunkt und Analyseleistung"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Rückstellzeitraum"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Erneut getestet"
@@ -4430,11 +4399,11 @@ msgstr "Zurückgezogen"
 msgid "Retracted analyses"
 msgstr "Zurückgezogene Analysen"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Zurückziehungsbericht nicht verfügbar"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Zurückgezogene"
 
@@ -4450,12 +4419,12 @@ msgstr "Routineproben (Analysen)"
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "SMTP Server nicht verbunden. Benutzererstellung wurde abgebrochen."
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "SWIFT Code."
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Anrede"
 
@@ -4463,19 +4432,19 @@ msgstr "Anrede"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Gleich, wie darüber, aber setzt den Analyseservice auf die Vorgabe. Diese Festlegung kann bei jeder Analyse individuel konfiguriert werden"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Probe"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Probenzustand"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Probenzustände"
 
@@ -4484,8 +4453,8 @@ msgid "Sample Due"
 msgstr "Probe fällig"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "Proben ID"
 
@@ -4497,12 +4466,12 @@ msgstr "Probe-ID Füllstellen"
 msgid "Sample ID Sequence Start"
 msgstr "Start der Proben ID Sequenz"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Probenmatrizes"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Probenmatrix"
 
@@ -4512,52 +4481,52 @@ msgstr "Probennummer"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Teilproben"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Probenahmestelle"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Probenahmestellen"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr "Ablehnung der Probe"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Probenart"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Probenartpräfix"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Proben Spezifikation (Kunde)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Proben Spezifikation (Labor)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Probenarten"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Probenzustand"
 
@@ -4567,9 +4536,9 @@ msgstr "Probenzustand"
 msgid "Sample due"
 msgstr "Probe ausstehend"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Probennahmestelle"
 
@@ -4597,17 +4566,17 @@ msgstr "Probe registriert"
 msgid "Sample related reports"
 msgstr "Probenbezogene Berichte"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Probenart"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Probenmatrix"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Probenart"
 
@@ -4617,30 +4586,30 @@ msgstr "Probenart"
 msgid "Sampled"
 msgstr "Proben entnommen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Probenehmer"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr "Probennehmer für die geplante Probennahme"
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Proben"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Proben dieses Typs sollten als gefährlich behandelt werden"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Proben Empfangen vs. Berichtet"
@@ -4649,62 +4618,62 @@ msgstr "Proben Empfangen vs. Berichtet"
 msgid "Samples received vs. samples reported"
 msgstr "Proben Empfangen vs. Proben berichtet"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Proben: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Probenahmedatum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Probenahme-Abweichung"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Probenahme-Abweichungen"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Probenahmehäufigkeit"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr "Probennahmestelle"
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr "Probennahmerunde"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr "Probennahmerundenvorlage"
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr "Probennahmerundenvorlagen"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr "Probennahmerunden"
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr "Probenahmerundenvorlagen"
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr "Datum der Probe"
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr "Proben"
 
@@ -4714,9 +4683,9 @@ msgstr "Proben"
 msgid "Sampling workflow"
 msgstr "Proben Workflow"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Speichern"
 
@@ -4729,17 +4698,17 @@ msgstr "Bemerkungen speichern"
 msgid "Schedule sampling"
 msgstr "Plane Probennahme"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Geplante Probennahme"
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Geplante Aufgabe"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Wissenschaftlicher Name"
 
@@ -4747,16 +4716,16 @@ msgstr "Wissenschaftlicher Name"
 msgid "Search"
 msgstr "Suchen"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Sekunden"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr "Sicherheitssiegel unbeschädigt"
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr "Sicherheitssiegel unbeschädigt J/N"
 
@@ -4768,11 +4737,11 @@ msgstr "Wählen Sie 'Registrierung', wenn Sie einen automatischen Etikettendruck
 msgid "Select AR Templates to include"
 msgstr "Einzubeziehende Analyseauftragsvorlagen auswählen"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Wählen Sie eine Datenschnittstelle aus"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Wählen Sie eine Standardkonservierung für diese Analyseleistung. Wenn die Konservierung von der Kombination abhängt, wählen Sie eine Konservierung je Probe in der Tabelle darunter."
 
@@ -4780,11 +4749,11 @@ msgstr "Wählen Sie eine Standardkonservierung für diese Analyseleistung. Wenn 
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Wählen Sie eine Zielposition und die Analyseanfrage zum kopieren aus"
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Wählen Sie einen Leiter aus dem verfügbaren Personal aus, das unter \"Laborkontakte\" eingerichtet wurde. Auf Bereichsleiter wird auf den Ergebnisberichten nach ihrem Bereich verwiesen."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Wählen Sie eine Probe für die Erstellung eines zweiten AR"
 
@@ -4796,7 +4765,7 @@ msgstr "Alle Einträge auswählen"
 msgid "Select an Export interface for this instrument."
 msgstr "Wählen Sie die Exportschnittstelle für dieses Instrument."
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Analysen, die in diese Vorlage einbezogen werden sollen, auswählen"
 
@@ -4808,11 +4777,11 @@ msgstr "Analytiker auswählen"
 msgid "Select existing file"
 msgstr "Bestehende Datei wählen"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr "Wählen Sie Bezeichner, mit denen dieses Objekt referenziert werden kann."
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Bitte auswählen, wenn die Analyse von der Rechnung ausgeschlossen werden soll"
 
@@ -4820,19 +4789,19 @@ msgstr "Bitte auswählen, wenn die Analyse von der Rechnung ausgeschlossen werde
 msgid "Select if is an in-house calibration certificate"
 msgstr "Im Fall eines internen Kalibrierzertifikats auswählen"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Bitte auswählen wenn die Berechnung der Standardmethode verwendet werden soll ansonsten kann die Berechnung manuelle gewählt werden."
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Bitte auswählen, wenn die Beschreibung angefügt werden soll"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr "Auswählen, wenn die Ergebnisse der Prüfungen dieses Analysetyps mittels eines Prüfgeräts eingetragen werden können. Wenn die Option deaktiviert ist, werden keine Prüfgeräte in der Ergebnisverwaltung dieses Analysetyps angezeigt, selbst wenn die ausgwählt Methode für die Prüfung Prüfgeräte zugewiesen hat."
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr "Auswählen, wenn die Ergebnisse der Prüfungen für diesen Analysetyp manuell eingegeben werden können. Wenn diese Option ausgewählt ist, kann der Benutzer das Ergebnis einer Prüfung dieses Analysetyps in der Ergebnisverwaltung eingeben, ohne ein Prüfgerät auszuwählen, selbst wenn die ausgewählte Methode dieser Prüfung ein Prüfgerät zugewiesen hat."
 
@@ -4858,7 +4827,7 @@ msgstr "Land, das die Seite per Voreinstellung anzeigen soll, auswählen"
 msgid "Select the currency the site will use to display prices."
 msgstr "Wählen Sie die Währung, die zur Anzeige von Preisen benutzt werden soll."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Wählen Sie den Standardbehälter der für diese Analysen verwendet werden soll. Wenn die Behälterart von der Kombination aus Probenart und Konservierung abhängt, geben Sie den Behälter in die Tabelle der Probenarten unten ein."
 
@@ -4870,7 +4839,7 @@ msgstr "Wählen Sie die Standard - Startseite die verwendet werden soll, wenn Ku
 msgid "Select the filter to apply"
 msgstr "Wählen Sie den zu aktivierenden Filter"
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Wählen Sie das bevorzugte Gerät aus"
 
@@ -4878,7 +4847,7 @@ msgstr "Wählen Sie das bevorzugte Gerät aus"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr "Wählen Sie die Standardvorlage die für das Veröffentlichen von Analyseaufträgen verwendet werden soll."
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr "Wählen sie die Typen die durch diese ID identifiziert werden."
 
@@ -4902,7 +4871,7 @@ msgstr "Wählen Sie diese Option, um den Probenahme-Schritt zu aktivieren."
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Auswählen um dem Proben Koordinator zu erlauben, eine Probe zeitlich einzuplanen. Diese Funktionalität ist nur dann von Bedeutung, wenn der \"Proben Workflow\" aktiviert ist. "
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Wählen Sie die Analysen aus, die auf dem Arbeitsblatt enthalten sein sollen"
 
@@ -4918,7 +4887,7 @@ msgstr "Wählen Sie das Etikett, das standardmäßig für kleine Etiketten verwe
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Druckauswahl Aufkleber, wenn automatischer Aufkleberdruck ermöglicht"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr "Erlaube Selbstverifizierung der Ergebnisse"
 
@@ -4930,7 +4899,7 @@ msgstr "E-Mail senden"
 msgid "Separate"
 msgstr "Trennen"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Seperater Behälter"
 
@@ -4938,32 +4907,28 @@ msgstr "Seperater Behälter"
 msgid "Serial No"
 msgstr "Seriennummer"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Service"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr "Dienst Abhängigkeiten"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "Leistung ist enthalten im ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Services"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr "Proben Arbeitsablauf mit Bemerkung setzen"
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Setze die Wartungsaufgabe auf geschlossen"
 
@@ -4971,31 +4936,31 @@ msgstr "Setze die Wartungsaufgabe auf geschlossen"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Stellen Sie die maximale Anzahl von Analyseaufträgen pro Ergebnis-E-Mail ein. Zu viele Spalten je E-Mail sind schwierig zu lesen für manche Kunden, die daher weniger Ergebnisse pro Mail bevorzugen."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Wählen Sie die Spezifikation für die Publikation der AR."
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Spezifikationen für die Analyseergebnisse des Labors einstellen"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Regalcode"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Regal-Beschreibung"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Regalname"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Versandadresse"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Kurztitel"
 
@@ -5011,7 +4976,7 @@ msgstr "Zeige QC Analysen"
 msgid "Show more"
 msgstr "Zeige mehr"
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Nur ausgewählte Kategorien in Kundenansichten anzeigen"
 
@@ -5023,29 +4988,25 @@ msgstr "Zeige/verberge Zeitlinienzusammenfassung"
 msgid "Signature"
 msgstr "Unterschrift"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Standortcode"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Standortbeschreibung"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Standortname"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Größe"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr "Einschub"
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Kleines Symbol"
 
@@ -5053,14 +5014,14 @@ msgstr "Kleines Symbol"
 msgid "Small sticker"
 msgstr "Kleines Etikett"
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Einige Analysen verwenden veraltete oder unkalibrierte Geräte. Ergebnisbearbeitung nicht erlaubt."
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Sortierschlüssel"
 
@@ -5068,41 +5029,41 @@ msgstr "Sortierschlüssel"
 msgid "Specification"
 msgstr "Spezifikation"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Spezifikationen"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Geben Sie die Größe des Arbeitsblatts an, z.B. entsprechend dem Samplertray eines bestimmten Geräts. Dann wählen Sie eine Analyseart pro Arbeitsblatt-Position. Wenn QC-Proben gewählt sind, muss auch angegeben werden welche Referenzproben zu verwenden sind. Wenn eine Doppelbestimmung gewählt ist, geben Sie an zu welcher Probenposition es ein Duplikat sein soll."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "Geben Sie die Unsicherheit für einen definierten Bereich an, z.B. für Ergebnisse innerhalb eines Bereichs eines Minimums von 0 und einem Maximum von 10, mit einer Unsicherheit von 0.5. Das Ergebnis wird dann als 6.67 +- 0.5 angezeigt. Ebenfalls können Unsicherheiten prozentual angegeben werden, indem ein '%' Zeichen dem Wert angehangen wird."
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Anfangsdatum"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr "Anfangsdatum muss vor dem Enddatum sein"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Status"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr "Buchungen"
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Status"
 
@@ -5110,33 +5071,33 @@ msgstr "Status"
 msgid "Sticker templates"
 msgstr "Etikett Vorlagen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Lagerort"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Lagerorte"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Untergruppe"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Untergruppen"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Untergruppen sind in der Gruppenansicht nach diesem Merkmal sortiert"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Einreichen"
 
@@ -5144,37 +5105,34 @@ msgstr "Einreichen"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Geben Sie eine gültige Open XML (.XLSX) Datei an, um mit den LIMS-Einstellungen fortzufahren."
 
-msgid "Submit for verification"
-msgstr "Zur Überprüfung einreichen"
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr "Eingereicht und verifiziert durch den gleichen Benutzer-"
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr "Übermittle Analyseauftragsimport"
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Zwischensumme"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Lieferant"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Lieferanten"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Lieferauftrag"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Nachname"
 
@@ -5194,11 +5152,11 @@ msgstr "Zur Startseite wechseln"
 msgid "System Dashboard"
 msgstr "System Dashboard"
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr "System Standard"
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Aufgabe"
 
@@ -5207,20 +5165,20 @@ msgid "Task ID"
 msgstr "Aufgaben ID"
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Aufgabentyp"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Technische Beschreibung und Anweisungen für Analytiker"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5238,35 +5196,35 @@ msgstr "Ergebnis testen"
 msgid "Tests requested"
 msgstr "Tests angefragt"
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Analyseprofil Auswahl für diese Vorlage"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "Die vom Labor zugewiesene ID für den Auftrag des Kunden"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "Die vom Labor zugewiesene ID für die Probe des Kunden"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Die Webadresse des Labors"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "Die untere Nachweisgrenze ist der niedrigste Wert des Parameters der für die gewählte Methode zulässig ist. Ergebnisse die unterhalb dieses Schwellwerts liegen werden als < LDL dargestellt."
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "Die obere Nachweisgrenze ist der höchste Wert des Parameters der für die gewählte Methode zulässig ist. Ergebnisse die oberhalb dieses Schwellwerts liegen werden als > UDL dargestellt."
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Gültiger Akkreditierungs-Standard, z.B. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Die in diesem Profil enthaltenen Analysen, gruppiert nach Kategorien"
 
@@ -5278,7 +5236,7 @@ msgstr "Die Analyse, die zur Bestimmung von Trockenmasse verwendet werden soll."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Der zuständige Prüfer für die Kalibrierung"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Der zuständige Prüfer für die Wartung"
 
@@ -5286,12 +5244,12 @@ msgstr "Der zuständige Prüfer für die Wartung"
 msgid "The analyst responsible of the validation"
 msgstr "Der zuständige Prüfer für die Validierung"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Mit Analyseanfragen und Analysen verknüpfte Anhänge"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Die Kategorie, zu der der Analyse-Service gehört"
 
@@ -5299,19 +5257,19 @@ msgstr "Die Kategorie, zu der der Analyse-Service gehört"
 msgid "The date the instrument was installed"
 msgstr "Geräte Installationsdatum"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr "Das Datum an dem der Probennahmeprozess ausgeführt werden soll"
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Dezimalzeichen im LIMS Setup wird verwendet."
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr "Standard Probennehmer für diese Probenrunde"
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Der standard Behältertyp. Neue Proben werden ihm automatisch zugewiesen, soweit keine Alternative in der Analyseleistung definiert ist."
 
@@ -5323,7 +5281,7 @@ msgstr "Rabatt für Kunden mit Mitglieder Status. Für gewöhnlich handelt es si
 msgid "The full URL: http://URL/path:port"
 msgstr "Die vollständige URL: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Die Höhe oder Tiefe, in der die Probe genommen wurde"
 
@@ -5340,24 +5298,24 @@ msgstr "Die Modellnummer des Geräts"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr "Das Intervall wird aufgrund des 'Von' Datums berechnet und definiert den Zeitraum bis zum Ablauf des Zertifikats in Tagen. Wenn Sie ein Intervall setzen, überschreibt dies das 'Bis' Datum. "
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr "Die Artikel %s können nicht übergeleitet werden."
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr "Dieser Artikel kann nicht übergeleitet werden."
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr "Die Laborabteilung, die für die Probenrunde verantwortlich ist"
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Das Labor ist nicht akkreditiert oder die Akkreditierung wurde nicht konfiguriert."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Die Laborabteilung"
@@ -5374,27 +5332,27 @@ msgstr "Die Länge der Null-Füllstellen für Proben-IDs"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Die Länge der Null-Füllstellen für die AR-Nummer in AR-IDs"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Liste der Probenahmepunkte an denen die Probenart genommen werden kann. Wenn keine Probenahmepunkte ausgewählt werden, sind alle Probenahmepunkte verfügbar."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Liste der Probenarten die an diesem Probenahmepunkt genommen werden können. Wenn keine Probenarten ausgewählt werden, sind alle Probenarten verfügbar."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Die Maßeinheit der Ergebnisse für den Analyse-Service, z.B. mg/l, ppm, dB, mV, etc.."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr "Die Methode %s ist ungültig: Keine manuelle Ergebniserfassung erlaubt und kein Gerät zugewiesen"
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr "Die Methode %s ist ungültig: Nur die Geräteerfassung ist erlaubt, aber die Methode hat kein Gerät zugewiesen"
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Die Mindestmenge, die für die Analyse benötigt wird, z.B. \"10 ml\" oder \"1 kg\"."
 
@@ -5418,7 +5376,7 @@ msgstr "Anzahl der Tage, bevor das Passwort verfällt. 0 deaktiviert das Verfall
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Die Anzahl der Tage, bevor eine Probe verfällt und nicht mehr analysiert werden kann. Diese Einstellung kann für jeden Probentyp im Probentypen-Setup überschrieben werden."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr "Die Anzahl der Tage zwischen wiederholenden Exkursionen"
@@ -5435,11 +5393,11 @@ msgstr "Anzahl der Anfragen und Analysen"
 msgid "The number of requests and analyses per client"
 msgstr "Anzahl der Anfragen und Analysen je Kunde"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "Preisaufschlag in Prozent bei Prioritätsanalysen"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Die Zeitspanne in der nicht konservierte Proben dieses Typs aufbewahrt werden können bevor sie verfallen und nicht mehr analysiert werden dürfen"
 
@@ -5456,19 +5414,19 @@ msgstr "Die Person beim Lieferanten, die die Aufgabe ausführte"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "Die Person beim Lieferanten, die das Zertifikat ausarbeitete"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "Preis pro Analyse für Kunden mit Mengenrabatt."
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "Buchhaltungs-ID des Analyseprofils"
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "Das Kennwort wird in Importdateien genutzt um es eindeutig dem entsprechenden Profil zuzuordnen. Es muss eindeutig sein und darf nicht einer Berechnungsfeld ID entsprechen."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Die Referenznummer, die dem Labor von der Akkreditierungsstelle zugewiesen wurde."
 
@@ -5476,11 +5434,11 @@ msgstr "Die Referenznummer, die dem Labor von der Akkreditierungsstelle zugewies
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "Das Ergebnis nach dieser Berechnung wurde aufgrund von Testwerten berechnet. Sie müssen die Berechnung speichern,  bevor dieser Wert berechnet werden kann."
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "Die Ergebnisse für diese Analyseleistung können manuell erfasst werden."
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Die Ergebnisse der Feldanalysen werden am Prüffeld direkt an der Probenahmestelle erhoben, z.B. Temperatur des Wassers. Laboranalysen werden im Labor durchgeführt."
 
@@ -5488,7 +5446,7 @@ msgstr "Die Ergebnisse der Feldanalysen werden am Prüffeld direkt an der Proben
 msgid "The room and location where the instrument is installed"
 msgstr "Aufstellort des Gerätes"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "Das gewählte Instrument unterstützt die Methode. Weisen Sie die Methode dem Instrument im Edit Modus zu."
 
@@ -5500,11 +5458,11 @@ msgstr "Die ausgewählte Startseite wird für unangemeldete Benutzer angezeigt, 
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Seriennummer zur eindeutigen Identitifiezierung des Geräts"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "Protokoll ID der Analyseleistung"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Eindeutige Buchhaltungsnummer der Analyseleistung"
 
@@ -5512,19 +5470,19 @@ msgstr "Eindeutige Buchhaltungsnummer der Analyseleistung"
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "Systemübergreifende Einstellung, ob Dateianhänge bei Analyseanfragen erforderlich, erlaubt oder nicht erlaubt sind."
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr "Die Prüfung dieses Analysetyps kann durch mehr als eine Methode durch die Option \"Manuelle Eingabe der Ergebnisse\" durchgeführt werden. Eine Auswahlliste mit den hier ausgewählten Methoden wird in der Ergebnisverwaltung jeder Prüfung dieses Analysetyps angezeigt. Bitte beachten Sie, dass nur Methoden mit der Option \"Erlaube manuelle Ergebniserfassung\" hier angezeigt werden; Wenn Sie wollen, dass Benutzer eine Methode auswählen können, die eine Prüfgeräteerfassung benötigen, dann aktivieren Sie die Option \"Erlaube Instrumentenzuweisung\"."
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr "Die gesamte Anzahl der Behälter in dieser Probenrunde."
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Bearbeitungszeit von Analysen"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "Bearbeitungszeiten im Verlauf der letzten Zeit"
 
@@ -5536,7 +5494,7 @@ msgstr "Bearbeitungszeiten von Analysen"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "Bearbeitungszeiten im Verlauf der letzten Zeit"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "Das Kennwort zur Identifikation von Analyseleistungen für den Datenimport von Instrumenten und Analysenanfragen. Ebenfalls findet es Verwenung für Ergebnis Berechungen."
 
@@ -5548,37 +5506,37 @@ msgstr "Keine Ergebnisse vorhanden."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr "Diese Gründe werden als Auswahl während des Ablehnungsprozesses angezeigt."
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Die Ergebnisse können als Trockenmasse berichtet werden"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Die Ergebnisse wurden zurückgezogen und werden zur Nachverfolgung hier aufgeführt. Bitte folgen Sie dem Link Neuprüfung"
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "Die Analyseanfrage wurde automatisch erstellt, um die Rückverfolgbarkeit zu gewährleisten. Analysenanfrage ${retracted_request_id}."
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Die Analyseanfrage wurde zurückgezogen und wird nur aus Gründen der Nachverfolgbarkeit angezeigt. Neuprüfung ${retest_child_id}."
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Diese Analyseleistung kann nicht verwendet werden, da ihre Berechnung deaktiviert wurden."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Diese Analyseleistung kann nicht deaktiviert werden, da eine oder mehrere aktive Berechnungen dazugehören."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr "Dieses Gerät wird standardmäßig in der Ergebnisverwaltungsansicht für Analysetests diesen Typs zugewiesen. Ebenso wird die Standard Geräte Methode zugewiesen. Hinweis: Die Gerätemethode ist vorrangig über andere Methoden die selektiert wurden, wenn die Option „Gerätezuordnung nicht erforderlich“ eingestellt wurde."
 
@@ -5590,7 +5548,7 @@ msgstr "Diese Leistung benötigt keine separate Teilprobe"
 msgid "This service requires a separate container."
 msgstr "Diese Dienstleistung benötigt einen extra Behälter."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr "Dieser Text wird ebenfalls als Hinweistext angezeigt, wenn man mit der Maus über das Titel Feld navigiert"
 
@@ -5598,13 +5556,9 @@ msgstr "Dieser Text wird ebenfalls als Hinweistext angezeigt, wenn man mit der M
 msgid "This text will be appended to results reports."
 msgstr "Dieser Text wird an Ergebnisreports angehangen."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Dieser Wert wird am unteren Rand aller veröffentlichten Ergebnisse angezeigt"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr "Dies entfernt alle existierenden Analysespezifikationen des Kunden und erstellt Kopien aller Laborspezifikationen. Sind Sie sicher?"
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5618,63 +5572,63 @@ msgstr "Dieses Arbeitsblatt wurde zurückgezogen und ersetzt durch ${ws_id}"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Angehängte Dokumente werden nicht geladen solange sie nicht verfügbar sind"
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Name"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Name des Standorts"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Name des Lagerregals"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Name der Einrichtung"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Bis"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Zu konservieren"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Zu beproben"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Unterhalb der Analysekategorien im Ergebnisbericht anzeigen"
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Zu konservieren"
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr "Zu veröffentlichen"
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Zu beproben"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Zu überprüfen"
 
@@ -5686,13 +5640,13 @@ msgstr "Geben Sie hier die Werte für alle Berechnungsparameter ein, um diese Be
 msgid "To:"
 msgstr "An:"
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr "Zu wenige Zeilen in der CSV Datei"
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Gesamt"
 
@@ -5700,22 +5654,22 @@ msgstr "Gesamt"
 msgid "Total Lag"
 msgstr "Gesamtverzögerung"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Gesmtpreis"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Analysen gesamt"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Datenpunkte gesamt"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Gesamtpreis"
 
@@ -5727,11 +5681,11 @@ msgstr "Summe:"
 msgid "Traceability"
 msgstr "Rückverfolgbarkeit"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr "Übergang durchgeführt."
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr "Transponiert"
 
@@ -5739,61 +5693,55 @@ msgstr "Transponiert"
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Bitte aktivieren wenn die Probe aufgeteilt werden soll"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Bearbeitungszeit (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Typ"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Tippfehler"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr "Typ des Dokuments (z.B. Bedienungsanleitung, Gerätespezifikation, Bild, ...)"
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Art des Standortes"
 
-msgid "Unable to apply the selected instrument"
-msgstr "Das ausgewählte Gerät kann nicht zugewiesen werden"
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr "Geräte konnten nicht geladen werden: ${invalid_list}"
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Laden des Templates fehlgeschlagen"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Alarm Email Versand an Kontaktpersonen der zurückgezogenen Analyse fehlgeschlagen: ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nicht zugeordnet"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Unsicherheit"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Wert der Unsicherheit"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Nicht definiert"
 
@@ -5801,13 +5749,13 @@ msgstr "Nicht definiert"
 msgid "Unique ID"
 msgstr "Eindeutige ID"
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Einheit"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "Unbekanntes IBAN Land %s"
 
@@ -5832,17 +5780,17 @@ msgstr "Benutzerverknüpfung aufgehoben und Benutzer gelöscht"
 msgid "Unpublished"
 msgstr "Unveröffentlicht"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Unbekanntes Dateiformat ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Unbekanntes Dateiformat ${file_format}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr "Unbekanntes Dateiformat ${format}"
 
@@ -5854,11 +5802,11 @@ msgstr "Zuordnung aufheben"
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Hier können Sie ihre gescannte Unterschirft hochladen. Ihre Unterschrift wird dann auf allen Ergebnisberichten verwendet. Die ideale Größe beträgt 250 Höhe x 150 Breite Pixel"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "Oberes Erkennungslimit"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "Verwende Preis des Analyseprofils"
 
@@ -5866,7 +5814,7 @@ msgstr "Verwende Preis des Analyseprofils"
 msgid "Use Dashboard as default front page"
 msgstr "Dashboard als Standardansicht für angemeldete Benutzer wählen"
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Standard-Berechnung nutzen"
 
@@ -5878,13 +5826,13 @@ msgstr "Externen ID-Server nutzen"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Verwenden Sie dieses Feld um beliebige Parameter dem export/import Modul zu übergeben."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Benutzer"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Benutzername"
@@ -5897,7 +5845,7 @@ msgstr "Historie (Benutzer)"
 msgid "User linked to this Contact"
 msgstr "Benutzer wurde zu diesem Kontakt verknüpft"
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Historie (Benutzer)"
@@ -5906,27 +5854,27 @@ msgstr "Historie (Benutzer)"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Derart wenige Messwerte machen statistisch keinen Sinn. Erfassen Sie weitere Daten für eine zuverlässige QC Auswertung."
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "MwSt."
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "MwSt. %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "MwSt. Anteil"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "MwSt. Gesamt"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "USt-IdNr."
 
@@ -5934,11 +5882,11 @@ msgstr "USt-IdNr."
 msgid "Valid"
 msgstr "Gültig"
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Gültig von"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Gültig bis"
 
@@ -5946,181 +5894,181 @@ msgstr "Gültig bis"
 msgid "Validate"
 msgstr "Validieren"
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validierung"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Validierung fehlgeschlagen: '${keyword}': Kennwort bereits vorhanden"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Validierung fehlgeschlagen: '${title}': Dieses Schlüsselwort wird bereits von Berechnung '${used_by}' verwendet"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Validierung fehlgeschlagen: '${title}': Dieses Schlüsselwort wird bereits von Service '${used_by}' verwendet"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Validierung fehlgeschlagen: '${title}': Titel bereits vorhanden"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Validierung fehlgeschlagen: '${value}' ist nicht eindeutig"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Validierung fehlgeschlagen: Ausrichtung muss O/W sein"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Validierung fehlgeschlagen: Ausrichtung muss N/S sein"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Validierung fehlgeschlagen: Prozentuale Fehlerangaben müssen zwischen 0 und 100 liegen"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Validierung fehlgeschlagen: Tolleranzwerte müssen 0 oder größer sein"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Validierung fehlgeschlagen: Tolleranzwerte müssen numerisch sein"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Validierung fehlgeschlagen: Werte müssen zwischen Min- und Max-Werten liegen"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Validierung fehlgeschlagen: Werte müssen numerisch sein"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Validierung fehlgeschlagen: Kennwort '${keyword}' ist ungültig"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Validierung fehlgeschlagen: Max-Werte müssen größer als Min-Werte sein"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Validierung fehlgeschlagen: Max-Werte müssen numerisch sein"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Validierung fehlgeschlagen: Min-Werte müssen numerisch sein"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Validierung fehlgeschlagen: Prozentuale Fehlerwerte müssen zwischen 0 und 100 liegen"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Validierung fehlgeschlagen: Prozentuale Fehlerwerte müssen numerisch sein"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Validierung fehlgeschlagen: Bei bereits eingelagerten Proben muss eine Einlagerung ausgewählt werden"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Validierung fehlgeschlagen: Ergebnistext darf nicht leer sein"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Validierung fehlgeschlagen: Ergebniswerte müssen Zahlen sein"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Validierung fehlgeschlagen: Die Auswahl benötigt die folgenden aktivierten Kategorien: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Validierung fehlgeschlagen: Wert muss numerisch sein"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Validierung fehlgeschlagen: Spaltentitel '${title}' muss ein Kennwort '${keyword}' enthalten"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Validierung fehlgeschlagen: Grad beträgt 180; Minuten müssen NULL sein"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Validierung fehlgeschlagen: Grad beträgt 180; Sekunden müssen NULL sein"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Validierung fehlgeschlagen: Grad beträgt 90; Minuten müssen NULL sein"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Validierung fehlgeschlagen: Grad beträgt 90; Sekunden müssen NULL sein"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Validierung fehlgeschlagen: Grad muss zwischen 0 und 180 liegen"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Validierung fehlgeschlagen: Grad muss zwischen 0 und 90 sein"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Validierung fehlgeschlagen: Grad muss numerisch sein"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Validierung fehlgeschlagen: Kennwort '${keyword}' muss einen Spaltentitel'${title}' haben"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Validierung fehlgeschlagen: Kennwort enthält ungültige Zeichen"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Validierung fehlgeschlagen: Kennwort erforderlich"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Validierung fehlgeschlagen: Minuten müssen zwischen 0 und 59 liegen"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Validierung fehlgeschlagen: Minuten müssen numerisch sein"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Validierung fehlgeschlagen: Werte müssen zwischen 0 und 100 sein"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Validierung fehlgeschlagen: Prozentwerte müssen numerisch sein"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Validierung fehlgeschlagen: Sekunden müssen zwischen 0 und 59 liegen"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Validierung fehlgeschlagen: Sekunden müssen numerisch sein"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Validierung fehlgeschlagen: Titel wird benötigt."
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr "Validierung fehlgeschlagen: Wert muss zwischen 0 und 1000 liegen"
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr "Validierung fehlgeschlagen: Wert muss eine Gleitkommazahl sein"
 
@@ -6128,7 +6076,7 @@ msgstr "Validierung fehlgeschlagen: Wert muss eine Gleitkommazahl sein"
 msgid "Validation report date"
 msgstr "Validierungsbericht - Veröffentlichungsdatum"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Validiert von"
@@ -6139,12 +6087,12 @@ msgstr "Validiert von"
 msgid "Value"
 msgstr "Wert"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Die hier eingetragenen Werte ersetzen die vorläufigen Standardwerte der Berechnungsfelder."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verifiziert"
@@ -6155,7 +6103,7 @@ msgstr "Verifiziert"
 msgid "Verify"
 msgstr "Verifizieren"
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Version"
 
@@ -6165,11 +6113,11 @@ msgstr "Version"
 msgid "Volume"
 msgstr "Volumen"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Webadresse der Akkreditierungsstelle"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Webseite"
 
@@ -6177,24 +6125,24 @@ msgstr "Webseite"
 msgid "Weekly"
 msgstr "Wöchentlich"
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Wochen bis zum Ablauf"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "Wenn gesetzt, benutzt das System den Preis des Analysenprofils und die systemweit eingestellte MwSt. wird überschrieben"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Ergebnisse von Doppelbestimmung der selben Probe außerhalb des Prozentbereichs lösen einen Alarm aus"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "Wildcards sind für Interims nicht erlaubt: ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Ausgeführte Arbeiten"
@@ -6205,25 +6153,25 @@ msgstr "Arbeitsablauf"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Arbeitsblatt"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Arbeitsblattlayout"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Arbeitsblattvorlagen"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Arbeitsblätter"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Falsche IBAN Länge von %s: %s ist %i zu kurz"
 
@@ -6231,9 +6179,9 @@ msgstr "Falsche IBAN Länge von %s: %s ist %i zu kurz"
 msgid "Yearly"
 msgstr "Jährlich"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Ja"
 
@@ -6245,7 +6193,7 @@ msgstr "Sie haben keine ausreichenden Rechte um Arbeitsblätter zu bearbeiten."
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "Sie haben keine ausreichenden Rechte um das Arbeitsblatt einzusehen ${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "Sie müssen diesen Auftrag einem Kunden zuordnen"
 
@@ -6253,11 +6201,11 @@ msgstr "Sie müssen diesen Auftrag einem Kunden zuordnen"
 msgid "You must select an instrument"
 msgstr "Sie müssen ein Gerät auswählen"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "Sie sollten einen Standard Ergebnisschlüssel einführen."
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "Maßnahme"
 
@@ -6273,15 +6221,15 @@ msgstr "Analyse"
 msgid "analysis requests selected"
 msgstr "ausgewählte Analyseanfrage"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "und andere"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr "zugewiesen"
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr "Anhang fällig"
 
@@ -6304,7 +6252,7 @@ msgstr "Bika LIMS Arbeitsprozesse passen zu allen Labor Disziplinen und sind kon
 msgid "bika-frontpage-title"
 msgstr "<img src=\\\"${DYNAMIC_CONTENT}\\\" /> Willkomen auf Bika LIMS ${version} ${DYNAMIC_CONTENT}"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "Kommentar"
 
@@ -6312,38 +6260,9 @@ msgstr "Kommentar"
 msgid "daily"
 msgstr "täglich"
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "Datensätze"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr "${d}.${m}.${Y} ${H}:${M}"
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr "${d}.${m}.${Y}"
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-#, fuzzy
-msgid "date_format_short_datepicker"
-msgstr "dd.mm.yy"
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6354,7 +6273,7 @@ msgstr "deaktivieren"
 msgid "heading_arpriority"
 msgstr "Priorität des Analyseauftrags"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "inaktiv"
 
@@ -6403,19 +6322,19 @@ msgstr "Version ${new_Version} wurde am ${new_date} veröffentlich und die derze
 msgid "new_version_available_title"
 msgstr "Eine neue Version von Bika LIMS ist verfügbar"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr "von"
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr "offen"
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr "anderer Status"
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr "veröffentlicht"
 
@@ -6423,19 +6342,19 @@ msgstr "veröffentlicht"
 msgid "quarterly"
 msgstr "vierteljährlich"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "wiederholt sich jede"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "Wiederholungszeitraum"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr "Probe fällig"
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr "Probe empfangen"
 
@@ -6454,20 +6373,9 @@ msgstr "Inhalte auflisten"
 msgid "text_default_site_title"
 msgstr "Bika"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
 msgstr "die Gesamtanzahl der in der Probenrunde definierten Probennahmen"
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
-msgstr "${H}:${M}"
 
 #. Default: "Required"
 #: bika/lims/browser/templates/header_table.pt:39
@@ -6478,7 +6386,7 @@ msgstr "Title fehlt"
 msgid "to"
 msgstr "An"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr "zu prüfen"
 
@@ -6486,7 +6394,7 @@ msgstr "zu prüfen"
 msgid "type"
 msgstr "Typ"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "bis"
 
@@ -6512,7 +6420,7 @@ msgstr "Wert"
 msgid "verification(s) pending"
 msgstr "Prüfung(en) ausgehend"
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr "geprüft"
 
@@ -6524,6 +6432,6 @@ msgstr "wöchentlich"
 msgid "yearly"
 msgstr "jährlich"
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr "{} Woche(n) und {} Tag(e)"

--- a/bika/lims/locales/el/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/el/LC_MESSAGES/bika.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Greek (http://www.transifex.com/bikalabs/bika-lims/language/el/)\n"
@@ -25,49 +25,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Σφάλμα"
 
@@ -97,15 +97,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -117,15 +117,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -138,7 +138,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -147,32 +147,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -183,16 +177,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -204,7 +198,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -212,17 +206,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -230,54 +224,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Όνομα Λογαριασμού"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Αριθμός Λογαριασμού"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Είδος  Λογαριασμού"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Διαπίστευση"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Συντομογραφία Σώματος Διαπίστευσης"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL Σώματος Διαπίστευσης"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -291,21 +285,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Προσθήκη"
 
@@ -325,11 +319,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -337,16 +327,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Διεύθυνση"
@@ -359,26 +349,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Όλα"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -390,7 +380,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -398,15 +388,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -414,11 +404,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -426,48 +416,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Ποσό"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Αναλύσεις"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Αναλύσεις εκτός εύρους"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Αναλύσεις ανά είδος δείγματος"
@@ -481,7 +471,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -494,27 +484,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Ανάλυση"
 
@@ -522,52 +512,52 @@ msgstr "Ανάλυση"
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Κατηγορίες Ανάλυσης"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Κατηγορία Ανάλυσης"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Προφίλ Ανάλυσης"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Προφίλ Ανάλυσης"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -575,65 +565,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Αιτήσεις Ανάλυσης"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Είδος Ανάλυσης"
@@ -642,46 +632,46 @@ msgstr "Είδος Ανάλυσης"
 msgid "Analysis category"
 msgstr "Κατηγορία ανάλυσης"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Αιτήσεις ανάλυσης και αναλύσεις"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Αιτήσεις ανάλυσης και αναλύσεις ανά πελάτη"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -689,12 +679,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -710,17 +700,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -729,7 +719,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -741,7 +731,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -759,15 +749,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -785,27 +775,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Συνημμένο"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Είδος Συνημμένου"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Είδη Συνημμένων"
 
@@ -815,25 +805,25 @@ msgstr "Είδη Συνημμένων"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Είδος συνημμένου"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Συνημμένα"
 
@@ -845,7 +835,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -862,27 +852,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Υποκατάστημα τράπεζας"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Όνομα τράπεζας"
 
@@ -891,31 +881,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -923,7 +913,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -931,7 +921,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -939,63 +929,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Τηλέφωνο Εργασίας"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Από"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Υπολογισμός"
 
@@ -1003,8 +997,8 @@ msgstr "Υπολογισμός"
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1017,11 +1011,11 @@ msgstr "Υπολογισμός: ${calc_name}"
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Υπολογισμοί"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1033,12 +1027,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1052,9 +1046,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Ακυρώθηκε"
 
@@ -1070,18 +1064,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Χωρητικότητα"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1090,7 +1084,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Αριθμός Καταλόγου"
 
@@ -1098,17 +1092,17 @@ msgstr "Αριθμός Καταλόγου"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Κατηγορία"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1121,31 +1115,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1153,7 +1147,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1169,19 +1163,19 @@ msgstr ""
 msgid "City"
 msgstr "Πόλη"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1189,19 +1183,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Πελάτης"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1209,59 +1203,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Όνομα Πελάτη"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Παραγγελία Πελάτη"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Πελάτες"
 
@@ -1270,39 +1264,39 @@ msgstr "Πελάτες"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1310,21 +1304,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1333,13 +1327,13 @@ msgid "Confirm password"
 msgstr "Επιβεβαίωση κωδικού πρόσβασης"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Επαφή"
@@ -1348,8 +1342,8 @@ msgstr "Επαφή"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Επαφές"
@@ -1358,48 +1352,48 @@ msgstr "Επαφές"
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Δοχείο"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Είδος Δοχείου"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Είδη Δοχείων"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Δοχεία"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1415,12 +1409,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Αντιγραφή από"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Μέτρηση"
 
@@ -1433,18 +1427,18 @@ msgstr "Χώρα"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1452,7 +1446,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1460,8 +1454,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1469,12 +1463,12 @@ msgstr ""
 msgid "Currency"
 msgstr "Νόμισμα"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1487,7 +1481,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1501,88 +1495,88 @@ msgstr "Διεπαφή Δεδομένων"
 msgid "Data Interface Options"
 msgstr "Επιλογές Διεπαφής Δεδομένων"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Ημερομηνία Αποστολής"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Ημερομηνία Εισαγωγής"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Ημερομηνία Ανοίγματος"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Ημερομηνία Δημοσίευσης"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Ημερομηνία Παραλαβής"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Ημερομηνία Αίτησης"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Ημερομηνία Δειγματοληψίας"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1598,7 +1592,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1616,7 +1610,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1625,11 +1619,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Ημέρες"
 
@@ -1641,17 +1635,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1659,49 +1653,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Προεπιλεγμένο Δοχείο"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Είδος Προεπιλεγμένου Δοχείου"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Προεπιλεγμένες κατηγορίες"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1710,11 +1704,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Προεπιλεγμένα δοχεία: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1738,11 +1732,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Προεπιλεγμένη τιμή"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1750,7 +1744,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1758,11 +1752,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1770,16 +1764,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1787,9 +1781,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr "Διαγραφή συνημμένου"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Τμήμα"
 
@@ -1802,13 +1796,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Περιγραφή"
 
@@ -1816,7 +1810,7 @@ msgstr "Περιγραφή"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1824,19 +1818,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1844,7 +1838,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Έκπτωση %"
 
@@ -1852,16 +1846,16 @@ msgstr "Έκπτωση %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Αναγραφόμενη Τιμή"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1873,7 +1867,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1882,8 +1876,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1892,54 +1886,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1952,20 +1946,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Προθεσμία"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Προθεσμία"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1974,20 +1968,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1999,35 +1993,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Διάρκεια"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Π.χ. SANAS, APLAC, κλπ."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Υψόμετρο"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Διεύθυνση Email"
 
@@ -2035,7 +2029,7 @@ msgstr "Διεύθυνση Email"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2055,14 +2049,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2074,16 +2068,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2091,15 +2085,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2107,7 +2101,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2115,45 +2109,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2162,19 +2156,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Ημερομηνία Λήξης"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2182,44 +2176,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Φαξ"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Φαξ (επαγγελματικό)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Θήλυ"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Πεδίο"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Τίτλος Πεδίου"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Αρχείο"
 
@@ -2227,19 +2217,19 @@ msgstr "Αρχείο"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Όνομα Αρχείου"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2259,16 +2249,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2278,18 +2268,18 @@ msgstr ""
 msgid "From"
 msgstr "Από"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2299,7 +2289,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2311,37 +2301,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Ώρες"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2350,8 +2340,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2359,31 +2349,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2395,7 +2385,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2403,27 +2393,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2431,7 +2421,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2444,7 +2434,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Εισαγωγή"
@@ -2453,7 +2443,7 @@ msgstr "Εισαγωγή"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2462,8 +2452,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2472,7 +2462,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2480,7 +2470,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2488,30 +2478,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2535,7 +2522,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2548,17 +2535,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2571,16 +2558,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2588,19 +2575,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2644,9 +2631,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2670,7 +2657,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2686,24 +2673,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2711,43 +2695,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2757,7 +2741,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2765,12 +2749,12 @@ msgstr ""
 msgid "Key"
 msgstr "Κλειδί"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Λέξη Κλειδί"
@@ -2779,47 +2763,47 @@ msgstr "Λέξη Κλειδί"
 msgid "Keywords"
 msgstr "Λέξεις Κλειδιά"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Εργαστήριο"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Αναλύσεις Εργαστηρίου"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Επαφές Εργαστηρίου"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Τμήματα Εργαστηρίου"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Προϊόντα Εργαστηρίου"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL Εργαστηρίου"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Ετικέτα"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Εργαστήριο"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2839,13 +2823,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Καθυστερημένες Αναλύσεις"
@@ -2855,7 +2839,7 @@ msgstr "Καθυστερημένες Αναλύσεις"
 msgid "Late Analysis"
 msgstr "Καθυστερημένη Ανάλυση"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Γεωγραφικό Πλάτος"
 
@@ -2877,11 +2861,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2893,7 +2877,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2905,41 +2889,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2964,35 +2948,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Γεωγραφικό Μήκος"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Ταχυδρομική διεύθυνση"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Άρρεν"
 
@@ -3000,16 +2984,16 @@ msgstr "Άρρεν"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Διευθυντής"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Email Διευθυντή"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Τηλέφωνο Διευθυντή"
 
@@ -3017,31 +3001,25 @@ msgstr "Τηλέφωνο Διευθυντή"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Κατασκευαστής"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3050,14 +3028,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Μέγιστο"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Μέγιστος Χρόνος"
 
@@ -3065,30 +3043,30 @@ msgstr "Μέγιστος Χρόνος"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Μέγιστο δυνατό μέγεθος ή όγκος δειγμάτων."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3097,22 +3075,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Μέθοδος"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Έγγραφο Μεθόδου"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Οδηγίες Μεθόδου"
 
@@ -3124,9 +3102,9 @@ msgstr "Μέθοδος: ${method_name}"
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Μέθοδοι"
 
@@ -3134,17 +3112,17 @@ msgstr "Μέθοδοι"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Ελάχιστο"
 
@@ -3156,8 +3134,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr "Τουλάχιστον 5 χαρακτήρες."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Ελάχιστος Όγκος"
 
@@ -3165,27 +3143,27 @@ msgstr "Ελάχιστος Όγκος"
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Λεπτά"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Κινητό Τηλέφωνο"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3199,7 +3177,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3211,13 +3189,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Όνομα"
 
@@ -3226,17 +3204,17 @@ msgstr "Όνομα"
 msgid "New"
 msgstr "Νέο"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Όχι"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3252,18 +3230,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Δεν έχουν επιλεχθεί αναλύσεις"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3275,23 +3253,23 @@ msgstr "Δεν προστέθηκαν αναλύσεις"
 msgid "No analyses were added to this worksheet."
 msgstr "Δεν προστέθηκαν αναλύσεις σε αυτό το φύλλο εργασίας."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3299,7 +3277,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3311,17 +3289,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3329,7 +3307,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3339,16 +3317,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3366,25 +3344,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Δεν Επιτρέπεται"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3404,19 +3379,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3424,30 +3399,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Αριθμός αναλύσεων"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Αριθμός αναλύσεων εκτός εύρους για περίοδο"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3455,15 +3430,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3472,31 +3447,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Αριθμός δειγμάτων"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3504,15 +3479,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Άνοιγμα"
@@ -3525,26 +3497,26 @@ msgstr ""
 msgid "Order"
 msgstr "Παραγγελία"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Ημερομηνία Παραγγελίας"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Αριθμός Παραγγελίας"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Παραγγελίες"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3552,7 +3524,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3564,8 +3536,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3577,16 +3549,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3607,8 +3576,8 @@ msgstr "Κωδικός Πρόσβασης"
 msgid "Password lifetime"
 msgstr "Διάρκεια ζωής κωδικού πρόσβασης"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Εκκρεμεί"
@@ -3633,31 +3602,31 @@ msgstr ""
 msgid "Period"
 msgstr "Περίοδος"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Τηλέφωνο"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Τηλέφωνο (εργασίας)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Τηλέφωνο (οικίας)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Τηλέφωνο (κινητό)"
 
@@ -3670,8 +3639,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3679,7 +3648,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3687,19 +3656,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3708,13 +3677,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Ταχυδρομική διεύθυνση"
 
@@ -3722,16 +3691,16 @@ msgstr "Ταχυδρομική διεύθυνση"
 msgid "Postal code"
 msgstr "Ταχυδρομικός κώδικας"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3759,7 +3728,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3767,12 +3736,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3784,17 +3753,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3805,7 +3774,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3815,14 +3784,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3830,34 +3799,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Τιμή"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Τιμή (χωρίς ΦΠΑ)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Τιμή χωρίς ΦΠΑ"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Τιμοκατάλογος για"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3872,13 +3841,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3895,34 +3864,34 @@ msgstr "Αναφορές Παραγωγικότητας"
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Προφίλ"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Προφίλ Αναλύσεων"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Κλειδί Προφίλ"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Προφίλ"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3930,7 +3899,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3945,21 +3914,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3972,8 +3941,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3994,23 +3963,23 @@ msgstr "Ποσότητα"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4032,9 +4001,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4042,11 +4011,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4055,31 +4024,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Δείγμα Αναφοράς"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Δείγματα Αναφοράς"
 
@@ -4087,16 +4056,16 @@ msgstr "Δείγματα Αναφοράς"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4105,7 +4074,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4113,21 +4082,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr "Δείγμα αναφοράς"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4150,8 +4119,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4160,9 +4129,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4170,7 +4139,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4178,7 +4147,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4187,8 +4156,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4197,7 +4166,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Αναφορά"
 
@@ -4211,14 +4180,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4243,7 +4212,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4251,7 +4220,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Αναφορές"
 
@@ -4260,15 +4229,15 @@ msgstr "Αναφορές"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Αίτηση"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4276,26 +4245,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr "Αίτηση νέων αναλύσεων"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Αιτήσεις"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Απαιτούμενος Όγκος"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4303,13 +4272,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Αποτέλεσμα"
 
@@ -4317,15 +4286,15 @@ msgstr "Αποτέλεσμα"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Επιλογές Αποτελέσματος"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Τιμή Αποτελέσματος"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4343,11 +4312,11 @@ msgstr "Αποτέλεσμα εκτός εύρους"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4355,7 +4324,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4363,11 +4332,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Αποτελέσματα ανά σημείο δειγματοληψίας"
@@ -4376,14 +4345,14 @@ msgstr "Αποτελέσματα ανά σημείο δειγματοληψία�
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4402,11 +4371,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4422,12 +4391,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4435,19 +4404,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Δείγμα"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4456,8 +4425,8 @@ msgid "Sample Due"
 msgstr "Προθεσμία Δείγματος"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4469,12 +4438,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4484,52 +4453,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Σημείο Δειγματοληψίας"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Σημεία Δειγματοληψίας"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Είδος Δείγματος"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Είδη Δείγματος"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4539,9 +4508,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Σημείο δειγματοληψίας"
 
@@ -4569,17 +4538,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Είδος δείγματος"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4589,30 +4558,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Δειγματολήπτης"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Δείγματα"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4621,62 +4590,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Ημερομηνία Δειγματοληψίας"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Συχνότητα Δειγματοληψίας"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4686,9 +4655,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Αποθήκευση"
 
@@ -4701,17 +4670,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4719,16 +4688,16 @@ msgstr ""
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Δευτερόλεπτα"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4740,11 +4709,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Επιλέξτε μια διεπαφή δεδομένων"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4752,11 +4721,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4768,7 +4737,7 @@ msgstr "Επιλογή όλων των αντικειμένων"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Επιλέξτε αναλύσεις να περιληφθούν σε αυτό το πρότυπο"
 
@@ -4780,11 +4749,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4792,19 +4761,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4830,7 +4799,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4842,7 +4811,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4850,7 +4819,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4874,7 +4843,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Επιλέξτε ποιες Αναλύσεις πρέπει να περιληφθούν στο Φύλλο Εργασίας"
 
@@ -4890,7 +4859,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4902,7 +4871,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Ξεχωριστό Δοχείο"
 
@@ -4910,32 +4879,28 @@ msgstr "Ξεχωριστό Δοχείο"
 msgid "Serial No"
 msgstr "Σειριακός Αριθμός"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4943,31 +4908,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Διεύθυνση αποστολής"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4983,7 +4948,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4995,29 +4960,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Υπογραφή"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Μέγεθος"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5025,14 +4986,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5040,41 +5001,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Κατάσταση"
 
@@ -5082,33 +5043,33 @@ msgstr "Κατάσταση"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Υποβολή"
 
@@ -5116,37 +5077,34 @@ msgstr "Υποβολή"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Υποσύνολο"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Προμηθευτής"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5166,11 +5124,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5179,20 +5137,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Θερμοκρασία"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5210,35 +5168,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Η επιλογή Προφίλ Ανάλυσης για αυτό το πρότυπο"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Οι αναλύσεις που περιλαμβάνονται σε αυτό το προφίλ, ομαδοποιημένες ανά κατηγορία"
 
@@ -5250,7 +5208,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5258,12 +5216,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5271,19 +5229,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5295,7 +5253,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr "Το πλήρες URL: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Το ύψος ή βάθος στο οποίο πρέπει να ληφθεί το δείγμα"
 
@@ -5312,24 +5270,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Το εργαστηριακό τμήμα"
@@ -5346,27 +5304,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Η λίστα των σημείων δειγματοληψίας από τα οποία αυτό το δείγμα μπορεί να συλλεχθεί. Αν δεν επιλεχθεί κανένα σημείο δειγματοληψίας, τότε όλα τα σημεία δειγματοληψίας είναι διαθέσιμα."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Η λίστα των ειδών δείγματος που μπορούν να συλλεχθούν σε αυτό το σημείο δειγματοληψίας. Αν δεν επιλεχθεί κανένα είδος δείγματος, τότε όλα τα είδη δείγματος είναι διαθέσιμα."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5390,7 +5348,7 @@ msgstr "Ο αριθμός των ημερών πριν ένας κωδικός �
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5407,11 +5365,11 @@ msgstr "Ο αριθμός αιτήσεων και αναλύσεων"
 msgid "The number of requests and analyses per client"
 msgstr "Ο αριθμός αιτήσεων και αναλύσεων ανά πελάτη"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5428,19 +5386,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5448,11 +5406,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5460,7 +5418,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5472,11 +5430,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5484,19 +5442,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5508,7 +5466,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5520,37 +5478,37 @@ msgstr "Δεν υπάρχουν αποτελέσματα."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5562,7 +5520,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5570,12 +5528,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5590,63 +5544,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5658,13 +5612,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Σύνολο"
 
@@ -5672,22 +5626,22 @@ msgstr "Σύνολο"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Συνολική Τιμή"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Συνολικές αναλύσεις"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Συνολική τιμή"
 
@@ -5699,11 +5653,11 @@ msgstr "Σύνολο:"
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5711,61 +5665,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Είδος"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Αβεβαιότητα"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Τιμή αβεβαιότητας"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5773,13 +5721,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5804,17 +5752,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5826,11 +5774,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5838,7 +5786,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5850,13 +5798,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Χρήστης"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Όνομα Χρήστη"
@@ -5869,7 +5817,7 @@ msgstr "Ιστορικό χρήστη"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Ιστορικό χρηστών"
@@ -5878,27 +5826,27 @@ msgstr "Ιστορικό χρηστών"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "ΦΠΑ"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "ΦΠΑ %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Ποσό ΦΠΑ"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5906,11 +5854,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5918,181 +5866,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6100,7 +6048,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6111,12 +6059,12 @@ msgstr ""
 msgid "Value"
 msgstr "Τιμή"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6127,7 +6075,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Έκδοση"
 
@@ -6137,11 +6085,11 @@ msgstr "Έκδοση"
 msgid "Volume"
 msgstr "Όγκος"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6149,24 +6097,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6177,25 +6125,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Φύλλο Εργασίας"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Διάταξη Φύλλου Εργασίας"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Πρότυπα Φύλλου Εργασίας"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Φύλλα Εργασίας"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6203,9 +6151,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Ναι"
 
@@ -6217,7 +6165,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6225,11 +6173,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6245,15 +6193,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6274,7 +6222,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6282,36 +6230,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6323,7 +6243,7 @@ msgstr "απενεργοποίηση"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6371,19 +6291,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6391,19 +6311,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6422,19 +6342,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6446,7 +6355,7 @@ msgstr ""
 msgid "to"
 msgstr "σε"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6454,7 +6363,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6479,7 +6388,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6491,6 +6400,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/en/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en/LC_MESSAGES/bika.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,49 +18,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -76,7 +76,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -90,15 +90,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -110,15 +110,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -131,7 +131,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -140,32 +140,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -176,16 +170,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -197,7 +191,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -205,17 +199,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -223,54 +217,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -284,21 +278,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -318,11 +312,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -330,16 +320,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -352,26 +342,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -383,7 +373,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -391,15 +381,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -407,11 +397,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -419,48 +409,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -474,7 +464,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -487,27 +477,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -515,52 +505,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -568,65 +558,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -635,46 +625,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -682,12 +672,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -703,17 +693,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -722,7 +712,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -734,7 +724,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -752,15 +742,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -778,27 +768,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -808,25 +798,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -838,7 +828,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -855,27 +845,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -884,31 +874,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -916,7 +906,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -924,7 +914,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -932,63 +922,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -996,8 +990,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1010,11 +1004,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1026,12 +1020,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1045,9 +1039,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1063,18 +1057,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1083,7 +1077,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1091,17 +1085,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1114,31 +1108,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1146,7 +1140,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1162,19 +1156,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1182,19 +1176,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1202,59 +1196,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1263,39 +1257,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1303,21 +1297,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1326,13 +1320,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1341,8 +1335,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1351,48 +1345,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1408,12 +1402,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1426,18 +1420,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1445,7 +1439,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1453,8 +1447,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1462,12 +1456,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1480,7 +1474,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1494,88 +1488,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1591,7 +1585,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1609,7 +1603,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1618,11 +1612,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1634,17 +1628,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1652,49 +1646,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1703,11 +1697,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1731,11 +1725,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1743,7 +1737,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1751,11 +1745,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1763,16 +1757,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1780,9 +1774,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1795,13 +1789,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1809,7 +1803,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1817,19 +1811,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1837,7 +1831,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1845,16 +1839,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1866,7 +1860,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1875,8 +1869,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1885,54 +1879,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1945,20 +1939,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1967,20 +1961,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1992,35 +1986,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2028,7 +2022,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2048,14 +2042,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2067,16 +2061,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2084,15 +2078,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2100,7 +2094,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2108,45 +2102,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2155,19 +2149,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2175,44 +2169,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2220,19 +2210,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2252,16 +2242,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2271,18 +2261,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2292,7 +2282,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2304,37 +2294,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2343,8 +2333,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2352,31 +2342,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2388,7 +2378,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2396,27 +2386,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2424,7 +2414,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2437,7 +2427,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2446,7 +2436,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2455,8 +2445,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2465,7 +2455,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2473,7 +2463,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2481,30 +2471,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2528,7 +2515,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2541,17 +2528,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2564,16 +2551,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2581,19 +2568,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2637,9 +2624,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2663,7 +2650,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2679,24 +2666,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2704,43 +2688,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2750,7 +2734,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2758,12 +2742,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2772,47 +2756,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2832,13 +2816,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2848,7 +2832,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2870,11 +2854,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2886,7 +2870,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2898,41 +2882,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2957,35 +2941,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2993,16 +2977,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3010,31 +2994,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3043,14 +3021,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3058,30 +3036,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3090,22 +3068,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3117,9 +3095,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3127,17 +3105,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3149,8 +3127,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3158,27 +3136,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3192,7 +3170,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3204,13 +3182,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3219,17 +3197,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3245,18 +3223,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3268,23 +3246,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3292,7 +3270,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3304,17 +3282,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3322,7 +3300,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3332,16 +3310,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3359,25 +3337,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3397,19 +3372,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3417,30 +3392,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3448,15 +3423,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3465,31 +3440,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3497,15 +3472,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3518,26 +3490,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3545,7 +3517,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3557,8 +3529,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3570,16 +3542,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3600,8 +3569,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3626,31 +3595,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3663,8 +3632,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3672,7 +3641,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3680,19 +3649,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3701,13 +3670,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3715,16 +3684,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3752,7 +3721,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3760,12 +3729,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3777,17 +3746,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3798,7 +3767,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3808,14 +3777,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3823,34 +3792,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3865,13 +3834,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3888,34 +3857,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3923,7 +3892,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3938,21 +3907,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3965,8 +3934,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3987,23 +3956,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4025,9 +3994,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4035,11 +4004,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4048,31 +4017,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4080,16 +4049,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4098,7 +4067,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4106,21 +4075,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4143,8 +4112,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4153,9 +4122,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4163,7 +4132,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4171,7 +4140,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4180,8 +4149,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4190,7 +4159,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4204,14 +4173,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4236,7 +4205,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4244,7 +4213,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4253,15 +4222,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4269,26 +4238,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4296,13 +4265,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4310,15 +4279,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4336,11 +4305,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4348,7 +4317,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4356,11 +4325,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4369,14 +4338,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4395,11 +4364,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4415,12 +4384,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4428,19 +4397,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4449,8 +4418,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4462,12 +4431,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4477,52 +4446,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4532,9 +4501,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4562,17 +4531,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4582,30 +4551,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4614,62 +4583,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4679,9 +4648,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4694,17 +4663,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4712,16 +4681,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4733,11 +4702,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4745,11 +4714,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4761,7 +4730,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4773,11 +4742,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4785,19 +4754,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4823,7 +4792,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4835,7 +4804,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4843,7 +4812,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4867,7 +4836,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4883,7 +4852,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4895,7 +4864,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4903,32 +4872,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4936,31 +4901,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4976,7 +4941,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4988,29 +4953,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5018,14 +4979,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5033,41 +4994,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5075,33 +5036,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5109,37 +5070,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5159,11 +5117,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5172,20 +5130,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5203,35 +5161,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5243,7 +5201,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5251,12 +5209,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5264,19 +5222,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5288,7 +5246,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5305,24 +5263,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5339,27 +5297,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5383,7 +5341,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5400,11 +5358,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5421,19 +5379,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5441,11 +5399,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5453,7 +5411,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5465,11 +5423,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5477,19 +5435,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5501,7 +5459,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5513,37 +5471,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5555,7 +5513,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5563,12 +5521,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5583,63 +5537,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5651,13 +5605,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5665,22 +5619,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5692,11 +5646,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5704,61 +5658,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5766,13 +5714,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5797,17 +5745,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5819,11 +5767,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5831,7 +5779,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5843,13 +5791,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5862,7 +5810,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5871,27 +5819,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5899,11 +5847,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5911,181 +5859,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6093,7 +6041,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6104,12 +6052,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6120,7 +6068,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6130,11 +6078,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6142,24 +6090,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6170,25 +6118,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6196,9 +6144,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6210,7 +6158,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6218,11 +6166,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6238,15 +6186,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6264,7 +6212,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6272,36 +6220,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6313,7 +6233,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6359,19 +6279,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6379,19 +6299,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6410,19 +6330,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6434,7 +6343,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6442,7 +6351,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6464,7 +6373,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6476,6 +6385,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/en_ES/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en_ES/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (Spain) (http://www.transifex.com/bikalabs/bika-lims/language/en_ES/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/en_US/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/en_US/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/bikalabs/bika-lims/language/en_US/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -136,7 +136,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -210,17 +204,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -323,11 +317,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -388,7 +378,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -479,7 +469,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -520,52 +510,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -640,46 +630,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -813,25 +803,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1096,17 +1090,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1207,59 +1201,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1268,39 +1262,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1346,8 +1340,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1356,48 +1350,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1785,9 +1779,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2033,7 +2027,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2225,19 +2215,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2276,18 +2266,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2348,8 +2338,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2460,8 +2450,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2486,30 +2476,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2763,12 +2747,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2777,47 +2761,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2853,7 +2837,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2998,16 +2982,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3015,31 +2999,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3063,30 +3041,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4040,11 +4009,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4085,16 +4054,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4168,7 +4137,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4274,26 +4243,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4315,15 +4284,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5670,22 +5624,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Tax ID"
 
@@ -5904,11 +5852,11 @@ msgstr "Tax ID"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6125,7 +6073,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6135,11 +6083,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/eo/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/eo/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Esperanto (http://www.transifex.com/bikalabs/bika-lims/language/eo/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -96,15 +96,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -116,15 +116,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -137,7 +137,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -211,17 +205,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -229,54 +223,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -324,11 +318,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -336,16 +326,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -358,26 +348,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -389,7 +379,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -480,7 +470,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -493,27 +483,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -521,52 +511,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -641,46 +631,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -688,12 +678,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -709,17 +699,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -740,7 +730,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -814,25 +804,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -922,7 +912,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -930,7 +920,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -938,63 +928,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1002,8 +996,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1016,11 +1010,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1032,12 +1026,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1069,18 +1063,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1097,17 +1091,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1208,59 +1202,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1269,39 +1263,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1309,21 +1303,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1347,8 +1341,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1357,48 +1351,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1432,18 +1426,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1451,7 +1445,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1468,12 +1462,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Defaŭlto"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1786,9 +1780,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1815,7 +1809,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1851,16 +1845,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1881,8 +1875,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1891,54 +1885,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2034,7 +2028,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2161,19 +2155,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2226,19 +2216,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2277,18 +2267,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2452,7 +2442,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2461,8 +2451,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2487,30 +2477,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2764,12 +2748,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2778,47 +2762,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3016,31 +3000,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3164,27 +3142,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3225,17 +3203,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3678,7 +3647,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3721,16 +3690,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3814,14 +3783,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4041,11 +4010,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4169,7 +4138,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4259,15 +4228,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4779,11 +4748,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4849,7 +4818,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5447,11 +5405,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,12 +5527,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5671,22 +5625,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5698,11 +5652,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5868,7 +5816,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5877,27 +5825,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5905,11 +5853,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5917,181 +5865,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6126,7 +6074,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6136,11 +6084,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6281,36 +6229,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es/LC_MESSAGES/bika.po
@@ -19,7 +19,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/bikalabs/bika-lims/language/es/)\n"
@@ -37,49 +37,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} puede acceder al LIMS utilizando el nombre de usuario ${contact_username}. Se recomienda que los contactos modifiquen su contraseña. Si el usuario pierde su contraseña, siempre podrá solicitar una nueva en el formulario de acceso."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "Los elementos ${items} están a la espera de conservación"
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "Los elementos ${items} están a la espera de ser recepcionados."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "Se han invalidado ${items} elementos."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} fueron creados satisfactoriamente."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: particiones a la espera de ser recepcionadas."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} a la espera de conservación."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} a la espera de ser recepcionado."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} fue creado satisfactoriamente."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} a la espera de ser recepcionado."
 
@@ -95,7 +95,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Error"
 
@@ -109,15 +109,15 @@ msgstr "% Realizado"
 msgid "% Published"
 msgstr "% Publicado"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s ha sido rechazada"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -129,15 +129,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "La opción 'Classic' indica que se importaran las solicitudes de análisis por muestra y servicio de análisis. Si escoge la opción 'Perfiles', las claves de perfil de análisis se utilizaran para seleccionar múltiples servicios de análisis de forma conjunta."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blanco)"
@@ -150,7 +150,7 @@ msgstr "(Control)"
 msgid "(Duplicate)"
 msgstr "(Duplicado)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Peligroso)"
 
@@ -159,32 +159,26 @@ msgid "(Required)"
 msgstr "(Obligatorio)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Icono de 16x16 píxeles que indica la prioridad del elemento en las listas"
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Icono de 32x32 píxeles que indica la prioridad del elemento en las listas"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -195,16 +189,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Máx"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "Solicitud de análisis ${ar_number}"
 
@@ -216,7 +210,7 @@ msgstr "Ficheros adjuntos en solicitudes de análisis"
 msgid "AR ID Padding"
 msgstr "Tamaño del ID de las solicitudes de análisis"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importación de solicitudes de análisis"
 
@@ -224,17 +218,17 @@ msgstr "Importación de solicitudes de análisis"
 msgid "AR Import options"
 msgstr "Opciones de importación"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr "Nombre de plantilla de solicitud de análisis"
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Plantillas de solicitud de análisis"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Solicitud de análisis para resultados repetidos"
 
@@ -242,54 +236,54 @@ msgstr "Solicitud de análisis para resultados repetidos"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "Solicitudes de análisis: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nombre de la cuenta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo de cuenta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Acreditación"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviación de la Entidad de Acreditación"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL de la Entidad de Acreditación"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logotipo de la acreditación"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referencia de la acreditación"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Acreditado"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -303,21 +297,21 @@ msgstr "Acciones realizadas por los usuarios (o usuario específico) entre un pe
 msgid "Activate"
 msgstr "Activado"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Activos"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Nuevo..."
 
@@ -337,11 +331,7 @@ msgstr "Añadir muestra control"
 msgid "Add Duplicate"
 msgstr "Añadir duplicado"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Añadir comentario"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Añadir plantilla"
 
@@ -349,16 +339,16 @@ msgstr "Añadir plantilla"
 msgid "Add a remarks field to all analyses"
 msgstr "Agregar un campo de observaciones a todos los análisis"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Agregar nuevo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Comentarios adicionales:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Dirección"
@@ -371,26 +361,26 @@ msgstr "Añade los dos dígitos del año tras el prefijo del identificador"
 msgid "Administrative Reports"
 msgstr "Informes administrativos"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Después de ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agencia"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Todos"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Se muestran todos los análisis acreditados."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
 
@@ -402,7 +392,7 @@ msgstr "Todos los análisis del tipo"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Los usuarios con perfil administrativo pueden editar clientes"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir ingreso manual de límite de detección"
 
@@ -410,15 +400,15 @@ msgstr "Permitir ingreso manual de límite de detección"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Los analistas solo pueden acceder a sus hojas de trabajo"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Permitir ingreso manual de incertidumbre"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -426,11 +416,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr "Permitir verificación de resultados por el mismo usuario"
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Permitir al analista reemplazar el valor de incertidumbre predeterminado."
 
@@ -438,48 +428,48 @@ msgstr "Permitir al analista reemplazar el valor de incertidumbre predeterminado
 msgid "Allow users to filter datas by department."
 msgstr "Permitir al usuario filtrar por departamento"
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Cálculo Alternativo"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Expandir siempre las categorías seleccionadas a las vistas de cliente"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr "Condiciones ambientales"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Cantidad"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Análisis"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Análisis en el rango de error"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Análisis fuera de rango"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr "Análisis pendientes"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Análisis por servicio de análisis"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Análisis por tipo de muestra"
@@ -493,7 +483,7 @@ msgstr "Análisis por servicio"
 msgid "Analyses performed and published as % of total"
 msgstr "% o de análisis realizados y publicados con respecto al total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "% o de análisis realizados con respecto al total"
 
@@ -506,27 +496,27 @@ msgstr "Reportes de análisis relacionados"
 msgid "Analyses repeated"
 msgstr "Análisis repetidos"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Resultados de los análisis fuera del rango especificado"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Análisis reprocesados"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Resumen de análisis por departamento"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Análisis que han sido reprocesados"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Análisis"
 
@@ -534,52 +524,52 @@ msgstr "Análisis"
 msgid "Analysis Attachment Option"
 msgstr "Ficheros adjuntos en los anállisis"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorías de análisis"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoría del análisis"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Código de análisis"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Perfil de análisis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Perfiles de solicitud de análisis"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Solicitud de análisis"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Identificador de la solicitud de análisis"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importaciones de solicitudes de análisis"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Prioridad de Solicitudes de Análisis"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Especificaciones de Solicitudes de Análisis"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -587,65 +577,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Solicitudes de análisis"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr "Solicitud de análisis por preservar"
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr "Solicitud de análisis por publicar"
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr "Solicitud de análisis por recibir"
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr "Solicitud de análisis por muestrear"
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr "Solicitud de análisis por verificar"
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Solicitud de análisis con resultados pendientes"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr "Solicitud de análisis con muestreo programado"
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Servicio de análisis"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Servicios de análisis"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Especificaciones de análisis"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificaciones de análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Estado del análisis"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo de análisis"
@@ -654,46 +644,46 @@ msgstr "Tipo de análisis"
 msgid "Analysis category"
 msgstr "Categoría de análisis"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "La solicitud de análisis ${AR} se ha creado satisfactoriamente"
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr "Plantillas de solicitud de análisis por incluir en la Plantilla de Rondas de Muestreo"
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Las solicitudes de análisis ${ARs} se han creado satisfactoriamente"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Solicitudes de análisis y análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Solicitudes de análisis y análisis por cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Solicitudes de análisis no facturadas"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Resultados del análisis que están dentro del rango de error"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Resultados de análisis"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Resultados de análisis para ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Resultados por punto de muestreo y servicio de análisis"
 
@@ -701,12 +691,12 @@ msgstr "Resultados por punto de muestreo y servicio de análisis"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Resultados fuera del rango especificado por el cliente o el laboratorio. Esto puede tardar unos minutos"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Servicio de análisis"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Especificaciones de análisis reiniciadas a los valores por defecto."
 
@@ -722,17 +712,17 @@ msgstr "Tiempo de respuesta del análisis"
 msgid "Analysis turnaround time over time"
 msgstr "Análisis fuera de tiempo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Tiempo de respuesta de los análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Análisis fuera de tiempo"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -741,7 +731,7 @@ msgid "Analyst must be specified."
 msgstr "Debe indicar un analista."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Sin definir"
 
@@ -753,7 +743,7 @@ msgstr "Aplicar cambios"
 msgid "Apply template"
 msgstr "Aplicar plantilla"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Aplicar cambios en todo"
 
@@ -771,15 +761,15 @@ msgstr "Número de lote"
 msgid "Assign"
 msgstr "Asignar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Con análisis asignados"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Asignado a hoja de trabajo"
 
@@ -797,27 +787,27 @@ msgstr "Adjuntar"
 msgid "Attach to"
 msgstr "Adjuntar a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Fichero adjunto"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Claves de adjunto"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opciones de adjuntos"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipo de fichero adjunto"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipos de ficheros adjuntos"
 
@@ -827,25 +817,25 @@ msgstr "Tipos de ficheros adjuntos"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "No se permiten adjunciones"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Adjunciones obligatorias"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipo de fichero adjunto"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Ficheros adjuntos"
 
@@ -857,7 +847,7 @@ msgstr "Autorizado por"
 msgid "Autofill"
 msgstr "Auto-rellenado"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Importación automática"
 
@@ -874,27 +864,27 @@ msgstr "Impresión automática de etiqueta"
 msgid "Available templates"
 msgstr "Plantillas disponibles"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Promedio TAT"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Promedio anticipado"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Promedio de retraso"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Oficina bancaria"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nombre del banco"
 
@@ -903,31 +893,31 @@ msgid "Basis"
 msgstr "Base"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lote"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID Lote"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etiquetas del Lote"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lotes"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Retraso"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Antes de ${start_date}"
 
@@ -935,7 +925,7 @@ msgstr "Antes de ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Icono grande"
 
@@ -943,7 +933,7 @@ msgstr "Icono grande"
 msgid "Bika LIMS"
 msgstr "Bika LIMS"
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuración de Bika LIMS"
 
@@ -951,63 +941,67 @@ msgstr "Configuración de Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blanco"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Análisis de muestras blanco de QC"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Descuento por volumen aplicable"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Precio con descuento por volumen (sin IVA)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Teléfono del negocio"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Por"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "Contactos con CC"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Correos"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calcular precisión de acuerdo a incertidumbre"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Cálculo"
 
@@ -1015,8 +1009,8 @@ msgstr "Cálculo"
 msgid "Calculation Formula"
 msgstr "Fórmula de cálculo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de cálculo provisionales"
@@ -1029,11 +1023,11 @@ msgstr "Cálculo: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Cálculo: ninguno"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Cálculos"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibración"
 
@@ -1045,12 +1039,12 @@ msgstr "Certificados de calibración"
 msgid "Calibration report date"
 msgstr "Fecha del reporte de calibración"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1064,9 +1058,9 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -1082,18 +1076,18 @@ msgstr "No ha sido posible desactivar el cálculo porque hay servicios de análi
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "No se permite verificar al mismo usuario que ha introducido los resultados"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacidad"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturado"
 
@@ -1102,7 +1096,7 @@ msgid "Cardinal"
 msgstr "Cardinal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
@@ -1110,17 +1104,17 @@ msgstr "Número de catálogo"
 msgid "Categorise analysis services"
 msgstr "Categorizar los servicios de análisis"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoría"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "La Categoría no se puede desactivar porque tiene servicios de análisis asociados"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Núm. Cert."
 
@@ -1133,31 +1127,31 @@ msgstr "Código de certificado"
 msgid "Changes saved."
 msgstr "Cambios guardados."
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Marcar si el método es acreditado"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Marque esta casilla si el servicio de análisis está en proceso de acreditación"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Marque esta casilla si las muestras recogidas en este punto de muestreo deben ser consideradas en conjunto (composición). Por ejemplo, las muestras recogidas en puntos de muestreo distintos de la orilla de un lago suelen mezclarse para que sean una muestra representativa de la totalidad del lago."
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Marque la casilla de verificación si el recipiente ya incluye un método que garantize la conservación de la muestra. En ese caso, el sistema omitirá el circuito de conservación para todas aquellas muestras en las que se utilice este recipiente."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Marcar esta casilla si ésta debe ser la prioridad por defecto"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Marque la casilla si el laboratorio está acreditado"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "El servicio de análisis requiere de un recipiente distinto para la muestra"
 
@@ -1165,7 +1159,7 @@ msgstr "El servicio de análisis requiere de un recipiente distinto para la mues
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Marcar para utilizar un ID server distinto. Puede configurar los prefijos individualmente para cada sitio Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Escoja los valores de la especificación por defecto para la solicitud de análisis"
 
@@ -1181,19 +1175,19 @@ msgstr ""
 msgid "City"
 msgstr "Ciudad"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clásico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Haga clic sobre las cabeceras de categorías de análisis (con fondo gris) para ver los servicios de análisis que contienen cada una de ellas. Introducid los valores mínimo y máximo para indicar el rango válido de los resultados. Si el resultado se encuentra fuera de este rango, el sistema lanzará una alerta. El campo % Error le permite indicar el porcentaje de incertidumbre que tiene que tener en cuenta el sistema en la evaluación de los resultados con el rango indicado. Si un resultado fuera de rango pasa a ser válido cuando el sistema tiene en cuenta el porcentaje de incertidumbre, el sistema lo notificará con una alerta menos severa."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1201,19 +1195,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "Clic para descargar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID Lote de Cliente"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID del cliente"
 
@@ -1221,59 +1215,59 @@ msgstr "ID del cliente"
 msgid "Client Landing Page"
 msgstr "Página de inicio del cliente"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nombre del cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Pedido de cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Número de pedido de cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. del cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referencia del cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "ID de muestra del cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Identificador de la muestra asignado por el cliente"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr "Rondas de muestreo del cliente"
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr "Contacto del momento de realizar la toma de muestra"
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Para tramitar una solicitud de análisis, el cliente debe tener dado de alta como mínimo un contacto."
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr "Contacto que coordina con el Laboratorio"
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clientes"
 
@@ -1282,39 +1276,39 @@ msgstr "Clientes"
 msgid "Close"
 msgstr "Cerrar"
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Cerrados"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Código de la ubicación"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Código del sitio"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Código del estante"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Coma (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentarios"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Comentarios o interpretación de resultados"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1322,21 +1316,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Compuesta"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr "Compuesta Si/No"
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "% Nivel de confidencia"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configuración de las particiones de muestras y métodos de conservación asignados a la plantilla. Puede asignar análisis a distintas particiones des de la pestaña de plantilla de análisis."
 
@@ -1345,13 +1339,13 @@ msgid "Confirm password"
 msgstr "Confirme la contraseña"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contacto"
@@ -1360,8 +1354,8 @@ msgstr "Contacto"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contactos"
@@ -1370,48 +1364,48 @@ msgstr "Contactos"
 msgid "Contacts to CC"
 msgstr "Contactos a CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Recipiente"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr "Nombre del recipiente"
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipo de recipiente"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipos de recipiente"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr "Volumen del recipiente"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Recipientes de muestras"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo de contenido"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Control"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Análisis de muestras control de QC"
 
@@ -1427,12 +1421,12 @@ msgstr "Copiar servicio de análisis"
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Copiar a nuevo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Recuento"
 
@@ -1445,18 +1439,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr "Crear un nuevo usuario"
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Crear una nueva muestra de este tipo"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creado"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creado por:"
 
@@ -1464,7 +1458,7 @@ msgstr "Creado por:"
 msgid "Created by:"
 msgstr "Creado por:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1472,8 +1466,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Creado por"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criterios"
 
@@ -1481,12 +1475,12 @@ msgstr "Criterios"
 msgid "Currency"
 msgstr "Moneda"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "En curso"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Separador decimal personalizado"
 
@@ -1499,7 +1493,7 @@ msgstr "Límite de Detección"
 msgid "Daily"
 msgstr "Diario"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1513,88 +1507,88 @@ msgstr "Interfaz de datos"
 msgid "Data Interface Options"
 msgstr "Opciones de interfaz de datos"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Libro de entrada diaria de datos"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Fecha"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Fecha de Creación"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Fecha de envío"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Fecha de exclusión"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Fecha de caducidad"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Fecha de importación"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Fecha de carga"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Fecha de apertura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Fecha de conservación"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Fecha de publicación"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Fecha de petición"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Fecha de muestreo"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr "Fecha de validación"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr "Fecha de verificación"
 
@@ -1610,7 +1604,7 @@ msgstr "Certificado de calibración válido desde"
 msgid "Date from which the instrument is under calibration"
 msgstr "Fecha hasta donde el instrumento está calibrado"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Fecha hasta donde el instrumento está bajo mantenimiento"
 
@@ -1628,7 +1622,7 @@ msgid "Date until the certificate is valid"
 msgstr "Certificado de calibración válido hasta"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Fecha hasta donde el instrumento no estará disponible"
@@ -1637,11 +1631,11 @@ msgstr "Fecha hasta donde el instrumento no estará disponible"
 msgid "Date when the calibration certificate was granted"
 msgstr "Fecha del certificado de calibración"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Días"
 
@@ -1653,17 +1647,17 @@ msgstr "Desactivado hasta la próxima calibración"
 msgid "Deactivate"
 msgstr "Desactivar"
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Separador decimal a utilizar en los informes de este Cliente."
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Por defecto"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Especificación por defecto de la solicitud de análisis"
 
@@ -1671,49 +1665,49 @@ msgstr "Especificación por defecto de la solicitud de análisis"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Cálculo por defecto"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Recipiente por defecto"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tipo de recipiente por defecto"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Instrumento predeterminado"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Método predeterminado"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Método de conservación por defecto"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Prioridad por defecto"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "El cálculo por defecto se obtiene del método seleccionado por defecto. Puede assignar un cálculo a un método en la vista de edición del método."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categorías por defecto"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Recipiente por defecto para nuevas particiones de muestra"
 
@@ -1722,11 +1716,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Recipientes por defecto: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Separador decimal predeterminado"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr "Instrumento predeterminado %s no es válido"
 
@@ -1750,11 +1744,11 @@ msgstr "Formato de notación científica para los informes por defecto"
 msgid "Default scientific notation format for results"
 msgstr "Formato de notación científica para los resultados por defecto"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valor por defecto"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "Especificaciones por defecto en nuevas Solicitudes de Análisis, para la visualización de notificaciones y alertas durante la introducción de resultados, así como también en el informe de resultados asociado."
 
@@ -1762,7 +1756,7 @@ msgstr "Especificaciones por defecto en nuevas Solicitudes de Análisis, para la
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1770,11 +1764,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1782,16 +1776,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Grados"
 
@@ -1799,9 +1793,9 @@ msgstr "Grados"
 msgid "Delete attachment"
 msgstr "Eliminar el fichero adjunto"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Departamento"
 
@@ -1814,13 +1808,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Descripción del método en lenguaje llano. Esta información estará disponible para los clientes del laboratorio."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descripción"
 
@@ -1828,7 +1822,7 @@ msgstr "Descripción"
 msgid "Description of the actions made during the calibration"
 msgstr "Descripción de las acciones realizadas durante el calibramiento"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Descripción de las acciones realizadas durante el proceso de mantenimiento"
 
@@ -1836,19 +1830,19 @@ msgstr "Descripción de las acciones realizadas durante el proceso de mantenimie
 msgid "Description of the actions made during the validation"
 msgstr "Descripción de las acciones realizadas durante la validación"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Descripción de la ubicación"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Descripción del estante"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Descripción del sitio"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1856,7 +1850,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Descuento %"
 
@@ -1864,16 +1858,16 @@ msgstr "Descuento %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Valor a mostrar"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1885,7 +1879,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr "Mostrar particiones de muestras de forma individualizada"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Fecha de eliminación"
 
@@ -1894,8 +1888,8 @@ msgstr "Fecha de eliminación"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminados"
@@ -1904,54 +1898,54 @@ msgstr "Eliminados"
 msgid "District"
 msgstr "Región"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "División por cero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Documento"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inactivos"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Punto (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Abajo desde"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Abajo hacia"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Descargar"
 
@@ -1964,20 +1958,20 @@ msgstr "Secar"
 msgid "Dry matter analysis"
 msgstr "Análisis de materia seca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Pendientes"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Var. Dup."
 
@@ -1986,20 +1980,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicado de"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Análisis de muestras duplicadas de QC"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Variación del duplicado %"
 
@@ -2011,35 +2005,35 @@ msgstr "QC de análisis de duplicados"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Gráficos de control de calidad para análisis duplicados"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Duración"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "P.ej., ENAC, Applus, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Anticipado"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Reciente"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Elevación"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
@@ -2047,7 +2041,7 @@ msgstr "Dirección de correo electrónico"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Asunto del correo electrónico"
 
@@ -2067,14 +2061,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Fecha fin"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Mejoramiento"
 
@@ -2086,16 +2080,16 @@ msgstr "Introduzca un nombre de usuario, que normalmente es similar a 'jgarcia'.
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Introduzca su dirección de correo electrónico. Es necesaria en caso de perder la clave de acceso. Respetamos su privacidad y su cuenta de correo electrónico nunca será revelada ni facilitada a terceros."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Introducir el porcentaje de descuento"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Introducir un porcentaje, p.ej. 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2103,15 +2097,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje se aplicará a todo el sistema, pero podrá ser sobreescrito individualmente para cada elemento."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Introducir un porcentaje, p.ej. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Introducir la latitud del punto de muestreo en grados (de 0 a 90) , minutos (de 0 a 59) y la orientación N/S"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Introducir la longitud del punto de muestreo en grados (de 0 a 90), minutos (0 a 59), segundos (0 a 59) y orientación E/W"
 
@@ -2119,7 +2113,7 @@ msgstr "Introducir la longitud del punto de muestreo en grados (de 0 a 90), minu
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Introducir los detalles de cada uno de los servicios de análisis a copiar."
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2127,45 +2121,45 @@ msgstr ""
 msgid "Entity"
 msgstr "Entidad"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Publicación de resultados errónea de ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Excluir de la factura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Resultado esperado"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Resultados esperados"
 
@@ -2174,19 +2168,19 @@ msgstr "Resultados esperados"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Caducados"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Fecha de caducidad"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2194,44 +2188,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (trabajo)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Mujer"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Campo"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Análisis de campo"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Conservación fuera del laboratorio"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Título del campo"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Fichero"
 
@@ -2239,19 +2229,19 @@ msgstr "Fichero"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Incluir los documentos adjuntos a resultados (como fotografías de microscopía) en los mensajes de correo electrónico"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nombre del fichero"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2271,16 +2261,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Primer nombre"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Fórmula"
 
@@ -2290,18 +2280,18 @@ msgstr "Fórmula"
 msgid "From"
 msgstr "Desde"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Desde ${start_date} hasta ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Muestra con fecha de asignación futura"
 
@@ -2311,7 +2301,7 @@ msgstr "Muestra con fecha de asignación futura"
 msgid "Generate report"
 msgstr "Generar reporte"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de cortesía, como p.ej. Sr., Sra. o Dr."
 
@@ -2323,37 +2313,37 @@ msgstr "Agrupar los servicios de análisis por categorías. Esto es útil cuando
 msgid "Group by"
 msgstr "Agrupar por"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Período de agrupamiento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Peligroso"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Oculto"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Campo Oculto"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Horas"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2362,8 +2352,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "URL del servidor de IDs"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "Servidor de IDs no disponible"
 
@@ -2371,31 +2361,31 @@ msgstr "Servidor de IDs no disponible"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Si la casilla 'Permitir entrada de resultados desde instrumento' está marcada, se utilizará por defecto el método del instrumento seleccionado. En caso contrario, solo se mostrarán los métodos seleccionados manualmente."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2407,7 +2397,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2415,27 +2405,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "En caso que el campo 'Título' esté vacío, el sistema utilizará el ID de Lote. "
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Selección de cálculo para los servicios de análisis vinculados a este método. Puede configurar los cálculos en el área de configuración del LIMS"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Seleccionar el cálculo asociado al análisis si es necesario. Los cálculos pueden ser configurados en el apartado 'Cálculos'"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Campo opcional. Texto que reemplazará al título del servicio de análisis en las cabeceras de las columnas de las listas. Permite formato HTML."
 
@@ -2443,7 +2433,7 @@ msgstr "Campo opcional. Texto que reemplazará al título del servicio de análi
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "Los resultados que hayan sido introducidos previamente para algun servicio de análisis del mismo lote también se mostrarán en el informe."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Método de conservación del recipiente."
 
@@ -2456,7 +2446,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importación"
@@ -2465,7 +2455,7 @@ msgstr "Importación"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importados"
@@ -2474,8 +2464,8 @@ msgstr "Importados"
 msgid "In-lab calibration procedure"
 msgstr "Procedimiento de calibración en el laboratorio"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Inactivo"
@@ -2484,7 +2474,7 @@ msgstr "Inactivo"
 msgid "Include Previous Results From Batch"
 msgstr "Incluir resultados anteriores del lote"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Incluir todas las solicitudes de análisis que pertenecen al objeto seleccionado."
 
@@ -2492,7 +2482,7 @@ msgstr "Incluir todas las solicitudes de análisis que pertenecen al objeto sele
 msgid "Include and display pricing information"
 msgstr "Incluir y mostrar información de precios"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Incluir descripciones"
 
@@ -2500,30 +2490,27 @@ msgstr "Incluir descripciones"
 msgid "Include year in ID prefix"
 msgstr "Incluir el año en el prefijo ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Resultado indeterminado"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indica si es necesaria la adjunción de ficheros para este análisis y, por lo tanto, si la opción de carga de fichero estará disponible en las pantallas de captura de datos."
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Heredar de"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisión inicial"
 
@@ -2547,7 +2534,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instrucciones"
@@ -2560,17 +2547,17 @@ msgstr "Instrucciones para rutinas de calibramiento de laboratorio  destinados a
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instrucciones para rutinas preventivas y mantenimiento destinados a los analistas"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Equipo"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Calibramiento de Instrumentos"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2583,16 +2570,16 @@ msgstr "Importación desde equipo"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Mantenimiento de Instrumentos"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Tareas Programadas de Instrumentos"
 
@@ -2600,19 +2587,19 @@ msgstr "Tareas Programadas de Instrumentos"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Tipo de Instrumento"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validaciones de Instrumento"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2656,9 +2643,9 @@ msgstr "Tipo de equipo"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Equipos"
 
@@ -2682,7 +2669,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Tests internos de calibrado"
 
@@ -2698,24 +2685,21 @@ msgstr "Interpolación"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Inválido"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "Solicitud de análisis invalidada y repetida"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2723,43 +2707,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Factura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Fecha de factura"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Excluido de facturación"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Número de factura"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "No se ha especificado fecha de fin para el lote de facturación"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "No se ha especificado fecha de inicio para el lote de facturación"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "Lote de facturación sin título"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "El elemento está inactivo."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Elementos que deben incluirse en el asunto del correo electrónico"
 
@@ -2769,7 +2753,7 @@ msgstr "Elementos que deben incluirse en el asunto del correo electrónico"
 msgid "Job Title"
 msgstr "Cargo"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Cargo"
 
@@ -2777,12 +2761,12 @@ msgstr "Cargo"
 msgid "Key"
 msgstr "Clave"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Error de clave"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Palabra clave"
@@ -2791,47 +2775,47 @@ msgstr "Palabra clave"
 msgid "Keywords"
 msgstr "Palabras clave"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratorio"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Análisis del laboratorio"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contactos del laboratorio"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Departamentos del laboratorio"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Conservación en el laboratorio"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Productos del laboratorio"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL del laboratorio"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etiqueta"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorio"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorio acreditado"
 
@@ -2851,13 +2835,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Última modificación"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Con retraso"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Análisis con retraso"
@@ -2867,7 +2851,7 @@ msgstr "Análisis con retraso"
 msgid "Late Analysis"
 msgstr "Análisis con retraso"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitud"
 
@@ -2889,11 +2873,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Muestra vinculada"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2905,7 +2889,7 @@ msgstr "Listar todas las muestras recibidas para un rango de fecha"
 msgid "Load Setup Data"
 msgstr "Carga de datos iniciales"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Aquí puede cargar los documentos que describen el método"
 
@@ -2917,41 +2901,41 @@ msgstr "Cargar desde archivo"
 msgid "Load the certificate document here"
 msgstr "Documento de la certificación"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Cargado"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Código de la ubicación"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Descripción de la Ubicación"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Nombre de Ubicación"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Tipo de Ubicación"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Ubicación donde se almacena la muestra"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Lugar donde la muestra fue tomada"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Registro"
@@ -2976,35 +2960,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitud"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Número de lote"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Dirección de correo electrónico"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Mantenedor"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Tipo de mantenimiento"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Hombre"
 
@@ -3012,16 +2996,16 @@ msgstr "Hombre"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Correo del responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Teléfono del responsable"
 
@@ -3029,31 +3013,25 @@ msgstr "Teléfono del responsable"
 msgid "Manual"
 msgstr "Manual"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Ingreso Manual"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Entrada manual de resultados"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabricante"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Fabricantes"
 
@@ -3062,14 +3040,14 @@ msgstr "Fabricantes"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Tiempo máximo"
 
@@ -3077,30 +3055,30 @@ msgstr "Tiempo máximo"
 msgid "Maximum columns per results email"
 msgstr "Número máximo de columnas en los resultados por correo electrónico"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Tamaño o volumen máximo admitidos por muestra"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Tiempo máximo permitido para la consecución de un análisis. El sistema mostrará una alerta para los análisis con retraso"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Tiempo máximo de respuesta"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "% de descuento para clientes habituales"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Aplicar descuento de cliente habitual"
 
@@ -3109,22 +3087,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Método"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Documento del método"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instrucciones del método"
 
@@ -3136,9 +3114,9 @@ msgstr "Método: ${method_name}"
 msgid "Method: None"
 msgstr "Método: ninguno"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Métodos"
 
@@ -3146,17 +3124,17 @@ msgstr "Métodos"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Métodos incluidos en el alcance de acreditación ante ${accreditation_body}. Los comentarios y observaciones no están acreditados."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Inicial de Segundo Nombre"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Segundo nombre"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3168,8 +3146,8 @@ msgstr "Mis elementos"
 msgid "Minimum 5 characters."
 msgstr "Tamaño mínimo de 5 caracteres"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volumen mínimo"
 
@@ -3177,27 +3155,27 @@ msgstr "Volumen mínimo"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para los cálculos estadísticos de QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutos"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Teléfono móvil"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modelo"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Fecha de modificación"
 
@@ -3211,7 +3189,7 @@ msgstr ""
 msgid "More"
 msgstr "Más"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3223,13 +3201,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nombre"
 
@@ -3238,17 +3216,17 @@ msgstr "Nombre"
 msgid "New"
 msgstr "Nuevo"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "No"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "No hay Solicitud de Análisis que coincida con su busqueda"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3264,18 +3242,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "No se han encontrado acciones por el usuario ${user}"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Ningún análisis seleccionado"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "No se han encontrado análisis que coincidan con el criterio de búsqueda"
 
@@ -3287,23 +3265,23 @@ msgstr "No se han añadido análisis"
 msgid "No analyses were added to this worksheet."
 msgstr "No se han añadido análisis en esta hoja de trabajo"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Ningún análisis seleccionado"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "No hay servicio de análisis seleccionado"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "No ha seleccionado ningún servicio de análisis."
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Sin cambios."
 
@@ -3311,7 +3289,7 @@ msgstr "Sin cambios."
 msgid "No control type specified"
 msgstr "No se ha indicado el tipo de control"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3323,17 +3301,17 @@ msgstr "No se han indicado recipientes por defecto para este servicio"
 msgid "No default preservations specified for this service"
 msgstr "No se han indicado conservaciones para este servicio "
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "No ha seleccionado ningún fichero"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "No hay acción historica que coincida con su busqueda"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "No se ha seleccionado ningún elemento"
 
@@ -3341,7 +3319,7 @@ msgstr "No se ha seleccionado ningún elemento"
 msgid "No items selected"
 msgstr "No ha seleccionado ningún elemento"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "No se han creado ítems nuevos."
 
@@ -3351,16 +3329,16 @@ msgstr "No se han creado ítems nuevos."
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "No ha seleccionado ninguna muestra de referencia"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "No se ha especificado ningún informe en la solicitud"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "No existen muestras que coincidan con su busqueda"
 
@@ -3378,25 +3356,22 @@ msgstr "No hay datos de acceso registrados para el contacto ${contact_fullname},
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Ninguno"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "No permitido"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "No disponible"
 
@@ -3416,19 +3391,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Número de análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Número de solicitudes de análisis y análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Número de solicitudes de análisis y análisis por cliente"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr "Cantidad de recipientes"
 
@@ -3436,30 +3411,30 @@ msgstr "Cantidad de recipientes"
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr "Cantidad de puntos de muestreo"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Número de análisis"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Número de análisis fuera de rango por periodo"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Número de análisis solicitados por servicio de análisis"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Número de análisis solicitados por tipo de muestra"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Número de análisis reprocesados por periodo"
 
@@ -3467,15 +3442,15 @@ msgstr "Número de análisis reprocesados por periodo"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Número de análisis solicitados y publicados por departamento y expresados como porcentaje en relación a todos los análisis realizados"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr "Cantidad de recipientes"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Número de solicitudes"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3484,31 +3459,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Número de muestras"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr "Cantidad de puntos de muestreo"
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Valor numérico que indica el orden de los elementos a priorizar"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "Identificación del Objeto"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "La muestra será descartada durante el periodo de tiempo indicado cuando se le asigne el estado de conservación. Si no se indica nada, se utilizará el periodo de retención por tipo de muestra."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3516,15 +3491,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Solo los responsables de laboratorio pueden gestionar las hojas de trabajo"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Solo campos sin valor o con valor cero"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Abierto"
@@ -3537,26 +3509,26 @@ msgstr ""
 msgid "Order"
 msgstr "Pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Fecha de pedido"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID de pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Número de pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Pedidos"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Pedidos: ${orders}"
 
@@ -3564,7 +3536,7 @@ msgstr "Pedidos: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Organización que emite el certificado de calibración"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3576,8 +3548,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Otros reportes de productividad"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Caducado"
 
@@ -3589,16 +3561,13 @@ msgstr "Formato de salida"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Partición"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3619,8 +3588,8 @@ msgstr "Contraseña"
 msgid "Password lifetime"
 msgstr "Tiempo de vida de las contraseñas"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pendiente"
@@ -3645,31 +3614,31 @@ msgstr "Realizado por"
 msgid "Period"
 msgstr "Periodo"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Permitido"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "% de error permitido"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Teléfono"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Teléfono (negocio)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Teléfono (casa)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Teléfono (móvil)"
 
@@ -3682,8 +3651,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Dirección postal"
 
@@ -3691,7 +3660,7 @@ msgstr "Dirección postal"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Des de aquí puede restringir los resultados del análisis a opciones específicas. Por ejemplo, si solo desea que se puedan escoger como resultado alguna de las opciones 'Positivo', 'Negativo' o 'Indeterminado'. El valor de la opción tiene que ser numérico."
 
@@ -3699,19 +3668,19 @@ msgstr "Des de aquí puede restringir los resultados del análisis a opciones es
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Por favor, añada el logotipo autorizado para emplear en su sitio web y en los informes de resultados de su entorno acreditativo. El tamaño máximo es de 175 x 175 píxeles."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Punto de muestreo"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3720,13 +3689,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posición"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Dirección postal"
 
@@ -3734,16 +3703,16 @@ msgstr "Dirección postal"
 msgid "Postal code"
 msgstr "Código postal"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Pre-conservación"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Precisión en el número de decimales"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3771,7 +3740,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefijo"
 
@@ -3779,12 +3748,12 @@ msgstr "Prefijo"
 msgid "Prefixes"
 msgstr "Prefijos"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Suplemento"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3796,17 +3765,17 @@ msgstr "Preparado por"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Conservación"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Categoría de método de conservación"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3817,7 +3786,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Conservaciones"
 
@@ -3827,14 +3796,14 @@ msgstr "Conservaciones"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Conservador"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Preventivo"
 
@@ -3842,34 +3811,34 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedimiento de mantenimiento preventivo"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Importe"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Importe (sin IVA)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Porcentaje del suplemento"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Importe sin IVA"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Lista de precios"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Listas de precios"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3884,13 +3853,13 @@ msgstr "Imprimir"
 msgid "Print date:"
 msgstr "Fecha de impresión:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Prioridad"
 
@@ -3907,34 +3876,34 @@ msgstr "Informes de productividad"
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Perfil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Perfiles de análisis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Identificador del perfil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Clave identificativa del perfil"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (pendiente de facturar)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3942,7 +3911,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr "Público. Retraso"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Especificación de publicación"
 
@@ -3957,21 +3926,21 @@ msgstr "Preferencias de publicación"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publicado"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Solicitudes de análisis publicadas que están pendientes de facturar"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Publicado por"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Resultados publicados"
 
@@ -3984,8 +3953,8 @@ msgid "QC Analyses"
 msgstr "Análisis de QC"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "ID Muestra QC"
 
@@ -4006,23 +3975,23 @@ msgstr "Cantidad"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Comentario de rango"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Comentario de rango"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Umbral máximo"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Umbral mínimo"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Especificaciones de rango"
 
@@ -4044,9 +4013,9 @@ msgstr "Recibir"
 msgid "Receive sample"
 msgstr "Recibir muestra"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Recibida"
 
@@ -4054,11 +4023,11 @@ msgstr "Recibida"
 msgid "Recept. Lag"
 msgstr "Retraso Recepción."
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Destinatarios"
 
@@ -4067,31 +4036,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referencia"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Análisis de Referencia"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Definición de referencia"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Definiciones de referencia"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Muestra de referencia"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Muestras de referencia"
 
@@ -4099,16 +4068,16 @@ msgstr "Muestras de referencia"
 msgid "Reference Supplier"
 msgstr "Proveedor de muestras de referencia"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Tipo de referencia"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valores de referencia"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Análisis de control de calidad QC estándar"
@@ -4117,7 +4086,7 @@ msgstr "Análisis de control de calidad QC estándar"
 msgid "Reference analysis quality control graphs"
 msgstr "Gráficos de análisis de control de calidad estándar"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Gráficos de control de calidad en análisis de referencia"
 
@@ -4125,21 +4094,21 @@ msgstr "Gráficos de control de calidad en análisis de referencia"
 msgid "Reference sample"
 msgstr "Muestra de referencia"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "QCAnalysisID"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition representa una definición de referencia o un tipo de muestra que se utiliza para las pruebas de control de calidad"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Refs: ${references}"
 
@@ -4162,8 +4131,8 @@ msgstr ""
 msgid "Reject"
 msgstr "Rechazar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr "Rechazado"
@@ -4172,9 +4141,9 @@ msgstr "Rechazado"
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Porcentaje de diferencia relativa, ${variation_here} %, fuera de rango (${variation} %)"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Comentarios"
 
@@ -4182,7 +4151,7 @@ msgstr "Comentarios"
 msgid "Remarks to take into account before calibration"
 msgstr "Observaciones a tener en cuenta antes de la calibración"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Observaciones a tener en cuenta antes de ejecutar la tarea"
 
@@ -4190,7 +4159,7 @@ msgstr "Observaciones a tener en cuenta antes de ejecutar la tarea"
 msgid "Remarks to take into account before validation"
 msgstr "Observaciones a tener en cuenta antes de la validación"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Observaciones a tener en cuenta para proceso de mantenimiento"
 
@@ -4199,8 +4168,8 @@ msgstr "Observaciones a tener en cuenta para proceso de mantenimiento"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Reparar"
 
@@ -4209,7 +4178,7 @@ msgid "Repeated analyses"
 msgstr "Análisis repetidos"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Informes"
 
@@ -4223,14 +4192,14 @@ msgstr "Fecha del informe"
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Tipo de informe"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Interpretar como materia seca"
 
@@ -4255,7 +4224,7 @@ msgstr "Reportar tablas para un período de tiempo del número de muestras recib
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Reportar tablas de Solicitudes de Análisis y totales entregados entre un período de tiempo"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Tipo de informe"
 
@@ -4263,7 +4232,7 @@ msgstr "Tipo de informe"
 msgid "Report upload"
 msgstr "Cargar informe"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Informes"
 
@@ -4272,15 +4241,15 @@ msgstr "Informes"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Solicitud"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID de la solicitud"
 
@@ -4288,26 +4257,26 @@ msgstr "ID de la solicitud"
 msgid "Request new analyses"
 msgstr "Solicitar nuevos análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Solicitados"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Solicitudes"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Campo obligatorio"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volumen necesario"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4315,13 +4284,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Restringir las categorías"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultado"
 
@@ -4329,15 +4298,15 @@ msgstr "Resultado"
 msgid "Result Footer"
 msgstr "Pie de página"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opciones para resultados"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valor de los resultados"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4355,11 +4324,11 @@ msgstr "El resultado está fuera de rango"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Interpretación de resultados"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Interpretación de resultados"
 
@@ -4367,7 +4336,7 @@ msgstr "Interpretación de resultados"
 msgid "Results attachments permitted"
 msgstr "Se permite la adjunción de documentos a resultados"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Los resultados han sido descartados"
 
@@ -4375,11 +4344,11 @@ msgstr "Los resultados han sido descartados"
 msgid "Results interpretation"
 msgstr "Interpretación de resultados"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Resultados por punto de muestreo"
@@ -4388,14 +4357,14 @@ msgstr "Resultados por punto de muestreo"
 msgid "Results per samplepoint and analysis service"
 msgstr "Resultados por punto de muestreo y servicio de análisis"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Período de retención"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Prueba repetida"
@@ -4414,11 +4383,11 @@ msgstr "Retractado"
 msgid "Retracted analyses"
 msgstr "Análisis rechazados"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "El informe de análisis rechazados no está disponible"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Rechazos"
 
@@ -4434,12 +4403,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Tratamiento"
 
@@ -4447,19 +4416,19 @@ msgstr "Tratamiento"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Como en el caso anterior, pero para servicios de análisis. Este parámetro se puede establecer individualmente para cada análisis en su propia configuración."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Muestra"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Condiciones de muestra"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Condiciones de muestra"
 
@@ -4468,8 +4437,8 @@ msgid "Sample Due"
 msgstr "Muestra pendiente"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID de muestra"
 
@@ -4481,12 +4450,12 @@ msgstr "Tamaño del ID de la muestra"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Soportes de las muestras"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Soporte de la muestra"
 
@@ -4496,52 +4465,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Particiones de muestras"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Punto de muestreo"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Puntos de muestreo"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Tipo de muestra"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefijo del tipo de muestra"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Especificaciones por tipos de muestra (cliente)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Especificaciones por tipo de muestra (laboratorio)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Tipos de muestras"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Condiciones de la muestra"
 
@@ -4551,9 +4520,9 @@ msgstr "Condiciones de la muestra"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Punto de muestreo"
 
@@ -4581,17 +4550,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Reportes de muestras relacionadas"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Tipo de muestra"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Tipo de muestra"
 
@@ -4601,30 +4570,30 @@ msgstr "Tipo de muestra"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Muestreado por"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Muestras"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Las muestras de este tipo deben ser tratadas como peligrosas"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Muestras recibidas vs. reportadas"
@@ -4633,62 +4602,62 @@ msgstr "Muestras recibidas vs. reportadas"
 msgid "Samples received vs. samples reported"
 msgstr "Muestras recibidas vs. muestras reportadas"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Muestras: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Fecha prevista de muestreo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Desviación en el muestreo"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Desviaciones en el muestreo"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Frecuencia de muestreo"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr "Punto de muestreo"
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr "Ronda de muestreo"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr "Plantilla de ronda de muestreo"
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr "Plantillas de rondas de muestreo"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr "Rondas de muestreo"
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr "Plantilla de rondas de muestreo"
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr "Fecha de muestreo"
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4698,9 +4667,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Guardar"
 
@@ -4713,17 +4682,17 @@ msgstr "Guardar comentarios"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Tarea programada"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Nombre científico"
 
@@ -4731,16 +4700,16 @@ msgstr "Nombre científico"
 msgid "Search"
 msgstr "Buscar"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Segundos"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr "Sello de seguridad íntegro"
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr "Sello de seguridad íntegro Sí/No"
 
@@ -4752,11 +4721,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr "Seleccione Plantillas de Solicitud de Análisis para incluirlas"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Seleccione una interfaz de datos"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Seleccione un método de conservación para el servicio de análisis. Si el método de preservación depende de la combinación de tipos de muestra, especifique un método de preservación por tipo de muestra de la tabla siguiente."
 
@@ -4764,11 +4733,11 @@ msgstr "Seleccione un método de conservación para el servicio de análisis. Si
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Seleccione el destino y la solicitud de análisis a ser duplicada."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Seleccione alguno de los responsables que están registrados en el apartado 'Contactos del laboratorio'. El sistema incluye los nombres de los responsables de departamento a todos los informes de análisis que le pertenecen."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Seleccione una muestra para crear una solicitud de análisis derivada"
 
@@ -4780,7 +4749,7 @@ msgstr "Seleccionar todos los elementos"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Seleccionar los análisis a ser incluidos en la plantilla"
 
@@ -4792,11 +4761,11 @@ msgstr "Seleccionar el analista"
 msgid "Select existing file"
 msgstr "Seleccione un archivo existente"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Indique si los análisis no deben facturarse"
 
@@ -4804,19 +4773,19 @@ msgstr "Indique si los análisis no deben facturarse"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Certificado interno de calibración"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Utilizar el cálculo asociado por defecto al método seleccionado. Desmarque la casilla si desea seleccionar el cálculo manualmente"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Indique si es necesario incluir las descripciones"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4842,7 +4811,7 @@ msgstr "País a mostrar por defecto"
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccione la moneda que se debe utilizar al mostrar los importes."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Seleccionar el recipiente por defecto que debe ser utilizado para este servicio de análisis. Si el recipiente depende de la combinación del tipo de muestra y del método de conservación, deberá especificar el recipiente específico para cada tipo de de muestra."
 
@@ -4854,7 +4823,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Seleccione el equipo deseado"
 
@@ -4862,7 +4831,7 @@ msgstr "Seleccione el equipo deseado"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4886,7 +4855,7 @@ msgstr "Seleccione esta casilla para activar el flujo de trabajo de los pasos pa
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Seleccione qué análisis desea incluir a la hoja de trabajo"
 
@@ -4902,7 +4871,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4914,7 +4883,7 @@ msgstr "Enviar un correo electrónico"
 msgid "Separate"
 msgstr "Separar"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Recipiente por separado"
 
@@ -4922,32 +4891,28 @@ msgstr "Recipiente por separado"
 msgid "Serial No"
 msgstr "Nº de serie"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Servicio"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "El servicio está acreditado por ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Servicios"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Asignar la tarea de mantenimiento como cerrada"
 
@@ -4955,31 +4920,31 @@ msgstr "Asignar la tarea de mantenimiento como cerrada"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Número máximo de resultados de solicitudes de análisis por correo electrónico. Tened en cuenta que demasiadas columnas de resultados en un correo electrónico puede comprometer la lectura."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Escoja la especificación que desea utilizar antes de publicar una solicitud de análisis"
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Configurar las especificaciones del laboratorio para los resultados del servicio de análisis"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Código de estante"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Descripción del estante"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Nombre del estante"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Dirección de envío"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Nombre corto"
 
@@ -4995,7 +4960,7 @@ msgstr ""
 msgid "Show more"
 msgstr "Mostrar más"
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Solo muestra las categorías seleccionadas a las vistas de cliente"
 
@@ -5007,29 +4972,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Firma"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Código del lugar"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Descripción del lugar"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Nombre del lugar"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Tamaño"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Icono pequeño"
 
@@ -5037,14 +4998,14 @@ msgstr "Icono pequeño"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Algunos servicios de análisis utilizan instrumentos sin calibración vigente. La edición de resultados no es permitida."
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Clave de ordenación"
 
@@ -5052,41 +5013,41 @@ msgstr "Clave de ordenación"
 msgid "Specification"
 msgstr "Especificación"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Especificaciones"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Tamaño de la hoja de trabajo, como por ejemplo el número de posiciones para muestras de un equipo concreto. Si selecciona muestras de QC, seleccionad también qué muestras de referencia deben utilizarse. Si habéis escogido un análisis duplicado, indicad también en qué posición se encuentra el duplicado"
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Fecha de inicio"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Estado"
 
@@ -5094,33 +5055,33 @@ msgstr "Estado"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Ubicación de almacenamiento"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Ubicaciones de almacenamiento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Subgrupo"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Subgrupos"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Se utilizará el valor de este campo para ordenar los subgrupos en las listas. En una lista, un subgrupo que para este campo tenga valor '1' se mostrará antes que otro con valor '5'. Admite valores numéricos y caracteres."
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Tramitar"
 
@@ -5128,37 +5089,34 @@ msgstr "Tramitar"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Proporcione un archivo Open XML (.XLSX) válido que contenga los datos de configuración del Bika para continuar."
 
-msgid "Submit for verification"
-msgstr "Enviar para verificación"
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Proveedores"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Pedido de proveedor"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Apellidos"
 
@@ -5178,11 +5136,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Tarea"
 
@@ -5191,20 +5149,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Tipo de tarea"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripción técnica e instrucciones para los analistas"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5222,35 +5180,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Selección del perfil de solicitud de análisis para esta plantilla"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "ID asignado por el laboratorio a la solicitud del cliente"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "ID asignado por el laboratorio a la muestra del cliente"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Dirección web del laboratorio"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Normativa de la acreditación, p.ej. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Análisis de este perfil, agrupados por categoría"
 
@@ -5262,7 +5220,7 @@ msgstr "El análisis que debe ser usado para determinar la materia seca"
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Analista o agente responsable de la calibración"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Analista o agente responsable del mantenimiento"
 
@@ -5270,12 +5228,12 @@ msgstr "Analista o agente responsable del mantenimiento"
 msgid "The analyst responsible of the validation"
 msgstr "Analista responsable de la validación"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Ficheros adjuntos vinculados a las solicitudes de análisis y análisis"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Categoría a la que pertenece el servicio de análisis"
 
@@ -5283,19 +5241,19 @@ msgstr "Categoría a la que pertenece el servicio de análisis"
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "El tipo de recipiente por defecto. Este tipo de recipiente se asignará automáticamente a nuevas particiones de muestra a menos que ya se haya indicado un tipo de recipiente específico para el servicio de análisis relacionado"
 
@@ -5307,7 +5265,7 @@ msgstr "El porcentaje de descuento solo se aplicará a clientes que estén etiqu
 msgid "The full URL: http://URL/path:port"
 msgstr "Dirección URL completa: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Altura o profundidad del muestreo"
 
@@ -5324,24 +5282,24 @@ msgstr "Número de modelo del equipo"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "El laboratorio no está acreditado o no se ha configurado."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Departamento del laboratorio"
@@ -5358,27 +5316,27 @@ msgstr "Número de ceros de relleno en los identificadores de muestra."
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Número de ceros de relleno del número y identificador de una solicitud de análisis"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "La lista de puntos de muestreo de desde poden ser recogidas las muestras de este tipo. Si no selecciona ningún punto de muestreo, entonces estarán disponibles todos los puntos de muestreo."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Lista de tipos de muestra que pueden ser recogidos en este punto de muestreo. Si no selecciona ningún tipo de muestra, entonces estarán disponibles todos los tipos de muestra."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Las unidades de medida para el resultado de este servicio de análisis, como mg/l, ppm, dB, mV, etc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por ejemplo, '10 ml' o '1 kg')."
 
@@ -5402,7 +5360,7 @@ msgstr "Número de días antes que caduque la contraseña. Si desea que la contr
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de días antes que caduque la muestras sin que pueda ser analizada más. Esta propiedad puede ser sobreescrita individualmente para cada tipo de muestra desde la página de configuración de tipos de muestras."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5419,11 +5377,11 @@ msgstr "El número de solicitudes de análisis"
 msgid "The number of requests and analyses per client"
 msgstr "El número de solicitudes y análisis por cliente"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "Porcentaje utilizado para el cálculo del precio de los análisis efectuados con esta prioridad"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Periodo de tiempo durante el que se pueden mantener las muestras en un estado de no conservación antes que caduquen y no puedan ser analizadas."
 
@@ -5440,19 +5398,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "El precio por análisis que se aplicará a los clientes que tengan asignado el 'descuento por volumen'"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "La palabra clave del perfil se utiliza para identificarlo inequívocamente en los ficheros de importación. Debe ser único y no puede ser igual a ninguno de los identificadores utilizados en los campos de entrada de cálculos."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Código de referencia que la entidad de acreditación ha concedido al laboratorio."
 
@@ -5460,11 +5418,11 @@ msgstr "Código de referencia que la entidad de acreditación ha concedido al la
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "Los resultados para este Servicio de Análisis pueden ser ingresados manualmente"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Los resultados para el campo de análisis se capturarán durante el muestreo. Por ejemplo, la temperatura de una muestra de agua del río."
 
@@ -5472,7 +5430,7 @@ msgstr "Los resultados para el campo de análisis se capturarán durante el mues
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "El instrumento seleccionado puede ser usado para este método. Utilice la vista de edición de instrumento para asignar el método a un instrumento específico."
 
@@ -5484,11 +5442,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de serie que identifica inequívocamente al equipo"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5496,19 +5454,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "La configuración por defecto del sistema en relación a la política de archivos adjuntos asociados a una solicitud de análisis"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "El tiempo de respuesta de los análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "El tiempo de respuesta de los análisis en función del tiempo"
 
@@ -5520,7 +5478,7 @@ msgstr "El tiempo de repuesta de los análisis"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "El tiempo de respuesta de los análisis en función del tiempo"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "La palabra clave utilizada para identificar el servicio de análisis en los ficheros de importación para solicitudes de análisis e importaciones de resultados desde equipos."
 
@@ -5532,37 +5490,37 @@ msgstr "Sin resultados."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Estos resultados pueden ser reportados como materia seca"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Solicitud de análisis rechazada. Los resultados no tienen validez y solo se muestran aquí por motivos de trazabilidad. Siga el vínculo a la solicitud de análisis duplicada para visualizar resultados posteriores."
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "Solicitud de análisis duplicada. Generada automáticamente debido al rechazo de la Solicitud de análisis ${retracted_request_id}."
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Solicitud de análisis rechazada. Solicitud de análisis duplicada generada automáticamente: ${retest_child_id}."
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "No se ha podido activar el servicio de análisis porque el cálculo asociado no está activo."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "No ha sido posible desactivar el Servicio de Análisis porque hay cálculos que dependen de él."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5574,7 +5532,7 @@ msgstr "El servicio no requiere de una partición por separado"
 msgid "This service requires a separate container."
 msgstr "Para este servicio es necesario utilizar un recipiente por separado"
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5582,13 +5540,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "El texto será añadido al pie de página de los informes de resultados."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "El valor se indica debajo de todos los resultados publicados"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5602,63 +5556,63 @@ msgstr "Esta hoja de trabajo ha sido rechazada. La hoja de trabajo de reemplazo 
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Título"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Nombre de la ubicación"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Nombre del estante"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Nombre del lugar"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "A"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Por conservar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Por muestrear"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Pendiente de verificación"
 
@@ -5670,13 +5624,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5684,22 +5638,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr "Total en Retraso"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Importe total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Total de análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Total de puntos de datos"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Importe total"
 
@@ -5711,11 +5665,11 @@ msgstr "Total:"
 msgid "Traceability"
 msgstr "Trazabilidad"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5723,61 +5677,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Habilitar esta función para utilizar el sistema de partición de muestras"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Tiempo de respuesta (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipo"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Tipo de error"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Tipo de ubicación"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "No se puede cargar la plantilla"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Error durante el envío del correo electrónico para informar a los contactos del cliente que la solicitud de análisis ha sido rechazada. Informe de error: ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sin asignar"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incertidumbre"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valor de incertidumbre"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "No definido"
 
@@ -5785,13 +5733,13 @@ msgstr "No definido"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unidades"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5816,17 +5764,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Por publicar"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Formato de ficheo no válido: ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Formato de fichero no válido: ${fileformat}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5838,11 +5786,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Cargar una firma digitalizada para que sea imprimida en los informes de resultados. Las dimensiones idóneas son 250 píxels de ancho por 150 píxels de alto."
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5850,7 +5798,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Utilizar cálculo predeterminado"
 
@@ -5862,13 +5810,13 @@ msgstr "Utilizar un servidor de IDs externo"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Utilizad estos campos para pasar parámetros arbitrarios al módulo de importación"
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Usuario"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nombre de usuario"
@@ -5881,7 +5829,7 @@ msgstr "Historial del usuario"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Historial de Usuarios"
@@ -5890,27 +5838,27 @@ msgstr "Historial de Usuarios"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "El uso de un número bajo de puntos de datos suele conllevar que los resultados del cálculo estadístico no tengan sentido. Estableced un número mínimo aceptable de resultados antes que se ejecuten los cálculos estadísticos de Control de Calidad (QC)"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "IVA Total"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "CIF"
 
@@ -5918,11 +5866,11 @@ msgstr "CIF"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Válido desde"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Válido hasta"
 
@@ -5930,181 +5878,181 @@ msgstr "Válido hasta"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validación"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "La validación ha fallado: '${keyword}': palabra clave duplicada"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "La validación ha fallado: '${title}': la palabra clave ya está en uso en el cálculo '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Error de validación: '${title}': Esta palabra clave ya está en uso por el servicio '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Error de validación: '${title}': título duplicado"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Error de validación: '${value}' no es único"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Ha fallado la validación: la orientación debe ser E/W (Este/Oeste)"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Error de validación: la orientación debe ser N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Error de validación: el porcentaje de error debe tener un valor entre 0 y 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Error de validación: El error debe ser 0 o mayor"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Error de validación: El valor del error debe ser numérico"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Error de validación: los valores esperados deben estar dentro del rango de valores mínimo (Min) y máximo (Max)"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Error de validación: los valores esperados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Error de validación: la palabra clave '$ {palabra clave}' no es válida"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Error de validación: los valores máximos (Max) tienen que ser mayores que los valores mínimos (Min)"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Error de validación: los valores máximos (Max) tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Error de validación: los valores mínimos (Min) tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Error de validación: los porcentajes de error tienen que tener un valor entre 0 y 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Error de validación: los porcentajes de error tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Error de validación: Debe indicar el método de conservación."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Ha fallado la validación: el texto del resultado no puede estar vacío"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Error de validación: los resultados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Error de validación: imprescindible seleccionar una de las categorías siguientes: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Error de validación: los valores deben ser números"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Error de validación: el título de columna '${title}' tiene que tener la palabra clave '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Error de validación: los grados son 180; el valor para minutos debe ser cero"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Error de validación: los grados son 180; el valor para los segundos debe ser cero"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Error de validación: los grados son 90; el valor de minutos debe ser cero"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Error de validación: los grados son 90; el valor de segundos debe ser cero"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Error de validación: los grados deben variar entre 0 - 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Error de validación: los grados tienen que estar entre 0 y 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Error de validación: los grados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Error de validación: la palabra clave '${keyword}' tiene que tener '${title}' como título de columna"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Error de validación: el identificador contiene caracteres no válidos"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Error de validación: palabra clave requerida"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Error de validación: los minutos tienen que estar entre 0 y 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Error de validación: los minutos tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Error de validación: el valor del porcentaje debe ser entre 0 y 100"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Error de validación: el valor del porcentaje debe ser un número"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Error de validación: los segundos tienen que estar entre 0 y 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Error de validación: los segundos tienen que ser de tipo numérico"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Error de validación: título requerido"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6112,7 +6060,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Validador"
@@ -6123,12 +6071,12 @@ msgstr "Validador"
 msgid "Value"
 msgstr "Valor"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Los valores ingresados aquí anularan los establecidos en los campos de la sección de Cálculo Provisional"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificadas"
@@ -6139,7 +6087,7 @@ msgstr "Verificadas"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versión"
 
@@ -6149,11 +6097,11 @@ msgstr "Versión"
 msgid "Volume"
 msgstr "Volumen"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Dirección de correo electrónico de la entidad acreditadora"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6161,24 +6109,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Semanas para expirar"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Si la diferencia porcentual entre los resultados de una réplica de análisis en la hoja de trabajo para la misma muestra y análisis es mayor que este valor, el sistema lo notificará con una alerta."
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Trabajo Realizado"
@@ -6189,25 +6137,25 @@ msgstr "Flujo de trabajo"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Hoja de trabajo"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Diseño de la hoja de trabajo"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Plantillas para hojas de trabajo"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Hojas de trabajo"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6215,9 +6163,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Si"
 
@@ -6229,7 +6177,7 @@ msgstr "No tiene suficientes privilegios para gestionar hojas de trabajo."
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "No tiene suficientes privilegios para ver la hoja de trabajo ${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "Debe asignar esta solicitud a un cliente"
 
@@ -6237,11 +6185,11 @@ msgstr "Debe asignar esta solicitud a un cliente"
 msgid "You must select an instrument"
 msgstr "Debe seleccionar un equipo"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "acción"
 
@@ -6257,15 +6205,15 @@ msgstr "Análisis"
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "y otros"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6286,7 +6234,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "comentario"
 
@@ -6294,37 +6242,9 @@ msgstr "comentario"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "Líneas de datos"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6335,7 +6255,7 @@ msgstr "desactivar"
 msgid "heading_arpriority"
 msgstr "Prioridad de la solicitud de análisis"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "inactivo"
 
@@ -6383,19 +6303,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr "de"
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr "abierto"
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr "otro estado"
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr "publicado"
 
@@ -6403,19 +6323,19 @@ msgstr "publicado"
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "repitiendo cada"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "período de repetición"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr "Muestra pendiente"
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr "Muestra recibida"
 
@@ -6434,19 +6354,8 @@ msgstr "summary_content_listing"
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6458,7 +6367,7 @@ msgstr "Campo obligatorio"
 msgid "to"
 msgstr "hasta"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr "Por verificar"
 
@@ -6466,7 +6375,7 @@ msgstr "Por verificar"
 msgid "type"
 msgstr "Tipo"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "hasta"
 
@@ -6491,7 +6400,7 @@ msgstr "Valor"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr "verificado"
 
@@ -6503,6 +6412,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es_419/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_419/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Latin America) (http://www.transifex.com/bikalabs/bika-lims/language/es_419/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} puede loguearse en el LIMS usando ${contact_username} como nombre de usuario. Los contactos deben cambiar sus contraseñas. Si una contraseña es olvidada, el contacto puede solicitar una nueva desde el formulario de login."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} Falta preservador, o fecha de preservación"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} están esperando formas de preservación."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} están esperando ser recibidos."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} se han invalidado."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} fueron creados exitosamente."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: las particiones están esperando ser recibidas."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} Falta preservador, o fecha de preservación"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} están esperando forma de preservación."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} está esperando ser recibido."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} fue creado exitosamente."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} la partición está esperando ser recibida."
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Error"
 
@@ -96,15 +96,15 @@ msgstr "% Realizado"
 msgid "% Published"
 msgstr "% Publicado"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr "%s No es posible realizar la transición"
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s ha sido rechazado"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s no tiene '%s' columna."
 
@@ -116,15 +116,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "\"Clásico\" indica la importación de solicitudes de análisis por muestra y la selección de los servicios de análisis. Con \"Perfiles\" palabras clave de un perfil son usados para seleccionar múltiples servicios de análisis simultáneamente"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr "'Fecha de Muestreo' y 'Definir el muestreador para la toma de muestra' debe ser completado y guardado para programar un muestreo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr "'Fecha de Muestreo' y 'Definir el muestreador para la toma de muestra' debe ser completado y guardado para programar un muestreo. Elemento: %s"
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blanco)"
@@ -137,7 +137,7 @@ msgstr "(Control)"
 msgid "(Duplicate)"
 msgstr "(Duplicado)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Peligroso)"
 
@@ -146,33 +146,27 @@ msgid "(Required)"
 msgstr "(Requerido)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Icono de 16x16 píxeles es utilizado para esta prioridad en listados."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Icono de 32x32 píxeles es utilizado para esta prioridad en vistas de objetos."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
 msgstr "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Otro"
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr "<p>${service} requiere que los siguientes servicios sean seleccionados:</p><br/><p>${deps}</p><br/><p>Deseas aplicar estos servicios ahora?</p>"
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
-msgstr "<p>Los siguientes servicio dependen de ${service}, y no serán seleccionados si continúa:</p><br/><p>${deps}</p><br/><p>Desea quitar estas selecciones ahora?</p>"
 
 #: bika/lims/content/calculation.py:84
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -182,16 +176,16 @@ msgstr "<p>La fórmula que escriba aquí será calculada dinámicamente cuando s
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr "<span>x</span> <span class=\"formHelp\">x</span>"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr "Un nombre corto que describe la Ronda para que sea fácilmente identificado en los formularios y en los menús desplegables"
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "AR ${ar_number}"
 
@@ -203,7 +197,7 @@ msgstr "AR Opción de Adjuntos"
 msgid "AR ID Padding"
 msgstr "AR Relleno en ID"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importar AR"
 
@@ -211,17 +205,17 @@ msgstr "Importar AR"
 msgid "AR Import options"
 msgstr "Opciones de Importación AR"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr "Nombre Plantilla Solucitud de Análisis"
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Plantillas de Solicitud de Análisis"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Solicitu de Análisis para re-analizar resultados"
 
@@ -229,54 +223,54 @@ msgstr "Solicitu de Análisis para re-analizar resultados"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "ARs: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nombre de Cuenta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número de Cuenta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo de Cuenta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Acreditación"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviatura del ente de acreditación"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL del ente de Acreditación"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logo de Acreditación"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referencia de Acreditación"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Acreditación en encabezado de página "
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Acreditado"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr "Acciones realizadas por los usuarios (un usuario específico) en un peri
 msgid "Activate"
 msgstr "Activar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Activo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Muestra puntual"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Nuevo"
 
@@ -324,11 +318,7 @@ msgstr "Añadir Muestra Control"
 msgid "Add Duplicate"
 msgstr "Añadir Duplicado"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Añadir Comentario"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Nueva Plantilla"
 
@@ -336,16 +326,16 @@ msgstr "Nueva Plantilla"
 msgid "Add a remarks field to all analyses"
 msgstr "Añadir un campo para observaciones en todos los análisis"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Añadir nuevo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Comentarios adicionales"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Dirección"
@@ -358,26 +348,26 @@ msgstr "Añadir dos dígitos del año después del prefijo del ID"
 msgid "Administrative Reports"
 msgstr "Reportes Arministrativos"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Despúes ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agencia"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Todos"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Todos los servicios de análisis acreditados se listan aquí."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
 
@@ -389,7 +379,7 @@ msgstr "Todos los tipos de análisis"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Permitir que los Lab Clerks (empelados adminsitrativos) crear y editar clientes"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir la entrada manual del Límite de Detección"
 
@@ -397,15 +387,15 @@ msgstr "Permitir la entrada manual del Límite de Detección"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Permitir el acceso a las hojas de trabajo únicamente a los analistas asignados"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Permitir el ingreso manual de la incertidumbre"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr "Permitir que el mismo usuario verifique varias veces"
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permitir que el mismo usuario verifique varias veces, pero no consecutivamente"
 
@@ -413,11 +403,11 @@ msgstr "Permitir que el mismo usuario verifique varias veces, pero no consecutiv
 msgid "Allow self-verification of results"
 msgstr "Permitir la auto-verificación de los resultados"
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Permitir a los analistas reemplazar manualmente el valor prederminado para los Límites de Detección (LDL y UDL) sobre las entradas de los resultados"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Permitir a lo analistas reemplazar manualmente el valor predeterminado de la incertidumbre."
 
@@ -425,48 +415,48 @@ msgstr "Permitir a lo analistas reemplazar manualmente el valor predeterminado d
 msgid "Allow users to filter datas by department."
 msgstr "Permitir a los usuarios filtrar datos por departamento."
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Fórmula de cálculo alternativo"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Expandir siempre las categorias seleccionadas en la vista de Clientes"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr "Condicione ambientales"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Cantidad"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Análisis"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Análisis en el rango de los límites de error"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Análisis fuera de rango"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr "Análisis pendientes"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Análisis por Servicios de Análisis"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Análisis por tipo de Muestra"
@@ -480,7 +470,7 @@ msgstr "Análisis por Servicio"
 msgid "Analyses performed and published as % of total"
 msgstr "Análisis realizados y publicados como % del total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Análisis realizados como% del total"
 
@@ -493,27 +483,27 @@ msgstr "Análisis de reportes relacionados"
 msgid "Analyses repeated"
 msgstr "Análisis Repetidos"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Resultados de análisis fuera del rango de especificación"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Análisis re-analizados"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Resumen de análisis por departamento"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Análisis que han sido re-analizados"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Análisis"
 
@@ -521,52 +511,52 @@ msgstr "Análisis"
 msgid "Analysis Attachment Option"
 msgstr "Opciones de Adjuntos en Análisis"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorías de Análisis"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoría de Análisis"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Palabra clave para el análisis"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Perfil de Análisis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Perfiles de Análisis"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Solicitud de Análisis"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID de Solicitud de Análisis"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importaciones de Solicitudes de Análisis"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Prioridades de Solicitudes de Análisis"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Especificaciones de Solicitudes de Análisis"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr "Plantilla de Solicitud de Análisis"
 
@@ -574,65 +564,65 @@ msgstr "Plantilla de Solicitud de Análisis"
 msgid "Analysis Request rejection reporting form"
 msgstr "Formulario para el reporte de rechazo de Solicitud de Análisis"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Solicitud de Análisis"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr "Solicitudes de Análisis para preservar"
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr "Solicitudes de Análisis para Publicar"
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr "Solicitudes de Análisis por Recibir"
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr "Solicitudes de Análisis para Muestrear"
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr "Solicitudes de Análisis para Verificar"
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Solicitudes de Análisis con resultados pendientes"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr "Solicitudes de Análisis con muestreo programado"
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Servicio de Análisis"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Servicios de Análisis"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Especificación de Análisis"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificaciones de Análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Estado de Análisis"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo de Análisis"
@@ -641,46 +631,46 @@ msgstr "Tipo de Análisis"
 msgid "Analysis category"
 msgstr "Categoría de Análisis"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Solicitud de Análisis ${AR} ha sido creada."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr "Plantillas de Solicitud de Análisis que se incluirán en la Plantilla de Ronda de Muestreo"
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Solicitud de Análisis ${AR} ha sido creada."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Solicitudes de Análisis y Análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Solicitudes de Análisis y Análisis por cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Solicitudes de análisis no facturadas"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Resultado del análisis dentro del rango de error"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Resultados de análisis"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Resultados de análisis para ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Resultados de análisis por punto de muestreo y servicio de análisis"
 
@@ -688,12 +678,12 @@ msgstr "Resultados de análisis por punto de muestreo y servicio de análisis"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Resultados de análisis fuera del rango especificado por el laboratorio o el cliente Tenga en cuenta que esto puede tomar varios minutos"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Servicio de análisis"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Las especificaciones de análisis se restablecen a los valores predeterminados del laboratorio."
 
@@ -709,17 +699,17 @@ msgstr "Tiempo de respuesta al análisis"
 msgid "Analysis turnaround time over time"
 msgstr "Tiempo de respuesta del análisis a lo largo del tiempo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Tiempos de respuesta al análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Tiempo de respuesta en el análisis a lo largo del tiempo"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr "El Analista debe ser especificado"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Cualquiera"
 
@@ -740,7 +730,7 @@ msgstr "Aplicar"
 msgid "Apply template"
 msgstr "Aplicar plantilla"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Aplicar ancho"
 
@@ -758,15 +748,15 @@ msgstr "Número de Artículo"
 msgid "Assign"
 msgstr "Asignar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignado"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Asignado a la hoja de trabajo"
 
@@ -784,27 +774,27 @@ msgstr "Adjuntar"
 msgid "Attach to"
 msgstr "AAdjuntar a "
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Archivo adjuntp"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Claves de archivos adjuntos"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opciones de archivos adjuntos"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipos de archivos adjuntos"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipos de archivos adjuntos"
 
@@ -814,25 +804,25 @@ msgstr "Tipos de archivos adjuntos"
 msgid "Attachment due"
 msgstr "Archivo adjunto pendiente"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Archivos adjuntos no permitidos"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Archivos adjuntos requeridos"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipos de Archivos adjuntos"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Archivos Adjuntos"
 
@@ -844,7 +834,7 @@ msgstr "Autorizado por"
 msgid "Autofill"
 msgstr "Autollenado"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "AutoImportación"
 
@@ -861,27 +851,27 @@ msgstr "Impresión automática de rótulos"
 msgid "Available templates"
 msgstr "Plantillas disponibles"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Promedio Vencidos"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Promedio A Tiempo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Promedio Reatrasados"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Estado mal especificado: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Sucursal bancaria"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nombre del Banco"
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr "Base"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lote"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID del Lote"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etiquetas del lote"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lote"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Soporte"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Antes de ${start_date}"
 
@@ -922,7 +912,7 @@ msgstr "Antes de ${start_date}"
 msgid "Biannual"
 msgstr "Semestral"
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Icono grande"
 
@@ -930,7 +920,7 @@ msgstr "Icono grande"
 msgid "Bika LIMS"
 msgstr "Bika LIMS"
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuración de Bika LIMS"
 
@@ -938,63 +928,67 @@ msgstr "Configuración de Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr "Página de Inicio de Bika LIMS"
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blanco"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Análisis de Blanco "
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Brand"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr "Descuento por volumen"
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Se aplica descuento por volumen"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Precio por volumen (excluido de IVA)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Tenéfono empresarial"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Por"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "Contactos CC"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "Correos CC"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calcular la presición desde la incertidumbre"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Cálculo"
 
@@ -1002,8 +996,8 @@ msgstr "Cálculo"
 msgid "Calculation Formula"
 msgstr "Fórmula de cálculo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos clave del cálculo"
@@ -1016,11 +1010,11 @@ msgstr "Cálculo: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Cálculo: Ninguno"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Cálculos"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibración"
 
@@ -1032,12 +1026,12 @@ msgstr "Certificados de Calibración"
 msgid "Calibration report date"
 msgstr "Fecha de Reporte de Calibración"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Técnico"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr "Puede verificar, pero si es enviado por el usuario actual"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -1069,18 +1063,18 @@ msgstr "No se puede desactivar el cálculo porque está siendo usado en los sigu
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr "No puede verificar, antes el usuario actual debe enviar o verificar "
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "No se puede verificar: Enviado por el usuario actual"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacidad"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturado"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr "Cardinal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
@@ -1097,17 +1091,17 @@ msgstr "Número de catálogo"
 msgid "Categorise analysis services"
 msgstr "Categorice los servicios de análisis"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoría"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "La categoría no se puede desactivar porque contiene servicios de análisis activos"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Num Certificado"
 
@@ -1120,31 +1114,31 @@ msgstr "Código certificado"
 msgid "Changes saved."
 msgstr "Cambios guardados"
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Marcar si el método ha sido acreditado"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Marque esta casilla si el servicio de análisis esta incluido en la resolución de análisis acreditados"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Marque esta casilla si las muestras tomadas en este punto son \"compuestas\" y son una mezclas de más de una sub-muestras. Por ejemplo, varias muestras de la superficie de una represa son mezcladas para obtener una muestra representativa. El valor predeterminado, no marcado, indica muestras putuales"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Marque esta casilla si este envase ya está preservado. Esta configuración provoca un cortocircuito en el flujo de trabajo de preservación para las particiones de muestra almacenadas con este envase"
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Marque esta casilla si ésta es la prioridad predeterminada"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Marque esta casilla si su Laboratorio está acreditado"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Marque esta casilla para asegurarse de que se utiliza un envase separado para la particion de la muestra para este servicio de análisis"
 
@@ -1152,7 +1146,7 @@ msgstr "Marque esta casilla para asegurarse de que se utiliza un envase separado
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Marque esta opción si desea utilizar un servidor de ID independiente. Los prefijos son configurados por separado en cada sitio Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Elija valores de especificación predeterminados para la solicitud de análisis"
 
@@ -1168,19 +1162,19 @@ msgstr "Elija el tipo de verificación múltiple para el mismo usuario. Esta con
 msgid "City"
 msgstr "Ciudad"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clásico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Haga clic en Categorías de análisis (en lista desplegable) para ver los Servicios de Análisis de cada categoría. Introduzca los valores mínimo y máximo para indicar un rango de resultados válido. Cualquier resultado fuera de este rango dará una alerta. El campo %Error permite considerar un % de incertidumbre para evaluar resultados con valores mínimos y máximos. Un resultado fuera del rango pero dentro del rango si se toma en cuenta el % de error, generará una alerta menos grave."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Haga clic en Categorías de análisis (en lista desplegable) para ver los Servicios de Análisis de cada categoría. Introduzca los valores mínimo y máximo para indicar un rango de resultados válido. Cualquier resultado fuera de este rango dará una alerta. El campo %Error permite considerar un % de incertidumbre para evaluar resultados con valores mínimos y máximos. Un resultado fuera del rango pero dentro del rango si se toma en cuenta el % de error, generará una alerta menos grave."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Haga clic en Categorías de Análisis (lista desplegable para ver los Servicios de Análisis en cada categoría.) Introduzca los valores mínimo y máximo para indicar un rango de resultados válido. Cualquier resultado fuera de este rango elevará una alerta. Si el resultado está por debajo de '<Min', el resultado se mostrará como '<Mínimo' [Min]'. Lo mismo se aplica a los resultados anteriores'> Max'"
 
@@ -1188,19 +1182,19 @@ msgstr "Haga clic en Categorías de Análisis (lista desplegable para ver los Se
 msgid "Click to download"
 msgstr "Click para descargar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID Cliente del Lote"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Cliente ID"
 
@@ -1208,59 +1202,59 @@ msgstr "Cliente ID"
 msgid "Client Landing Page"
 msgstr "Página del cliente"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nombre del Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Orden de Cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Número de Orden del Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref del Cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referencia del Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID del cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "ID Muestra por el Cliente"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr "Rondas de muestreo de clientes"
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr "Contacto con el cliente en el momento del muestreo"
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "El cliente debe tener un contacto antes de que la solicitud pueda ser enviada"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr "Contacto con el cliente que coordina con el laboratorio"
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clientes"
 
@@ -1269,39 +1263,39 @@ msgstr "Clientes"
 msgid "Close"
 msgstr "Cerrar"
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Cerrado"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Código para la ubicación"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Código para el sitio"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Código del estante"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Coma (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentarios"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Comentarios o interpretación de resultados"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "ID Comercial"
 
@@ -1309,21 +1303,21 @@ msgstr "ID Comercial"
 msgid "Complete"
 msgstr "Completo"
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Compuesta"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr "Compuesta Y/N"
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Nivel de Confianza %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configure las particiones de muestra y las preservaciones de esta plantilla. Asignar análisis a las diferentes particiones en la pestaña Plantilla de Análisis"
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "Corfirme la contraseña"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contacto"
@@ -1347,8 +1341,8 @@ msgstr "Contacto"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr "EL Contacto está desactivado. El usuario no puede ser desvinculado ."
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contactos"
@@ -1357,48 +1351,48 @@ msgstr "Contactos"
 msgid "Contacts to CC"
 msgstr "Contacto con CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Envase"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr "Nombre Envase"
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipo de Envase"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipos de Envases"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr "Volumen Envase"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Envases"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo de Envase"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Control"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Análisis de Control QC"
 
@@ -1414,12 +1408,12 @@ msgstr "Copiar Servicios de Análisis"
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Copiar a Nuevo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Contar"
 
@@ -1432,18 +1426,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr "Crear un usuario nuevo"
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Crear una nueva muestra de este tipo"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creado"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creado por"
 
@@ -1451,7 +1445,7 @@ msgstr "Creado por"
 msgid "Created by:"
 msgstr "Creado por:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr "Creación e inicialización de objetos"
 
@@ -1459,8 +1453,8 @@ msgstr "Creación e inicialización de objetos"
 msgid "Creator"
 msgstr "Creador"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criterio"
 
@@ -1468,12 +1462,12 @@ msgstr "Criterio"
 msgid "Currency"
 msgstr "Moneda"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Actual"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Marca decimal personalizada"
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Por defecto"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1786,9 +1780,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1815,7 +1809,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1851,16 +1845,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1881,8 +1875,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1891,54 +1885,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2034,7 +2028,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2161,19 +2155,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2226,19 +2216,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2277,18 +2267,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2452,7 +2442,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2461,8 +2451,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2487,30 +2477,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2764,12 +2748,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2778,47 +2762,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3016,31 +3000,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3164,27 +3142,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3225,17 +3203,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3678,7 +3647,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3721,16 +3690,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3814,14 +3783,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4041,11 +4010,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4169,7 +4138,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4259,15 +4228,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4779,11 +4748,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4849,7 +4818,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5447,11 +5405,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,12 +5527,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5671,22 +5625,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5698,11 +5652,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5868,7 +5816,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5877,27 +5825,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5905,11 +5853,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5917,181 +5865,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6126,7 +6074,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6136,11 +6084,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6281,36 +6229,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es_AR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_AR/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/bikalabs/bika-lims/language/es_AR/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es_MX/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_MX/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/bikalabs/bika-lims/language/es_MX/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Peru) (http://www.transifex.com/bikalabs/bika-lims/language/es_PE/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} puede acceder al LIMS utilizando el nombre de usuario ${contact_username}. Se recomienda que los contactos modifiquen su contraseña. Si el usuario pierde su contraseña, siempre podrá solicitar una nueva en el formulario de acceso."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "Los elementos ${items} están a la espera de conservación"
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "Los elementos ${items} están a la espera de ser recepcionados."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: particiones a la espera de ser recepcionadas."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} a la espera de conservación."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} a la espera de ser recepcionado."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} a la espera de ser recepcionado."
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Error"
 
@@ -96,15 +96,15 @@ msgstr "% Realizado"
 msgid "% Published"
 msgstr "% Publicado"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -116,15 +116,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "La opción 'Classic' indica que se importaran las solicitudes de análisis por muestra y servicio de análisis. Si escoge la opción 'Perfiles', las claves de perfil de análisis se utilizaran para seleccionar múltiples servicios de análisis de forma conjunta."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blanco)"
@@ -137,7 +137,7 @@ msgstr "(Control)"
 msgid "(Duplicate)"
 msgstr "(Duplicado)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Peligroso)"
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr "(Obligatorio)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr "Opciones de ficheros adjuntos en solicitudes de análisis"
 msgid "AR ID Padding"
 msgstr "Tamaño del ID de las solicitudes de análisis"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importación de solicitudes de análisis"
 
@@ -211,17 +205,17 @@ msgstr "Importación de solicitudes de análisis"
 msgid "AR Import options"
 msgstr "Opciones de importación de solicitudes de análisis"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Plantillas de solicitud de análisis"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -229,54 +223,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nombre de la cuenta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número de cuenta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo de cuenta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Acreditación"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviación de la entidad acreditadora"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL de la entidad acreditadora"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logotipo de la acreditación"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referencia de la acreditación"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Acreditado"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr "Acciones realizadas por los usuarios (o usuario específico) entre un pe
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Activos"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Añadir"
 
@@ -324,11 +318,7 @@ msgstr "Añadir control de referencia"
 msgid "Add Duplicate"
 msgstr "Añadir duplicado"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Añadir plantilla"
 
@@ -336,16 +326,16 @@ msgstr "Añadir plantilla"
 msgid "Add a remarks field to all analyses"
 msgstr "Agregar un campo de observaciones a todos los análisis"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Agregar nuevo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Dirección"
@@ -358,26 +348,26 @@ msgstr "Añade los dos dígitos del año tras el prefijo del identificador"
 msgid "Administrative Reports"
 msgstr "Informes administrativos"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agencia"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Todo"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Se muestran todos los análisis acreditados."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Todos los análisis asignados"
 
@@ -389,7 +379,7 @@ msgstr "Todos los análisis del tipo"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Expandir siempre las categorías seleccionadas a las vistas de cliente"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Cantidad"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Análisis"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Análisis en el rango de error"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Análisis fuera de rango"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Análisis por servicio de análisis"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Análisis por tipo de muestra"
@@ -480,7 +470,7 @@ msgstr "Análisis por servicio"
 msgid "Analyses performed and published as % of total"
 msgstr "% o de análisis realizados y publicados con respecto al total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "% o de análisis realizados con respecto al total"
 
@@ -493,27 +483,27 @@ msgstr "Reportes de análisis relacionados"
 msgid "Analyses repeated"
 msgstr "Análisis repetidos"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Análisis reprocesados"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Resumen de análisis por departamento"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Análisis que han sido reprocesados"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Análisis"
 
@@ -521,52 +511,52 @@ msgstr "Análisis"
 msgid "Analysis Attachment Option"
 msgstr "Opción de ficheros adjuntos para el análisis"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorías de análisis"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoría del análisis"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Identificador del análisis"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Perfil de análisis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Perfiles de solicitud de análisis"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Identificador de la solicitud de análisis"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importaciones de solicitudes de análisis"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Solicitudes de análisis"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Servicio de análisis"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Servicios de análisis"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificaciones de análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Estado del análisis"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo de análisis"
@@ -641,46 +631,46 @@ msgstr "Tipo de análisis"
 msgid "Analysis category"
 msgstr "Categoría de análisis"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "La solicitud de análisis ${AR} se ha creado satisfactoriamente"
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Las solicitudes de análisis ${ARs} se han creado satisfactoriamente"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Solicitudes de análisis y análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Solicitudes de análisis y análisis por cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Solicitudes de análisis no facturadas"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Resultados del análisis que están dentro del rango de error"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Resultados por punto de muestreo y servicio de análisis"
 
@@ -688,12 +678,12 @@ msgstr "Resultados por punto de muestreo y servicio de análisis"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Resultados fuera del rango especificado por el cliente o el laboratorio. Esto puede tardar unos minutos"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Servicio de análisis"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Especificaciones de análisis reiniciadas a los valores por defecto."
 
@@ -709,17 +699,17 @@ msgstr "Tiempo de respuesta del análisis"
 msgid "Analysis turnaround time over time"
 msgstr "Análisis fuera de tiempo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Tiempo de respuesta de los análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Análisis fuera de tiempo"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Cualquier"
 
@@ -740,7 +730,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Aplicar plantilla"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignado"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Asignado a hoja de trabajo"
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Adjuntar a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Fichero adjunto"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Claves de adjunto"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opciones de adjuntos"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipo de fichero adjunto"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipos de ficheros adjuntos"
 
@@ -814,25 +804,25 @@ msgstr "Tipos de ficheros adjuntos"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "No se permiten adjunciones"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Adjunciones obligatorias"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipo de fichero adjunto"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Ficheros adjuntos"
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Promedio TAT"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Promedio anticipado"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Promedio de retraso"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Oficina bancaria"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nombre del banco"
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lote"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID Lote"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etiquetas del Lote"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lotes"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Retraso"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -922,7 +912,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -930,7 +920,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuración de Bika LIMS"
 
@@ -938,63 +928,67 @@ msgstr "Configuración de Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Blanco"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Descuento por volumen aplicable"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Precio con descuento por volumen (sin IVA)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Teléfono del negocio"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Por"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Correos"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Cálculo"
 
@@ -1002,8 +996,8 @@ msgstr "Cálculo"
 msgid "Calculation Formula"
 msgstr "Fórmula de cálculo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de cálculo provisionales"
@@ -1016,11 +1010,11 @@ msgstr "Cálculo: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Cálculo: ninguno"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Cálculos"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibración"
 
@@ -1032,12 +1026,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -1069,18 +1063,18 @@ msgstr "No ha sido posible desactivar el cálculo porque hay servicios de análi
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacidad"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturado"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número de catálogo"
 
@@ -1097,17 +1091,17 @@ msgstr "Número de catálogo"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoría"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "La Categoría no se puede desactivar porque tiene servicios de análisis asociados"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Marque esta casilla si el servicio de análisis está en proceso de acreditación"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Marque esta casilla si las muestras recogidas en este punto de muestreo deben ser consideradas en conjunto (composición). Por ejemplo, las muestras recogidas en puntos de muestreo distintos de la orilla de un lago suelen mezclarse para que sean una muestra representativa de la totalidad del lago."
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Marque la casilla de verificación si el contenedor ya está bajo conservación, pues ello hará que el sistema omita el circuito de preservación para las muestras del contenedor. "
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Marque la casilla si el laboratorio está acreditado"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Marcar esta casilla para utilizar un contenidor de muestra separado para este servicio de análisis"
 
@@ -1152,7 +1146,7 @@ msgstr "Marcar esta casilla para utilizar un contenidor de muestra separado para
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Marcar para utilizar un ID server distinto. Puede configurar los prefijos individualmente para cada sitio Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr "Ciudad"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clásico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Haga clic sobre las cabeceras de categorías de análisis (con fondo gris) para ver los servicios de análisis que contienen cada una de ellas. Introducid los valores mínimo y máximo para indicar el rango válido de los resultados. Si el resultado se encuentra fuera de este rango, el sistema lanzará una alerta. El campo % Error le permite indicar el porcentaje de incertidumbre que tiene que tener en cuenta el sistema en la evaluación de los resultados con el rango indicado. Si un resultado fuera de rango pasa a ser válido cuando el sistema tiene en cuenta el porcentaje de incertidumbre, el sistema lo notificará con una alerta menos severa."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "Clic para descargar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID Lote de Cliente"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID del cliente"
 
@@ -1208,59 +1202,59 @@ msgstr "ID del cliente"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nombre del cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Pedido de cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. del cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referencia del cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "ID de muestra del cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Identificador de la muestra asignado por el cliente"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Para tramitar una solicitud de análisis, el cliente debe tener dado de alta como mínimo un contacto."
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clientes"
 
@@ -1269,39 +1263,39 @@ msgstr "Clientes"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Cerrados"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentarios"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1309,21 +1303,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composición"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "% Nivel de confidencia"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configuración de las particiones de muestras y métodos de conservación asignados a la plantilla. Puede asignar análisis a distintas particiones des de la pestaña de plantilla de análisis."
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "Confirme la contraseña"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Consideraciones"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contacto"
@@ -1347,8 +1341,8 @@ msgstr "Contacto"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contactos"
@@ -1357,48 +1351,48 @@ msgstr "Contactos"
 msgid "Contacts to CC"
 msgstr "Contactos a CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Contenedor"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipo de contenedor"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipos de contenedores"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Contenedores de muestras"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo de contenido"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Control"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiar desde"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Recuento"
 
@@ -1432,18 +1426,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creado"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creado por:"
 
@@ -1451,7 +1445,7 @@ msgstr "Creado por:"
 msgid "Created by:"
 msgstr "Creado por:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Creador"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criterios"
 
@@ -1468,12 +1462,12 @@ msgstr "Criterios"
 msgid "Currency"
 msgstr "Moneda"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "En curso"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr "Interfaz de datos"
 msgid "Data Interface Options"
 msgstr "Opciones de interfaz de datos"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Libro de entrada diaria de datos"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Fecha"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Fecha de Creación"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Fecha de envío"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Fecha de exclusión"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Fecha de caducidad"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Fecha de importación"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Fecha de carga"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Fecha de apertura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Fecha de conservación"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Fecha de publicación"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Fecha de recepción"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Fecha de petición"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Fecha de muestreo"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr "Fecha hasta donde el instrumento está calibrado"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Fecha hasta donde el instrumento está bajo mantenimiento"
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Fecha hasta donde el instrumento no estará disponible"
@@ -1624,11 +1618,11 @@ msgstr "Fecha hasta donde el instrumento no estará disponible"
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Días"
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Por defecto"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Contenidor por defecto"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tipo de contenedor por defecto"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Método de conservación por defecto"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categorías por defecto"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Contenedores por defecto: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valor por defecto"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Grados"
 
@@ -1786,9 +1780,9 @@ msgstr "Grados"
 msgid "Delete attachment"
 msgstr "Eliminar el fichero adjunto"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Departamento"
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Análisis dependientes"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Descripción del método en lenguaje llano. Esta información estará disponible para los clientes del laboratorio."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descripción"
 
@@ -1815,7 +1809,7 @@ msgstr "Descripción"
 msgid "Description of the actions made during the calibration"
 msgstr "Descripción de las acciones realizadas durante el calibramiento"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Descripción de las acciones realizadas durante el proceso de mantenimiento"
 
@@ -1823,19 +1817,19 @@ msgstr "Descripción de las acciones realizadas durante el proceso de mantenimie
 msgid "Description of the actions made during the validation"
 msgstr "Descripción de las acciones realizadas durante la validación"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Descuento %"
 
@@ -1851,16 +1845,16 @@ msgstr "Descuento %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Valor a mostrar"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Fecha de eliminación"
 
@@ -1881,8 +1875,8 @@ msgstr "Fecha de eliminación"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminados"
@@ -1891,54 +1885,54 @@ msgstr "Eliminados"
 msgid "District"
 msgstr "Región"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inactivos"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Abajo desde"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Abajo hacia"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr "Secar"
 msgid "Dry matter analysis"
 msgstr "Análisis de materia seca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Vencimiento"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Fecha de vencimiento"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Var. Dup."
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplicado"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicado de"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Variación del duplicado %"
 
@@ -1998,35 +1992,35 @@ msgstr "QC de duplicado de análisis"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Gráficos de control de calidad para análisis duplicados"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Duración"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "P.ej., ENAC, Applus, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Earliness"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Reciente"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Elevación"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Dirección de correo electrónico"
 
@@ -2034,7 +2028,7 @@ msgstr "Dirección de correo electrónico"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Asunto del correo electrónico"
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Mejoramiento"
 
@@ -2073,16 +2067,16 @@ msgstr "Introduzca un nombre de usuario, que normalmente es similar a 'jgarcia'.
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Introduzca su dirección de correo electrónico. Es necesaria en caso de perder la clave de acceso. Respetamos su privacidad y su cuenta de correo electrónico nunca será revelada ni facilitada a terceros."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Introducir el porcentaje de descuento"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Introducir un porcentaje, p.ej. 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Introducir un porcentaje, p.ej. 14.0. Este porcentaje se aplicará a todo el sistema, pero podrá ser sobreescrito individualmente para cada elemento."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Introducir un porcentaje, p.ej. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Introducir la latitud del punto de muestreo en grados (de 0 a 90) , minutos (de 0 a 59) y la orientación N/S"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Introducir la longitud del punto de muestreo en grados (de 0 a 90), minutos (0 a 59), segundos (0 a 59) y orientación E/W"
 
@@ -2106,7 +2100,7 @@ msgstr "Introducir la longitud del punto de muestreo en grados (de 0 a 90), minu
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr "Entidad"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Excluir de la factura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Resultado esperado"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Resultados esperados"
 
@@ -2161,19 +2155,19 @@ msgstr "Resultados esperados"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Caducados"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Fecha de caducidad"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (trabajo)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Mujer"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Campo"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Análisis de campo"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Campo de conservación"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Título del campo"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Fichero"
 
@@ -2226,19 +2216,19 @@ msgstr "Fichero"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nombre del fichero"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Primer nombre"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Fórmula"
 
@@ -2277,18 +2267,18 @@ msgstr "Fórmula"
 msgid "From"
 msgstr "Desde"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nombre completo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Muestra con fecha de asignación futura"
 
@@ -2298,7 +2288,7 @@ msgstr "Muestra con fecha de asignación futura"
 msgid "Generate report"
 msgstr "Generar reporte"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de cortesía, como p.ej. Sr., Sra. o Dr."
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr "Agrupar por"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Período de agrupamiento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Peligroso"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Campo Oculto"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Horas"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2349,8 +2339,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID Server URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID Server no disponible"
 
@@ -2358,31 +2348,31 @@ msgstr "ID Server no disponible"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Seleccionar el cálculo asociado al análisis si es necesario. Los cálculos pueden ser configurados en el apartado 'Cálculos'"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Método de conservación del contenedor."
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importación"
@@ -2452,7 +2442,7 @@ msgstr "Importación"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importados"
@@ -2461,8 +2451,8 @@ msgstr "Importados"
 msgid "In-lab calibration procedure"
 msgstr "Procedimiento de calibración en el laboratorio"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Incluir descripciones"
 
@@ -2487,30 +2477,27 @@ msgstr "Incluir descripciones"
 msgid "Include year in ID prefix"
 msgstr "Incluir el año en el prefijo ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Resultado indeterminado"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indica si es necesaria la adjunción de ficheros para este análisis y, por lo tanto, si la opción de carga de fichero estará disponible en las pantallas de captura de datos."
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisión inicial"
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr "Instrucciones para rutinas de calibramiento de laboratorio  destinados a
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instrucciones para rutinas preventivas y mantenimiento destinados a los analistas"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Equipo"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Calibramiento de Instrumentos"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr "Importación desde equipo"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Mantenimiento de Instrumentos"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Tareas Programadas de Instrumentos"
 
@@ -2587,19 +2574,19 @@ msgstr "Tareas Programadas de Instrumentos"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Tipo de Instrumento"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validaciones de Instrumento"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr "Tipo de equipo"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Equipos"
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Excluido de facturación"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "El elemento está inactivo."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Elementos que deben incluirse en el asunto del correo electrónico"
 
@@ -2756,7 +2740,7 @@ msgstr "Elementos que deben incluirse en el asunto del correo electrónico"
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Cargo"
 
@@ -2764,12 +2748,12 @@ msgstr "Cargo"
 msgid "Key"
 msgstr "Clave"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Palabra clave"
@@ -2778,47 +2762,47 @@ msgstr "Palabra clave"
 msgid "Keywords"
 msgstr "Palabras clave"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratorio"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Análisis del laboratorio"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contactos del laboratorio"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Departamentos del laboratorio"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Conservación en el laboratorio"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Productos del laboratorio"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL del laboratorio"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etiqueta"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorio"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorio acreditado"
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Última modificación"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Con retraso"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Análisis con retraso"
@@ -2854,7 +2838,7 @@ msgstr "Análisis con retraso"
 msgid "Late Analysis"
 msgstr "Análisis con retraso"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitud"
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Muestra vinculada"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr "Listar todas las muestras recibidas para un rango de fecha"
 msgid "Load Setup Data"
 msgstr "Carga de datos iniciales"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Aquí puede cargar los documentos que describen el método"
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Cargado"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Registro"
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitud"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Número de lote"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Dirección de correo electrónico"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Mantenedor"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Tipo de mantenimiento"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Hombre"
 
@@ -2999,16 +2983,16 @@ msgstr "Hombre"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Correo del responsable"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Teléfono del responsable"
 
@@ -3016,31 +3000,25 @@ msgstr "Teléfono del responsable"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabricante"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Fabricantes"
 
@@ -3049,14 +3027,14 @@ msgstr "Fabricantes"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Tiempo máximo"
 
@@ -3064,30 +3042,30 @@ msgstr "Tiempo máximo"
 msgid "Maximum columns per results email"
 msgstr "Número máximo de columnas en los resultados por correo electrónico"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Tamaño o volumen máximo admitidos por muestra"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Tiempo máximo permitido para la consecución de un análisis. El sistema mostrará una alerta para los análisis con retraso"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Tiempo máximo de respuesta"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "% de descuento para clientes habituales"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Aplicar descuento de cliente habitual"
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Método"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Documento del método"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instrucciones del método"
 
@@ -3123,9 +3101,9 @@ msgstr "Método: ${method_name}"
 msgid "Method: None"
 msgstr "Método: ninguno"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Métodos"
 
@@ -3133,17 +3111,17 @@ msgstr "Métodos"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Métodos que está previsto que sean acreditados próximamente por ${accreditation_body}. Los comentarios y observaciones no estan acreditados."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3155,8 +3133,8 @@ msgstr "Mine"
 msgid "Minimum 5 characters."
 msgstr "Tamaño mínimo de 5 caracteres"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volumen mínimo"
 
@@ -3164,27 +3142,27 @@ msgstr "Volumen mínimo"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para los cálculos estadísticos de QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutos"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Teléfono móvil"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modelo"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr "Más"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nombre"
 
@@ -3225,17 +3203,17 @@ msgstr "Nombre"
 msgid "New"
 msgstr "Nuevo"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "No"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "No hay Solicitud de Análisis que coincida con su busqueda"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Ningún análisis seleccionado"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "No se han encontrado análisis que coincidan con el criterio de búsqueda"
 
@@ -3274,23 +3252,23 @@ msgstr "No se han añadido análisis"
 msgid "No analyses were added to this worksheet."
 msgstr "No se han añadido análisis en esta hoja de trabajo"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "No ha seleccionado ningún servicio de análisis."
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Sin cambios."
 
@@ -3298,7 +3276,7 @@ msgstr "Sin cambios."
 msgid "No control type specified"
 msgstr "No se ha indicado el tipo de control"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr "No se han indicado contenedores por defecto para este servicio"
 msgid "No default preservations specified for this service"
 msgstr "No se han indicado conservaciones para este servicio "
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "No hay acción historica que coincida con su busqueda"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "No se ha seleccionado ningún elemento"
 
@@ -3328,7 +3306,7 @@ msgstr "No se ha seleccionado ningún elemento"
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "No ha seleccionado ninguna muestra de referencia"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "No existen muestras que coincidan con su busqueda"
 
@@ -3365,25 +3343,22 @@ msgstr "No hay datos de acceso registrados para el contacto ${contact_fullname},
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Ninguno"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "No permitido"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Número de solicitudes de análisis y análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Número de solicitudes de análisis y análisis por cliente"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Número de análisis"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Número de análisis fuera de rango por periodo"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Número de análisis solicitados por servicio de análisis"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Número de análisis solicitados por tipo de muestra"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Número de análisis reprocesados por periodo"
 
@@ -3454,15 +3429,15 @@ msgstr "Número de análisis reprocesados por periodo"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Número de análisis solicitados y publicados por departamento y expresados como porcentaje en relación a todos los análisis realizados"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Número de solicitudes"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Número de muestras"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "La muestra será descartada durante el periodo de tiempo indicado cuando se le asigne el estado de conservación. Si no se indica nada, se utilizará el periodo de retención por tipo de muestra."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Abierto"
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr "Pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Fecha de pedido"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID de pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Número de pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Pedidos"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Otros reportes de productividad"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Partición"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr "Contraseña"
 msgid "Password lifetime"
 msgstr "Tiempo de vida de las contraseñas"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pendiente"
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr "Periodo"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Permitido"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "% de error permitido"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Teléfono"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Teléfono (negocio)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Teléfono (casa)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Teléfono (móvil)"
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Dirección postal"
 
@@ -3678,7 +3647,7 @@ msgstr "Dirección postal"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Des de aquí puede restringir los resultados del análisis a opciones específicas. Por ejemplo, si solo desea que se puedan escoger como resultado alguna de las opciones 'Positivo', 'Negativo' o 'Indeterminado'. El valor de la opción tiene que ser numérico."
 
@@ -3686,19 +3655,19 @@ msgstr "Des de aquí puede restringir los resultados del análisis a opciones es
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Por favor, añada el logotipo autorizado para emplear en su sitio web y en los informes de resultados de su entorno acreditativo. El tamaño máximo es de 175 x 175 píxeles."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Punto de muestreo"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posición"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Dirección postal"
 
@@ -3721,16 +3690,16 @@ msgstr "Dirección postal"
 msgid "Postal code"
 msgstr "Código postal"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "En pre-conservación"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Precisión en el número de decimales"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefijo"
 
@@ -3766,12 +3735,12 @@ msgstr "Prefijo"
 msgid "Prefixes"
 msgstr "Prefijos"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Conservación"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Categoría de conservación"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Conservaciones"
 
@@ -3814,14 +3783,14 @@ msgstr "Conservaciones"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Conservador"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Preventivo"
 
@@ -3829,34 +3798,34 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedimiento de mantenimiento preventivo"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Importe"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Importe (sin IVA)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Importe sin IVA"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Lista de precios"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr "Fecha de impresión:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr "Informes de productividad"
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Perfil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Perfiles de análisis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Identificador del perfil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Clave identificativa del perfil"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr "Público. Retraso"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr "Preferencias de publicación"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publicado"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Solicitudes de análisis publicadas que están pendientes de facturar"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr "Cantidad"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Umbral máximo"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Umbral mínimo"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Especificaciones de rango"
 
@@ -4031,9 +4000,9 @@ msgstr "Recibir"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Recibida"
 
@@ -4041,11 +4010,11 @@ msgstr "Recibida"
 msgid "Recept. Lag"
 msgstr "Retraso Recepción."
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referencia"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Definición de referencia"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Definiciones de referencia"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Muestra de referencia"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Muestras de referencia"
 
@@ -4086,16 +4055,16 @@ msgstr "Muestras de referencia"
 msgid "Reference Supplier"
 msgstr "Proveedor de muestras de referencia"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Tipo de referencia"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valores de referencia"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Análisis de control de calidad QC estándar"
@@ -4104,7 +4073,7 @@ msgstr "Análisis de control de calidad QC estándar"
 msgid "Reference analysis quality control graphs"
 msgstr "Gráficos de análisis de control de calidad estándar"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Gráficos de control de calidad en análisis de referencia"
 
@@ -4112,21 +4081,21 @@ msgstr "Gráficos de control de calidad en análisis de referencia"
 msgid "Reference sample"
 msgstr "Muestra de referencia"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Los valores para las muestras de referencia son cero o 'blanco'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition representa una definición de referencia o un tipo de muestra que se utiliza para las pruebas de control de calidad"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Comentarios"
 
@@ -4169,7 +4138,7 @@ msgstr "Comentarios"
 msgid "Remarks to take into account before calibration"
 msgstr "Observaciones a tener en cuenta antes de la calibración"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Observaciones a tener en cuenta antes de ejecutar la tarea"
 
@@ -4177,7 +4146,7 @@ msgstr "Observaciones a tener en cuenta antes de ejecutar la tarea"
 msgid "Remarks to take into account before validation"
 msgstr "Observaciones a tener en cuenta antes de la validación"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Observaciones a tener en cuenta para proceso de mantenimiento"
 
@@ -4186,8 +4155,8 @@ msgstr "Observaciones a tener en cuenta para proceso de mantenimiento"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Reparar"
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr "Análisis repetidos"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Informes"
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Tipo de informe"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Informar como materia seca"
 
@@ -4242,7 +4211,7 @@ msgstr "Reportar tablas para un período de tiempo del número de muestras recib
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Reportar tablas de Solicitudes de Análisis y totales entregados entre un período de tiempo"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Tipo de informe"
 
@@ -4250,7 +4219,7 @@ msgstr "Tipo de informe"
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Informes"
 
@@ -4259,15 +4228,15 @@ msgstr "Informes"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Solicitud"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID de la solicitud"
 
@@ -4275,26 +4244,26 @@ msgstr "ID de la solicitud"
 msgid "Request new analyses"
 msgstr "Solicitar nuevos análisis"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Solicitados"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Solicitudes"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Campo obligatorio"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volumen necesario"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Restringir las categorías"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultado"
 
@@ -4316,15 +4285,15 @@ msgstr "Resultado"
 msgid "Result Footer"
 msgstr "Pie de página"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opciones para resultados"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valor de los resultados"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr "El resultado está fuera de rango"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Resultados por punto de muestreo"
@@ -4375,14 +4344,14 @@ msgstr "Resultados por punto de muestreo"
 msgid "Results per samplepoint and analysis service"
 msgstr "Resultados por punto de muestreo y servicio de análisis"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Período de retención"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Prueba repetida"
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Tratamiento"
 
@@ -4434,19 +4403,19 @@ msgstr "Tratamiento"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Como en el caso anterior, pero para servicios de análisis. Este parámetro se puede establecer individualmente para cada análisis en su propia configuración."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Muestra"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr "Muestra pendiente"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID de muestra"
 
@@ -4468,12 +4437,12 @@ msgstr "Tamaño del ID de la muestra"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Soportes de las muestras"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Soporte de la muestra"
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Particiones de muestras"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Punto de muestreo"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Puntos de muestreo"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Tipo de muestra"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefijo del tipo de muestra"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Tipos de muestras"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Punto de muestreo"
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Reportes de muestras relacionadas"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Tipo de muestra"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Muestreador"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Muestras"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Las muestras de este tipo deben ser tratadas como peligrosas"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Muestras recibidas vs. reportadas"
@@ -4620,62 +4589,62 @@ msgstr "Muestras recibidas vs. reportadas"
 msgid "Samples received vs. samples reported"
 msgstr "Muestras recibidas vs. muestras reportadas"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Fecha de muestreo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Desviación en el muestreo"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Desviaciones en el muestreo"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Frecuencia de muestreo"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Guardar"
 
@@ -4700,17 +4669,17 @@ msgstr "Guardar comentarios"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Tarea programada"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr "Buscar"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Segundos"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Seleccione una interfaz de datos"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Seleccione un método de conservación para el servicio de análisis. Si el método de preservación depende de la combinación de tipos de muestra, especifique un método de preservación por tipo de muestra de la tabla siguiente."
 
@@ -4751,11 +4720,11 @@ msgstr "Seleccione un método de conservación para el servicio de análisis. Si
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Seleccione el destino y la solicitud de análisis a ser duplicada."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Seleccione alguno de los responsables que están registrados en el apartado 'Contactos del laboratorio'. El sistema incluye los nombres de los responsables de departamento a todos los informes de análisis que le pertenecen."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr "Seleccionar todos los elementos"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Seleccionar los análisis a ser incluidos en la plantilla"
 
@@ -4779,11 +4748,11 @@ msgstr "Seleccionar el analista"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Indique si los análisis no deben facturarse"
 
@@ -4791,19 +4760,19 @@ msgstr "Indique si los análisis no deben facturarse"
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Indique si es necesario incluir las descripciones"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr "Seleccione la moneda que se debe utilizar al mostrar los importes."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Seleccionar el contenedor por defecto que debe utilizarse para este servicio de análisis. Si el contenedor depende de la combinación del tipo de muestra y del método de conservación, especificar el contenidor específico para el tipo de de muestra."
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Seleccione el equipo deseado"
 
@@ -4849,7 +4818,7 @@ msgstr "Seleccione el equipo deseado"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr "Seleccione esta casilla para activar el flujo de trabajo de los pasos pa
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Seleccione qué análisis desea incluir a la hoja de trabajo"
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr "Separar"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Contenedor separado"
 
@@ -4909,32 +4878,28 @@ msgstr "Contenedor separado"
 msgid "Serial No"
 msgstr "Nº de serie"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Servicio"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "El servicio está acreditado por ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Servicios"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Asignar la tarea de mantenimiento como cerrada"
 
@@ -4942,31 +4907,31 @@ msgstr "Asignar la tarea de mantenimiento como cerrada"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Número máximo de resultados de solicitudes de análisis por correo electrónico. Tened en cuenta que demasiadas columnas de resultados en un correo electrónico puede comprometer la lectura."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Configurar las especificaciones del laboratorio para los resultados del servicio de análisis"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Dirección de envío"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Solo muestra las categorías seleccionadas a las vistas de cliente"
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Firma"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Tamaño"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Especificaciones"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Tamaño de la hoja de trabajo, como por ejemplo el número de posiciones para muestras de un equipo concreto. Si selecciona muestras de QC, seleccionad también qué muestras de referencia deben utilizarse. Si habéis escogido un análisis duplicado, indicad también en qué posición se encuentra el duplicado"
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Estado"
 
@@ -5081,33 +5042,33 @@ msgstr "Estado"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Tramitar"
 
@@ -5115,37 +5076,34 @@ msgstr "Tramitar"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Proveedores"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Apellidos"
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Tarea"
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Tipo de tarea"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descripción técnica e instrucciones para los analistas"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Selección del perfil de solicitud de análisis para esta plantilla"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "ID asignado por el laboratorio a la solicitud del cliente"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "ID asignado por el laboratorio a la muestra del cliente"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Dirección web del laboratorio"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Normativa de la acreditación, p.ej. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Análisis de este perfil, agrupados por categoría"
 
@@ -5249,7 +5207,7 @@ msgstr "El análisis que debe ser usado para determinar la materia seca"
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Analista o agente responsable de la calibración"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Analista o agente responsable del mantenimiento"
 
@@ -5257,12 +5215,12 @@ msgstr "Analista o agente responsable del mantenimiento"
 msgid "The analyst responsible of the validation"
 msgstr "Analista responsable de la validación"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Ficheros adjuntos vinculados a las solicitudes de análisis y análisis"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Categoría a la que pertenece el servicio de análisis"
 
@@ -5270,19 +5228,19 @@ msgstr "Categoría a la que pertenece el servicio de análisis"
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "El tipo de contenedor por defecto. Para las nuevas particiones de muestras se les asignará por defecto este contenedor, a menos que se haya indicado un contenedor específico para el servicio de análisis"
 
@@ -5294,7 +5252,7 @@ msgstr "El porcentaje de descuento solo se aplicará a clientes que estén etiqu
 msgid "The full URL: http://URL/path:port"
 msgstr "Dirección URL completa: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Altura o profundidad del muestreo"
 
@@ -5311,24 +5269,24 @@ msgstr "Número de modelo del equipo"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "El laboratorio no está acreditado o no se ha configurado."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Departamento del laboratorio"
@@ -5345,27 +5303,27 @@ msgstr "Número de ceros de relleno en los identificadores de muestra."
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Número de ceros de relleno del número y identificador de una solicitud de análisis"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "La lista de puntos de muestreo de desde poden ser recogidas las muestras de este tipo. Si no selecciona ningún punto de muestreo, entonces estarán disponibles todos los puntos de muestreo."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Lista de tipos de muestra que pueden ser recogidos en este punto de muestreo. Si no selecciona ningún tipo de muestra, entonces estarán disponibles todos los tipos de muestra."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Las unidades de medida para el resultado de este servicio de análisis, como mg/l, ppm, dB, mV, etc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Volumen mínimo de muestra necesario para efectuar el análisis (por ejemplo, '10 ml' o '1 kg')."
 
@@ -5389,7 +5347,7 @@ msgstr "Número de días antes que caduque la contraseña. Si desea que la contr
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "El número de días antes que caduque la muestras sin que pueda ser analizada más. Esta propiedad puede ser sobreescrita individualmente para cada tipo de muestra desde la página de configuración de tipos de muestras."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr "El número de solicitudes de análisis"
 msgid "The number of requests and analyses per client"
 msgstr "El número de solicitudes y análisis por cliente"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Periodo de tiempo durante el que se pueden mantener las muestras en un estado de no conservación antes que caduquen y no puedan ser analizadas."
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "El precio por análisis que se aplicará a los clientes que tengan asignado el 'descuento por volumen'"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "La palabra clave del perfil se utiliza para identificarlo inequívocamente en los ficheros de importación. Debe ser único y no puede ser igual a ninguno de los identificadores utilizados en los campos de entrada de cálculos."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Código de referencia que la entidad de acreditación ha concedido al laboratorio."
 
@@ -5447,11 +5405,11 @@ msgstr "Código de referencia que la entidad de acreditación ha concedido al la
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Los resultados para el campo de análisis se capturarán durante el muestreo. Por ejemplo, la temperatura de una muestra de agua del río."
 
@@ -5459,7 +5417,7 @@ msgstr "Los resultados para el campo de análisis se capturarán durante el mues
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Número de serie que identifica inequívocamente al equipo"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "La configuración por defecto del sistema en relación a la política de archivos adjuntos asociados a una solicitud de análisis"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "El tiempo de respuesta de los análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "El tiempo de respuesta de los análisis en función del tiempo"
 
@@ -5507,7 +5465,7 @@ msgstr "El tiempo de repuesta de los análisis"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "El tiempo de respuesta de los análisis en función del tiempo"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "La palabra clave utilizada para identificar el servicio de análisis en los ficheros de importación para solicitudes de análisis e importaciones de resultados desde equipos."
 
@@ -5519,37 +5477,37 @@ msgstr "Sin resultados."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "No se ha podido activar el servicio de análisis porque el cálculo asociado no está activo."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "No ha sido posible desactivar el Servicio de Análisis porque hay cálculos que dependen de él."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr "El servicio no requiere de una partición por separado"
 msgid "This service requires a separate container."
 msgstr "Para este servicio es necesario utilizar un contenedor por separado"
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,13 +5527,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "El texto será añadido al pie de página de los informes de resultadosD"
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "El valor se indica debajo de todos los resultados publicados"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Título"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "A"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Por conservar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Por muestrear"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Pendiente de verificación"
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5671,22 +5625,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr "Total en Retraso"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Importe total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Total de análisis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Total de puntos de datos"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Importe total"
 
@@ -5698,11 +5652,11 @@ msgstr "Total:"
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Tiempo de respuesta (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipo"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sin asignar"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incertidumbre"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valor de incertidumbre"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "No definido"
 
@@ -5772,13 +5720,13 @@ msgstr "No definido"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unidades"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Por publicar"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Cargar una firma digitalizada para que sea imprimida en los informes de resultados. Las dimensiones idóneas son 250 píxels de ancho por 150 píxels de alto."
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr "Utilizar un ID server externo"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Utilizad estos campos para pasar parámetros arbitrarios al módulo de importación"
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Usuario"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nombre de usuario"
@@ -5868,7 +5816,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Historial de Usuarios"
@@ -5877,27 +5825,27 @@ msgstr "Historial de Usuarios"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "El uso de un número bajo de puntos de datos suele conllevar que los resultados del cálculo estadístico no tengan sentido. Estableced un número mínimo aceptable de resultados antes que se ejecuten los cálculos estadísticos de Control de Calidad (QC)"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "CIF"
 
@@ -5905,11 +5853,11 @@ msgstr "CIF"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Válido desde"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Válido hasta"
 
@@ -5917,181 +5865,181 @@ msgstr "Válido hasta"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validación"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "La validación ha fallado: '${keyword}': palabra clave duplicada"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "La validación ha fallado: '${title}': la palabra clave ya está en uso en el cálculo '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Error de validación: '${title}': Esta palabra clave ya está en uso por el servicio '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Error de validación: '${title}': título duplicado"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Error de validación: '${value}' no es único"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Ha fallado la validación: la orientación debe ser E/W (Este/Oeste)"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Ha fallado la validación: la orientación debe ser N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Error de validación: el porcentaje de error debe tener un valor entre 0 y 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Error de validación: los valores esperados deben estar dentro del rango de valores mínimo (Min) y máximo (Max)"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Error de validación: los valores esperados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Error de validación: la palabra clave '$ {palabra clave}' no es válida"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Error de validación: los valores máximos (Max) tienen que ser mayores que los valores mínimos (Min)"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Error de validación: los valores máximos (Max) tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Error de validación: los valores mínimos (Min) tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Error de validación: los porcentajes de error tienen que tener un valor entre 0 y 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Error de validación: los porcentajes de error tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Error de validación: los contenedores para la pre-conservación tienen que tener asignado un método de conservación."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Ha fallado la validación: los resultados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Error de validación: imprescindible seleccionar una de las categorías siguientes: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Error de validación: el título de columna '${title}' tiene que tener la palabra clave '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Error de validación: los grados son 180; el valor para minutos debe ser cero"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Error de validación: los grados son 180; el valor para los segundos debe ser cero"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Error de validación: los grados son 90; el valor de minutos debe ser cero"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Error de validación: los grados son 90; el valor de segundos debe ser cero"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Error de validación: los grados deben variar entre 0 - 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Ha fallado la validación: los grados tienen que estar entre 0 y 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Ha fallado la validación: los grados tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Error de validación: la palabra clave '${keyword}' tiene que tener '${title}' como título de columna"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Ha fallado la validación: el identificador contiene caracteres no válidos"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Error de validación: palabra clave requerida"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Ha fallado la validación: los minutos tienen que estar entre 0 y 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Ha fallado la validación: los minutos tienen que ser de tipo numérico"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Ha fallado la validación: los segundos tienen que estar entre 0 y 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Ha fallado la validación: los segundos tienen que ser de tipo numérico"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Error de validación: título requerido"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Validador"
@@ -6110,12 +6058,12 @@ msgstr "Validador"
 msgid "Value"
 msgstr "Valor"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Los valores ingresados aquí anularan los establecidos en los campos de la sección de Cálculo Provisional"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificado"
@@ -6126,7 +6074,7 @@ msgstr "Verificado"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versión"
 
@@ -6136,11 +6084,11 @@ msgstr "Versión"
 msgid "Volume"
 msgstr "Volumen"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Dirección de correo electrónico de la entidad acreditadora"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Si la diferencia porcentual entre los resultados de una réplica de análisis en la hoja de trabajo para la misma muestra y análisis es mayor que este valor, el sistema lo notificará con una alerta."
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Trabajo Realizado"
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Hoja de trabajo"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Diseño de la hoja de trabajo"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Plantillas para hojas de trabajo"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Hojas de trabajo"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Si"
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Debe seleccionar un equipo"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "acción"
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "comentario"
 
@@ -6281,36 +6229,8 @@ msgstr "comentario"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr "desactivar"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "repitiendo cada"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "período de repetición"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr "summary_content_listing"
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr "hasta"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "hasta"
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/es_UY/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/es_UY/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Spanish (Uruguay) (http://www.transifex.com/bikalabs/bika-lims/language/es_UY/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/fa/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/bika.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (http://www.transifex.com/bikalabs/bika-lims/language/fa/)\n"
@@ -26,49 +26,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -98,15 +98,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -118,15 +118,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -139,7 +139,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -148,32 +148,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -184,16 +178,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgstr "گزینه پیوست تقاضا"
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -213,17 +207,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -231,54 +225,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "نام حساب"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "شماره حساب"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "نوع حساب"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "اعتبار سازی"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "لوگو سازمان همکار"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "اکردیته شده"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -292,21 +286,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "فعال"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "افزودن"
 
@@ -326,11 +320,7 @@ msgstr "افزودن رفرنس کنترلی"
 msgid "Add Duplicate"
 msgstr "همانند سازی"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -338,16 +328,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -360,26 +350,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "همه"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "همه آزمونهای اختصاصی"
 
@@ -391,7 +381,7 @@ msgstr "همه انواع آزمونها"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -399,15 +389,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -415,11 +405,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -427,48 +417,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "مقدار"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "آزمونها"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "آزمونهای خارج ار محدوده"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "آزمونهای  نوع نمونه"
@@ -482,7 +472,7 @@ msgstr "آزمونهای مربوط به خدمات"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -495,27 +485,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "آزمون تکرار شده"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "آزمون"
 
@@ -523,52 +513,52 @@ msgstr "آزمون"
 msgid "Analysis Attachment Option"
 msgstr "گزینه پیوست به آزمون"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "طبقه بندیهای آزمون"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "طبقه بندی آزمونها"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "کلید واژه آزمون"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "پروفایل آزمون"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "شناسه درخواست آزمون"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "ورودیهای درخواست آزمون"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -576,65 +566,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "درخواستهای آزمون"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "خدمات آزمون"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "مجموعه خدمات آزمون"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "نوع آزمون"
@@ -643,46 +633,46 @@ msgstr "نوع آزمون"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "درخواستهای آزمون و آزمونها"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "درخواستهای آزمون و آزمونها برای مشتری"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "درخواستهای آزمون بدون فاکتور"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -690,12 +680,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -711,17 +701,17 @@ msgstr "زمان لازم برای آزمون"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "آنالیست"
 
@@ -730,7 +720,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "هر"
 
@@ -742,7 +732,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "بکار بردن الگو"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -760,15 +750,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -786,27 +776,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "پیوست به"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "پیوست"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "کلیدواژه گان پیوست"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "گزینه پیوست"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "نوع پیوست"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "انواع پیوست"
 
@@ -816,25 +806,25 @@ msgstr "انواع پیوست"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "پیوست مجاز نمی باشد"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "پیوست الزامیست"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "پیوستها"
 
@@ -846,7 +836,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -863,27 +853,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "شعبه بانک"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "نام بانک"
 
@@ -892,31 +882,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -924,7 +914,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -932,7 +922,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -940,63 +930,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "آدرس صورتحساب"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "شاهد"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "نام تجاری"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "قیمت عمده( بدون ارزش افزوده)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "تلفن محل کار"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "کپی ایمیلها"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "محاسبه"
 
@@ -1004,8 +998,8 @@ msgstr "محاسبه"
 msgid "Calculation Formula"
 msgstr "فرمول محاسبه"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "فیلدهای حین محاسباتی"
@@ -1018,11 +1012,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "محاسبات"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1034,12 +1028,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1053,9 +1047,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "کنسل شده"
 
@@ -1071,18 +1065,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "گنجایش"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1091,7 +1085,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "شماره کاتالوگ"
 
@@ -1099,17 +1093,17 @@ msgstr "شماره کاتالوگ"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "طبقه"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "این طبقه غیر فعال نمی شود زیرا حاوی خدمات آزمون می باشد"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1122,31 +1116,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "اگر خدمات آزمون شامل محدوده کاری مجاز آزمایشگاه است اینجا را علامت بزنید"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "اگر آزمایشگاه شما همکار سازمان یا مجاز می باشد اینجا را علامت بزنید"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1154,7 +1148,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1170,19 +1164,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "کلاسیک"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1190,19 +1184,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1210,59 +1204,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "نام مشتری"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "سفارش مشتری"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "شناسه نمونه مشتری"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "رابط مشتری باید قبل از ثبت درخواست لازم است"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1271,39 +1265,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "بسته شد"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1311,21 +1305,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "مختلط"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1334,13 +1328,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "مخاطب"
@@ -1349,8 +1343,8 @@ msgstr "مخاطب"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "مخاطبین"
@@ -1359,48 +1353,48 @@ msgstr "مخاطبین"
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "گنجانه"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "نوع گنجانه"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "انواع گنجانه"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "نوع محتویات"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "کنترل"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1416,12 +1410,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1434,18 +1428,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1453,7 +1447,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1461,8 +1455,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1470,12 +1464,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "جاری"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1488,7 +1482,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1502,88 +1496,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "تاریخ"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "تاریخ ارسال"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "تاریخ بررسی"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "تاریخ منقضی شده"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "تاریخ وارد شده"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "تاریخ بارگیری"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "تاریخ افتتاح"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "تاریخ انتشار"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "تاریخ دریافت"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "تاریخ درخواست"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "تاریخ نمونه برداری"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1599,7 +1593,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1617,7 +1611,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1626,11 +1620,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "روزها"
 
@@ -1642,17 +1636,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "پیش فرض"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1660,49 +1654,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1711,11 +1705,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1739,11 +1733,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "مقدار پیش فرض"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1751,7 +1745,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1759,11 +1753,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1771,16 +1765,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "درجه ها"
 
@@ -1788,9 +1782,9 @@ msgstr "درجه ها"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "دپارتمان"
 
@@ -1803,13 +1797,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "آزمونهای وابسته"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "شرح"
 
@@ -1817,7 +1811,7 @@ msgstr "شرح"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1825,19 +1819,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1845,7 +1839,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "٪ تخفیف"
 
@@ -1853,16 +1847,16 @@ msgstr "٪ تخفیف"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "ارسال شده"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "مقدلر نمایش"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1874,7 +1868,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1883,8 +1877,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "آماده"
@@ -1893,54 +1887,54 @@ msgstr "آماده"
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "تعطیل"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1953,20 +1947,20 @@ msgstr "خشک"
 msgid "Dry matter analysis"
 msgstr "آزمون ماده خشک"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "مقرر"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "موعد مقرر"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1975,20 +1969,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "تکرار"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "تکراری از"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -2000,35 +1994,35 @@ msgstr "کنترل کیفیت آزمون تکراری"
 msgid "Duplicate analysis quality control graphs"
 msgstr "گرافهای کنترل کیفیت آزمون تکراری"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "مدت"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "زود رسی"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "ترفیع"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "پست الکترونیک"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "آدرس پست الکترونیک"
 
@@ -2036,7 +2030,7 @@ msgstr "آدرس پست الکترونیک"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "موضوع پست الکترونیک"
 
@@ -2056,14 +2050,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2075,16 +2069,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "میزان تخفیف را وارد کنید"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "ارزش را به درصد وارد شود"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2092,15 +2086,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2108,7 +2102,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2116,45 +2110,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "حذف از فاکتور"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "نتیجه مورد انتظار"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2163,19 +2157,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "منقضی"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "تاریخ انقضا"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2183,44 +2177,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "فاکس"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "فاکس( محل کار)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "زن"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "فیلد"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "فیلد آزمونها"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "فیلد عنوان"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "فایل"
 
@@ -2228,19 +2218,19 @@ msgstr "فایل"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "نام فایل"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2260,16 +2250,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "نام"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "فرمول"
 
@@ -2279,18 +2269,18 @@ msgstr "فرمول"
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "نام کامل"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2300,7 +2290,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "عنوان افراد مانند آقا، خانم، دکتر، غیره"
 
@@ -2312,37 +2302,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "خطرناک"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "ساعات"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "شناسه"
@@ -2351,8 +2341,8 @@ msgstr "شناسه"
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2360,31 +2350,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2396,7 +2386,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2404,27 +2394,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2432,7 +2422,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2445,7 +2435,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "وارد کردن"
@@ -2454,7 +2444,7 @@ msgstr "وارد کردن"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "وارده"
@@ -2463,8 +2453,8 @@ msgstr "وارده"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2473,7 +2463,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2481,7 +2471,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "شامل توضیحات"
 
@@ -2489,30 +2479,27 @@ msgstr "شامل توضیحات"
 msgid "Include year in ID prefix"
 msgstr "شامل ارسال در پیشوند شناسه"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "تجدید نظر اولیه"
 
@@ -2536,7 +2523,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2549,17 +2536,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "دستگاه"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2572,16 +2559,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2589,19 +2576,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2645,9 +2632,9 @@ msgstr "نوع دستگاه"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "تجهیزات"
 
@@ -2671,7 +2658,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2687,24 +2674,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2712,43 +2696,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "حذف فاکتور"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "آیتم غیر فعال است"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2758,7 +2742,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "عنوان شغلی"
 
@@ -2766,12 +2750,12 @@ msgstr "عنوان شغلی"
 msgid "Key"
 msgstr "کلید"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "کلید واژه"
@@ -2780,47 +2764,47 @@ msgstr "کلید واژه"
 msgid "Keywords"
 msgstr "کلید واژه ها"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "آزمایشگاه"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "آزمونهای آزمایشگاه"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "مخاطبین آزمایشگاه"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "دپارتمانهای آزمایشگاه"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "محصولات آزمایشگاه"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "آدرس سایت آزمایشگاه"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "آزمایشگاه"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "آزمایشگاه همکار"
 
@@ -2840,13 +2824,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "آخرین ویرایش"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "اخیر"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "آخرین آزمونها"
@@ -2856,7 +2840,7 @@ msgstr "آخرین آزمونها"
 msgid "Late Analysis"
 msgstr "آخرین آزمون"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "عرض جغرافیایی"
 
@@ -2878,11 +2862,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "نمونه مرتبط"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2894,7 +2878,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2906,41 +2890,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "گزارش (log)"
@@ -2965,35 +2949,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "طول جغرافیایی"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "سری ساخت"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "آدرس پستی"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "مرد"
 
@@ -3001,16 +2985,16 @@ msgstr "مرد"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "مدیر"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "ایمیل مدیر"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "تلفن مدیر"
 
@@ -3018,31 +3002,25 @@ msgstr "تلفن مدیر"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "تولید کننده"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3051,14 +3029,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "حداکثر"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "حداکثر زمان"
 
@@ -3066,30 +3044,30 @@ msgstr "حداکثر زمان"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "حداکثر ابعاد یا حجم ممکن نمونه"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "حداکثر زمان چرخش کار"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "٪ تخفیف عضو"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "تخفیف اعمال شده عضو"
 
@@ -3098,22 +3076,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "روش"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "سند روش"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "روش کار"
 
@@ -3125,9 +3103,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "روشها"
 
@@ -3135,17 +3113,17 @@ msgstr "روشها"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "حداقل"
 
@@ -3157,8 +3135,8 @@ msgstr "مال من"
 msgid "Minimum 5 characters."
 msgstr "حداقل ۵ کاراکتر"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3166,27 +3144,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "دقیقه"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "تلفن همراه"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "مدل"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3200,7 +3178,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3212,13 +3190,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "نام"
 
@@ -3227,17 +3205,17 @@ msgstr "نام"
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3253,18 +3231,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "هیچ آزمونی انتخاب نشده است"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3276,23 +3254,23 @@ msgstr "هیچ آزمونی اضافه نشده است"
 msgid "No analyses were added to this worksheet."
 msgstr "هیچ انالیزی در این کاربرگ اضافه نشده است"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3300,7 +3278,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr "هیچ نوع کنترلی مشخص نشده"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3312,17 +3290,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3330,7 +3308,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3340,16 +3318,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3367,25 +3345,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "هیچکدام"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "مجاز نیست"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3405,19 +3380,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3425,30 +3400,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3456,15 +3431,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3473,31 +3448,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "تعداد نمونه ها"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3505,15 +3480,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "باز کردن"
@@ -3526,26 +3498,26 @@ msgstr ""
 msgid "Order"
 msgstr "سفارش دادن"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "تاریخ سفارش"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "شناسه سفارش"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "تعداد سفارش"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "سفارشات"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3553,7 +3525,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3565,8 +3537,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3578,16 +3550,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3608,8 +3577,8 @@ msgstr "رمز عبور"
 msgid "Password lifetime"
 msgstr "طول عمر رمز عبور"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "در انتظار"
@@ -3634,31 +3603,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "مجاز"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "٪ خطای مجاز"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "شماره تماس"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "تلفن(محل کار)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "تلفن(منزل)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "تلفن( همراه)"
 
@@ -3671,8 +3640,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "آدرس فیزیکی"
 
@@ -3680,7 +3649,7 @@ msgstr "آدرس فیزیکی"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3688,19 +3657,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Point of Capture"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3709,13 +3678,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "موقعیت"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "آدرس پستی"
 
@@ -3723,16 +3692,16 @@ msgstr "آدرس پستی"
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "قبل از نگهداری"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "دقت بر اساس ارقام اعشاری"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3760,7 +3729,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3768,12 +3737,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr "پیشوندها"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3785,17 +3754,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "نگهداری"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "طبقه بندی نگهداری"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3806,7 +3775,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3816,14 +3785,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3831,34 +3800,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "قیمت"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "قیمت ( بدون ارزش افزوده)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "قیمت بدون ارزش افزوده"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "لیست قیمت برای"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3873,13 +3842,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3896,34 +3865,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "پروفایل"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "پروفایل آزمون"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "کلید مشخصات"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "کلیدواژه پروفایل"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "پروفایلها"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3931,7 +3900,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3946,21 +3915,21 @@ msgstr "اولویت نشر"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "منتشر شده"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3973,8 +3942,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3995,23 +3964,23 @@ msgstr "مقدار"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "محدوده حداکثر"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "محدوده حداقل"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4033,9 +4002,9 @@ msgstr "دریافت"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "دریافت شده"
 
@@ -4043,11 +4012,11 @@ msgstr "دریافت شده"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4056,31 +4025,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "مرجع"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "تعریف مرجع"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "تعاریف مرجع"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "نمونه های مرجع"
 
@@ -4088,16 +4057,16 @@ msgstr "نمونه های مرجع"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "نوع مرجع"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4106,7 +4075,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4114,21 +4083,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "مقادیر نمونه مرجع صفر یا blank می باشد"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4151,8 +4120,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4161,9 +4130,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "اظهارات"
 
@@ -4171,7 +4140,7 @@ msgstr "اظهارات"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4179,7 +4148,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4188,8 +4157,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4198,7 +4167,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "گزارش"
 
@@ -4212,14 +4181,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "گزارش بر اساس ماده خشک"
 
@@ -4244,7 +4213,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4252,7 +4221,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4261,15 +4230,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "شناسه درخواست"
 
@@ -4277,26 +4246,26 @@ msgstr "شناسه درخواست"
 msgid "Request new analyses"
 msgstr "درخواست آزمونهای جدید"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "درخواستها"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "الزامی"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "حجم لازم"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4304,13 +4273,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "نتیجه"
 
@@ -4318,15 +4287,15 @@ msgstr "نتیجه"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "گزینه های نتیجه"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "مقدار نتیجه"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4344,11 +4313,11 @@ msgstr "نتیجه خارج از محدوده مجاز"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4356,7 +4325,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4364,11 +4333,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4377,14 +4346,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Retested"
@@ -4403,11 +4372,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4423,12 +4392,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "سلام و تهنیت"
 
@@ -4436,19 +4405,19 @@ msgstr "سلام و تهنیت"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "نمونه"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4457,8 +4426,8 @@ msgid "Sample Due"
 msgstr "نمونه های مقرر"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "شناسه نمونه"
 
@@ -4470,12 +4439,12 @@ msgstr "جزئیات شناسه نمونه"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4485,52 +4454,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "محل نمونه برداری"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "محلهای نمونه برداری"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "نوع نمونه"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "پیشوند نوع نمونه"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "انواع نمونه"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4540,9 +4509,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4570,17 +4539,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "نوع نمونه"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4590,30 +4559,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "نمونه ها"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "نمونه های این نوع باید خطرناک تلقی شوند"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4622,62 +4591,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "تاریخ نمونه برداری"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "تناوب نمونه برداری"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4687,9 +4656,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "ذخیره کردن"
 
@@ -4702,17 +4671,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4720,16 +4689,16 @@ msgstr ""
 msgid "Search"
 msgstr "جستجو"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "ثانیه"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4741,11 +4710,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4753,11 +4722,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4769,7 +4738,7 @@ msgstr "انتخاب تمام ایتمها"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4781,11 +4750,11 @@ msgstr "انتخاب انالیست"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4793,19 +4762,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4831,7 +4800,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4843,7 +4812,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4851,7 +4820,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4875,7 +4844,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4891,7 +4860,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4903,7 +4872,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4911,32 +4880,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "شماره سریال"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "خدمات"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "خدمات"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4944,31 +4909,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "تنظیم ویژگیهای نتایج خدمات آزمون آزمایشگاه"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "آدرس حمل"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4984,7 +4949,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4996,29 +4961,25 @@ msgstr ""
 msgid "Signature"
 msgstr "امضا"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "ابعاد"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5026,14 +4987,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5041,41 +5002,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "State"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "وضعیت"
 
@@ -5083,33 +5044,33 @@ msgstr "وضعیت"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "ارائه"
 
@@ -5117,37 +5078,34 @@ msgstr "ارائه"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "جمع کل"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "تامین کننده"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "نام خانوادگی"
 
@@ -5167,11 +5125,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5180,20 +5138,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "دما"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5211,35 +5169,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5251,7 +5209,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5259,12 +5217,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "پیوستهای مرتبط با درخواست آزمون و آزمونها"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5272,19 +5230,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5296,7 +5254,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5313,24 +5271,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5347,27 +5305,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5391,7 +5349,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5408,11 +5366,11 @@ msgstr "تعداد درخواستها و آزمونها"
 msgid "The number of requests and analyses per client"
 msgstr "تعداد درخواستها و آزمونهای هر مشتری"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5429,19 +5387,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5449,11 +5407,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5461,7 +5419,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5473,11 +5431,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5485,19 +5443,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5509,7 +5467,7 @@ msgstr "زمان رسیدگی آزمونها"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5521,37 +5479,37 @@ msgstr "هیچ نتیجه ای وجود ندارد"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "خدمات آزمون قابل فعال شدن نیست چرا که محاسبات مربوطه غیر فعال است"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "این خدمات آزمون را نمی توانید غیر فعال کنید چون یک یا چند محاسبه فعال به آن مربوط است"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5563,7 +5521,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5571,12 +5529,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5591,63 +5545,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "عنوان"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "باید تایید شود"
 
@@ -5659,13 +5613,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "جمع"
 
@@ -5673,22 +5627,22 @@ msgstr "جمع"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "مبلغ کل"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "مبلغ کل"
 
@@ -5700,11 +5654,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5712,61 +5666,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "نوع"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "عدم قطعیت"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "مقدار عدم قطعیت"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5774,13 +5722,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "واحد"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5805,17 +5753,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5827,11 +5775,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5839,7 +5787,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5851,13 +5799,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "کاربر"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "نام کاربری"
@@ -5870,7 +5818,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5879,27 +5827,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "مالیات ارزش افزوده"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "مقدار مالیات ارزش افزوده"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "شماره مالیات ارزش افزوده"
 
@@ -5907,11 +5855,11 @@ msgstr "شماره مالیات ارزش افزوده"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "معتبر از"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5919,181 +5867,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6101,7 +6049,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6112,12 +6060,12 @@ msgstr ""
 msgid "Value"
 msgstr "ارزش"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "تایید شده"
@@ -6128,7 +6076,7 @@ msgstr "تایید شده"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "ویرایش"
 
@@ -6138,11 +6086,11 @@ msgstr "ویرایش"
 msgid "Volume"
 msgstr "حجم"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6150,24 +6098,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6178,25 +6126,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "کاربرگ"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "طرح کاربرگ"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "الگوهای کاربرگ"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "کاربرگ ها"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6204,9 +6152,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6218,7 +6166,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6226,11 +6174,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "انتخاب دستگاه الزامیست"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6246,15 +6194,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6283,36 +6231,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6324,7 +6244,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6372,19 +6292,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6392,19 +6312,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6423,19 +6343,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6447,7 +6356,7 @@ msgstr ""
 msgid "to"
 msgstr "به"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6455,7 +6364,7 @@ msgstr ""
 msgid "type"
 msgstr "نوع"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6480,7 +6389,7 @@ msgstr "مقدار"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6492,6 +6401,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/fa_IR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fa_IR/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/bikalabs/bika-lims/language/fa_IR/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/fi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fi/LC_MESSAGES/bika.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/bikalabs/bika-lims/language/fi/)\n"
@@ -25,49 +25,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -97,15 +97,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -117,15 +117,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -138,7 +138,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -147,32 +147,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -183,16 +177,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -204,7 +198,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -212,17 +206,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -230,54 +224,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Asiakasnimi"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Asiakasnumero"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Asiakastyyppi"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akkreditointi"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -291,21 +285,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Lisää"
 
@@ -325,11 +319,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr "Lisää kopio"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -337,16 +327,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -359,26 +349,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Kaikki"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -390,7 +380,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -398,15 +388,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -414,11 +404,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -426,48 +416,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -481,7 +471,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -494,27 +484,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analyysit"
 
@@ -522,52 +512,52 @@ msgstr "Analyysit"
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -575,65 +565,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -642,46 +632,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -689,12 +679,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -710,17 +700,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -729,7 +719,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -741,7 +731,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -759,15 +749,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -785,27 +775,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Liitä"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Liite"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -815,25 +805,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -845,7 +835,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -862,27 +852,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -891,31 +881,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -923,7 +913,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -931,7 +921,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -939,63 +929,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Työpuhelin"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC sähköposti"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Laskenta"
 
@@ -1003,8 +997,8 @@ msgstr "Laskenta"
 msgid "Calculation Formula"
 msgstr "Laskentakaava"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1017,11 +1011,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Laskennat"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1033,12 +1027,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1052,9 +1046,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Peruutettu"
 
@@ -1070,18 +1064,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1090,7 +1084,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Luettelonumero"
 
@@ -1098,17 +1092,17 @@ msgstr "Luettelonumero"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1121,31 +1115,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1153,7 +1147,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1169,19 +1163,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klassinen"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1189,19 +1183,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1209,59 +1203,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Asiakas nimi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Asiakastilaus"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Asiakas viite"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1270,39 +1264,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1310,21 +1304,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Luotettavuustaso %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1333,13 +1327,13 @@ msgid "Confirm password"
 msgstr "Vahvista salasana"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontaktihenkilö"
@@ -1348,8 +1342,8 @@ msgstr "Kontaktihenkilö"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontaktit"
@@ -1358,48 +1352,48 @@ msgstr "Kontaktit"
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Säiliö"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Sisältötyyppi"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Tarkistus"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1415,12 +1409,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1433,18 +1427,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1452,7 +1446,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1460,8 +1454,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1469,12 +1463,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Nykyinen"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1487,7 +1481,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1501,88 +1495,88 @@ msgstr "Rajapinta"
 msgid "Data Interface Options"
 msgstr "Rajapintavaihtoehdot"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Päivämäärä"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Lähetyspäivämäärä"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Lähetyspäivämäärä"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Eräpäivämäärä"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Tuontipäivämäärä"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Pakkauspäivämäärä"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Avauspäivämäärä"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Julkaisupäivämäärä"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Vastaanottopäivämäärä"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Tiedustelupäivämäärä"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Näytteenotto pvm"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1598,7 +1592,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1616,7 +1610,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1625,11 +1619,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Päiviä"
 
@@ -1641,17 +1635,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1659,49 +1653,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1710,11 +1704,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1738,11 +1732,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Oletusarvo"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1750,7 +1744,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1758,11 +1752,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1770,16 +1764,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Astetta"
 
@@ -1787,9 +1781,9 @@ msgstr "Astetta"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Osasto"
 
@@ -1802,13 +1796,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -1816,7 +1810,7 @@ msgstr "Kuvaus"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1824,19 +1818,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1844,7 +1838,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Alennus %"
 
@@ -1852,16 +1846,16 @@ msgstr "Alennus %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Toimitettu"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Näyttöarvo"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1873,7 +1867,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1882,8 +1876,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Lähetetty"
@@ -1892,54 +1886,54 @@ msgstr "Lähetetty"
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1952,20 +1946,20 @@ msgstr "Kuiva"
 msgid "Dry matter analysis"
 msgstr "Kuiva-aine analyysit"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Voimassaolepvm"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1974,20 +1968,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Kopio"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1999,35 +1993,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Kesto"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Sähköposti"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Sähköpostiosoite"
 
@@ -2035,7 +2029,7 @@ msgstr "Sähköpostiosoite"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Sähköpostin aihe"
 
@@ -2055,14 +2049,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2074,16 +2068,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2091,15 +2085,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2107,7 +2101,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2115,45 +2109,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Oletustulos"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2162,19 +2156,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Vanhentunut"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2182,44 +2176,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (työ)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Kenttä"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Kenttäanalyysit"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Kentän nimi"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Tiedosto"
 
@@ -2227,19 +2217,19 @@ msgstr "Tiedosto"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Tiedostonimi"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2259,16 +2249,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Etunimi"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Kaava"
 
@@ -2278,18 +2268,18 @@ msgstr "Kaava"
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Koko nimi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2299,7 +2289,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2311,37 +2301,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Vaarallinen"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Tunnit"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2350,8 +2340,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2359,31 +2349,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2395,7 +2385,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2403,27 +2393,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2431,7 +2421,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2444,7 +2434,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Tuo"
@@ -2453,7 +2443,7 @@ msgstr "Tuo"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Tuotu"
@@ -2462,8 +2452,8 @@ msgstr "Tuotu"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2472,7 +2462,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2480,7 +2470,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2488,30 +2478,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2535,7 +2522,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2548,17 +2535,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2571,16 +2558,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2588,19 +2575,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2644,9 +2631,9 @@ msgstr "Laitetyyppi"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Laitteet"
 
@@ -2670,7 +2657,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2686,24 +2673,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2711,43 +2695,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2757,7 +2741,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Tehtävänimike"
 
@@ -2765,12 +2749,12 @@ msgstr "Tehtävänimike"
 msgid "Key"
 msgstr "Avain"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2779,47 +2763,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Laboratorioanalyysit"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorio"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2839,13 +2823,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Muutettu viimeksi"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2855,7 +2839,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2877,11 +2861,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2893,7 +2877,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2905,41 +2889,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2964,35 +2948,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -3000,16 +2984,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3017,31 +3001,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3050,14 +3028,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3065,30 +3043,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3097,22 +3075,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3124,9 +3102,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3134,17 +3112,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3156,8 +3134,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3165,27 +3143,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3199,7 +3177,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3211,13 +3189,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3226,17 +3204,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3252,18 +3230,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3275,23 +3253,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3299,7 +3277,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3311,17 +3289,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3329,7 +3307,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3339,16 +3317,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3366,25 +3344,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3404,19 +3379,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3424,30 +3399,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3455,15 +3430,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3472,31 +3447,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3504,15 +3479,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3525,26 +3497,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3552,7 +3524,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3564,8 +3536,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3577,16 +3549,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3607,8 +3576,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3633,31 +3602,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3670,8 +3639,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3679,7 +3648,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3687,19 +3656,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3708,13 +3677,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3722,16 +3691,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3759,7 +3728,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3767,12 +3736,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3784,17 +3753,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3805,7 +3774,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3815,14 +3784,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3830,34 +3799,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3872,13 +3841,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3895,34 +3864,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3930,7 +3899,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3945,21 +3914,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3972,8 +3941,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3994,23 +3963,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4032,9 +4001,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4042,11 +4011,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4055,31 +4024,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4087,16 +4056,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4105,7 +4074,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4113,21 +4082,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4150,8 +4119,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4160,9 +4129,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4170,7 +4139,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4178,7 +4147,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4187,8 +4156,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4197,7 +4166,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4211,14 +4180,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4243,7 +4212,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4251,7 +4220,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4260,15 +4229,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4276,26 +4245,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4303,13 +4272,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4317,15 +4286,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4343,11 +4312,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4355,7 +4324,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4363,11 +4332,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4376,14 +4345,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4402,11 +4371,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4422,12 +4391,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4435,19 +4404,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4456,8 +4425,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4469,12 +4438,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4484,52 +4453,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4539,9 +4508,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4569,17 +4538,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4589,30 +4558,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4621,62 +4590,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4686,9 +4655,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4701,17 +4670,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4719,16 +4688,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4740,11 +4709,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4752,11 +4721,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4768,7 +4737,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4780,11 +4749,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4792,19 +4761,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4830,7 +4799,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4842,7 +4811,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4850,7 +4819,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4874,7 +4843,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4890,7 +4859,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4902,7 +4871,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4910,32 +4879,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4943,31 +4908,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4983,7 +4948,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4995,29 +4960,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5025,14 +4986,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5040,41 +5001,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5082,33 +5043,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5116,37 +5077,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5166,11 +5124,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5179,20 +5137,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5210,35 +5168,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5250,7 +5208,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5258,12 +5216,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5271,19 +5229,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5295,7 +5253,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5312,24 +5270,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5346,27 +5304,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5390,7 +5348,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5407,11 +5365,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5428,19 +5386,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5448,11 +5406,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5460,7 +5418,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5472,11 +5430,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5484,19 +5442,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5508,7 +5466,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5520,37 +5478,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5562,7 +5520,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5570,12 +5528,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5590,63 +5544,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5658,13 +5612,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5672,22 +5626,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5699,11 +5653,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5711,61 +5665,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5773,13 +5721,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5804,17 +5752,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5826,11 +5774,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5838,7 +5786,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5850,13 +5798,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5869,7 +5817,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5878,27 +5826,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5906,11 +5854,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5918,181 +5866,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6100,7 +6048,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6111,12 +6059,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6127,7 +6075,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6137,11 +6085,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6149,24 +6097,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6177,25 +6125,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6203,9 +6151,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6217,7 +6165,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6225,11 +6173,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6245,15 +6193,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6274,7 +6222,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6282,36 +6230,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6323,7 +6243,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6371,19 +6291,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6391,19 +6311,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6422,19 +6342,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6446,7 +6355,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6454,7 +6363,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6479,7 +6388,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6491,6 +6400,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/fr/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/bika.po
@@ -22,7 +22,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: French (http://www.transifex.com/bikalabs/bika-lims/language/fr/)\n"
@@ -40,49 +40,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} peut se connecter au LIMS en utilisant ${contact_username} comme nom d'utilisateur. Les contacts doivent changer leur propre mot de passe. Si un mot de passe est oublié, un contact peut faire une demande de nouveau mot de passe via le formulaire de connexion."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "Il manque une date ou durée de conservation pour ${items}."
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} sont en attente de conservation."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} sont en attente de réception."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} invalidés"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} créés avec succès."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: aliquotes en attente de réception"
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "Il manque une date ou durée de conservation pour ${item}."
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} est en attente de conservation."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} est en attente de réception."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} a été créé avec succès."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} est en attente de réception."
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Erreur"
 
@@ -112,15 +112,15 @@ msgstr "% Réalisé"
 msgid "% Published"
 msgstr "% Publié"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s n'a pas de colonne '%s'."
 
@@ -132,15 +132,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Classique' indique que l'import de demandes d'analyses se fait par sélection d'échantillons et de services analytiques. Avec 'Profils', des mots-clés correspondants à des profils d'analyses sont utilisés pour sélectionner de multiples services analytiques simultanément."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Vide)"
@@ -153,7 +153,7 @@ msgstr "(Controle)"
 msgid "(Duplicate)"
 msgstr "(Dupliqué)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Dangereux)"
 
@@ -162,32 +162,26 @@ msgid "(Required)"
 msgstr "(Requis)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Icône de 16x16 pixels utilisée pour cette priorité dans les listes."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Icône de 32x32 pixels utilisée pour cette priorité dans les vues d'objets"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -198,16 +192,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "BA ${ar_number}"
 
@@ -219,7 +213,7 @@ msgstr "Option de lien du BA"
 msgid "AR ID Padding"
 msgstr "Pas d'ID des BA"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importation de BA"
 
@@ -227,17 +221,17 @@ msgstr "Importation de BA"
 msgid "AR Import options"
 msgstr "Options d'Importation des BA"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Modèles de BA"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "BA pour résultats issus d'une contre-analyse"
 
@@ -245,54 +239,54 @@ msgstr "BA pour résultats issus d'une contre-analyse"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "BAs : ${ars} "
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nom du compte"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Numéro de compte"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Type de compte"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Accréditation"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Accréditation abrégée"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL de l'Accréditation"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logo d'accréditation"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Référence Accréditation"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "En-tête d'accréditation"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Accrédité"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -306,21 +300,21 @@ msgstr "Actions réalisées par les utilisateurs (ou par un utilisateur spécifi
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Actif"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "ad-hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Ajout"
 
@@ -340,11 +334,7 @@ msgstr "Ajout d'une référence de contrôle"
 msgid "Add Duplicate"
 msgstr "Ajout d'un duplicat"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Ajouter un modèle"
 
@@ -352,16 +342,16 @@ msgstr "Ajouter un modèle"
 msgid "Add a remarks field to all analyses"
 msgstr "Ajoute un champ de commentaires à toutes les analyses"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Ajouter"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Commentaires additionnels :"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adresse"
@@ -374,26 +364,26 @@ msgstr "Ajoute les 2 derniers chiffres de l'année après le préfixe ID"
 msgid "Administrative Reports"
 msgstr "Rapports administratifs"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Après ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agence"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Tous"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Tous les services d'analyse accrédités sont listés ici."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Toutes les analyses  assignées"
 
@@ -405,7 +395,7 @@ msgstr "Toutes les analyses de type"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Autoriser les assistants de laboratoire à créer et éditer les clients"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Permet de saisir manuellement la limite de détection"
 
@@ -413,15 +403,15 @@ msgstr "Permet de saisir manuellement la limite de détection"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Autorise l'accès aux feuilles de travail uniquement aux analystes auxquels elles sont assignées"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Permet de saisir manuellement la valeur d'incertitude"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -429,11 +419,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Permet au technicien/biologiste de remplacer les limites de détection par défaut (haute et basse) sur les écrans de saisie des résultats"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Permet au technicien/biologiste de remplacer la valeur d'incertitude par défaut"
 
@@ -441,48 +431,48 @@ msgstr "Permet au technicien/biologiste de remplacer la valeur d'incertitude par
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Calcul alternatif"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Toujours déployer les catégories sélectionnées dans les vues client."
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Quantité"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analyses"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Analyses dans la marge d'erreur acceptable"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analyses hors spécifications"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Analyses par service analytique"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analyses par type d'échantillon"
@@ -496,7 +486,7 @@ msgstr "Analyses par service"
 msgid "Analyses performed and published as % of total"
 msgstr "Analyses réalisées et publiées en % du total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Analyses réalisées comme % du total"
 
@@ -509,27 +499,27 @@ msgstr "Rapports liés aux analyses"
 msgid "Analyses repeated"
 msgstr "Analyses répétées"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Résultats analytiques hors de la plage spécifiée"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Analyses relancées"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Résumé des analyses par département"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Analyses ayant été relancées"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analyse"
 
@@ -537,52 +527,52 @@ msgstr "Analyse"
 msgid "Analysis Attachment Option"
 msgstr "Option de liaison à l'analyse"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Classification par département"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Catégorie d'analyse"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Mot clé de l'analyse"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Profil d'analyse"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Profiles d'analyse"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Demande d'analyse"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID demande d'analyse"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importation de la Demande Analytique"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Priorités des demandes d'analyses"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Spécifications de demande d'analyses"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -590,65 +580,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Demandes d'analyse"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Service d'analyse"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Classification des analyses"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Spécifications analytiques"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Spécifications d'analyse"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "État d'analyse"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Type d'analyse"
@@ -657,46 +647,46 @@ msgstr "Type d'analyse"
 msgid "Analysis category"
 msgstr "Catégorie d'analyse"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "La demande d'analyse ${AR} a été créée avec succès."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Les demandes d'analyses ${ARs} ont été créées avec succès."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Demandes analytiques et analyses"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Demandes analytiques et analyses triées par client"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Demandes Analytiques Non envoyées"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Résultat analytique dans la plage d'erreur"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Résultats d'analyse"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Résultats analytiques pour ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Résultats analytiques par point d'échantillonnage et service analytique"
 
@@ -704,12 +694,12 @@ msgstr "Résultats analytiques par point d'échantillonnage et service analytiqu
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Résultats analytiques hors des spécifications du laboratoire ou du client. Note : cela peut prendre plusieurs minutes"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Service analytique"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Restauration des spécifications analytiques à celles par défaut du laboratoire."
 
@@ -725,17 +715,17 @@ msgstr "Durée moyenne de l'analyse"
 msgid "Analysis turnaround time over time"
 msgstr "Temps de traitement de l'analyse sur la période"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Temps de traitement des analyses"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Temps de traitement des analyses sur la période"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analyste"
 
@@ -744,7 +734,7 @@ msgid "Analyst must be specified."
 msgstr "L'analyste doit être spécifié."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Tous"
 
@@ -756,7 +746,7 @@ msgstr "Appliquer"
 msgid "Apply template"
 msgstr "Appliquer le modèle"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Appliquer à l'ensemble"
 
@@ -774,15 +764,15 @@ msgstr "Numéro d'équipement"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Affecté"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Assigné à une feuille de travail"
 
@@ -800,27 +790,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Lié à"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Lien"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Clé de lien"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Option de lien"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Type de lien"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Types de liens"
 
@@ -830,25 +820,25 @@ msgstr "Types de liens"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Pas de fichier attaché autorisé"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Fichier attaché requis"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "type de pièce-jointe"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Liens"
 
@@ -860,7 +850,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Autocomplétion"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Import automatique"
 
@@ -877,27 +867,27 @@ msgstr "Impression automatique d'étiquettes"
 msgid "Available templates"
 msgstr "Modèles diponibles"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Moyenne TAT"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Moyenne début"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Moyenne fin"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Etat mal formé : ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Filiale de la banque"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nom de la banque"
 
@@ -906,31 +896,31 @@ msgid "Basis"
 msgstr "Base"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lot"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Lot ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Libellés du lot"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lots"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Direction"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Avant le ${start_date}"
 
@@ -938,7 +928,7 @@ msgstr "Avant le ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Grande icône"
 
@@ -946,7 +936,7 @@ msgstr "Grande icône"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuration de Bika LIMS"
 
@@ -954,63 +944,67 @@ msgstr "Configuration de Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "adresse de facturation"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Vide"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Analyses QC à blanc"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "marque"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Remise sur la quantité"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Prix de gros (HT)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "téléphone professionnel"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Par"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC contacts"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "Emails CC"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calcule la précision à partir des incertitudes"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Calcul"
 
@@ -1018,8 +1012,8 @@ msgstr "Calcul"
 msgid "Calculation Formula"
 msgstr "Formule de calcul"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Champ(s) de calcul intermédiaire"
@@ -1032,11 +1026,11 @@ msgstr "Calcul : ${calc_name}"
 msgid "Calculation: None"
 msgstr "Calibration : aucune"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "calculs"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Etalonnage"
 
@@ -1048,12 +1042,12 @@ msgstr "Certificat d'étalonnage"
 msgid "Calibration report date"
 msgstr "Date du rapport de calibration"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Métrologue"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1067,9 +1061,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Annulé"
 
@@ -1085,18 +1079,18 @@ msgstr "Ne peut désactiver le calcul car utilisé par les services suivants : $
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Vérification impossible : soumis par l'utilisateur courant"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacité"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Saisi"
 
@@ -1105,7 +1099,7 @@ msgid "Cardinal"
 msgstr "Cardinal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Référence catalogue"
 
@@ -1113,17 +1107,17 @@ msgstr "Référence catalogue"
 msgid "Categorise analysis services"
 msgstr "Classe les services analytiques"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Catégorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "La catégorie ne peut pas être désactivée parce qu'elle contient des services analytiques"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Num. de cert."
 
@@ -1136,31 +1130,31 @@ msgstr "Référence du certificat"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Cochez si cette méthode a été accréditée"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Cochez cette case si le service analytique est inclus dans le programme d'analyses accréditées du laboratoire"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Cochez cette case si les échantillons prélevés à ce point sont des \"composites\", c'est à dire plusieurs échantillons réunis  et mélangés afin de former un échantillon représentatif. Décoché, par défaut, indique des échantillons indépendants."
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Cochez cette case si ce conteneur est déjà conditionné. Cette option va court-circuiter le workflow de conservation pour les échantillons stockés dans ce conteneur."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Cochez cette case si c'est la priorité par défaut."
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Cocher cette case si votre laboratoire est accrédité"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Cochez cette case pour garantir qu'un conteneur d'échantillon distinct est analysé pour ce service analytique."
 
@@ -1168,7 +1162,7 @@ msgstr "Cochez cette case pour garantir qu'un conteneur d'échantillon distinct 
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Cochez si vous voulez utiliser un ID serveur séparé. Les préfixes sont configurables séparément dans chaque site Bika."
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Choisissez les valeurs de BA spécifiées par défaut"
 
@@ -1184,19 +1178,19 @@ msgstr ""
 msgid "City"
 msgstr "Ville"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Classique"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Cliquez sur les catégories d'analyses (ci-contre sur fond sombre) pour voir les services d'analyses de chaque catégorie. Entrer des valeurs minimales et maximales pour indiquer la plage de validité des résultats. Chaque résultat en dehors de cette plage déclenchera une alerte. Le champ % d'erreur permet d'utiliser un % d'incertitude lors de la comparaison des résultats aux valeurs minimales et maximales. Un résultat en dehors de de la plage indiquée mais encore dans la plage si l'on prend en considération le % d'erreur relatif déclenchera une alerte de niveau inférieur."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Cliquez sur les catégories d'analyses (ci-contre sur fond sombre) pour voir les services d'analyses de chaque catégorie. Entrer des valeurs minimales et maximales pour indiquer la plage de validité des résultats. Chaque résultat en dehors de cette plage déclenchera une alerte. Le champ % d'erreur permet d'utiliser un % d'incertitude lors de la comparaison des résultats aux valeurs minimales et maximales. Un résultat en dehors de de la plage indiquée mais encore dans la plage si l'on prend en considération le % d'erreur relatif déclenchera une alerte de niveau inférieur."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Cliquez sur les catégories d'analyses (ci-contre sur fond sombre) pour voir les services d'analyses de chaque catégorie. Entrer des valeurs minimales et maximales pour indiquer la plage de validité des résultats. chaque résultat en dehors de cette plage déclenchera une alerte. Le champ % d'erreur permet d'utiliser un % d'incertitude lors de la comparaison des résultats aux valeurs minimales et maximales. Un résultat en dehors de de la plage indiquée mais encore dans la plage si l'on prend en considération le % d'erreur relatif déclenchera une alerte de niveau inférieur. Si le résultat est inférieur au minimum, le résultat sera exprimé sous la forme '< [min]'. Le même principe s'applique pour les résultats supérieurs, exprimés '> [max]'."
 
@@ -1204,19 +1198,19 @@ msgstr "Cliquez sur les catégories d'analyses (ci-contre sur fond sombre) pour 
 msgid "Click to download"
 msgstr "Cliquez pour télécharger"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Client"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID du lot du client"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Identifiant"
 
@@ -1224,59 +1218,59 @@ msgstr "Identifiant"
 msgid "Client Landing Page"
 msgstr "Page d'accueil du client"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nom du client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Commande du client"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Numéro de commande du client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Réf client"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Référence client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID client"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Un contact client est nécessaire avant de soumettre une requête"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clients"
 
@@ -1285,39 +1279,39 @@ msgstr "Clients"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Fermé"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Code de localisation"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Code du site"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Code du meuble"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Virgule (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Commentaires"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Commentaires ou interprétation des résultats"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "ID commercial"
 
@@ -1325,21 +1319,21 @@ msgstr "ID commercial"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composé"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Taux de confiance"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configure la répartition et conservation des échantillons pour ce modèle. Assigne des analyses aux différentes sections sur l'onglet des modèles d'analyses"
 
@@ -1348,13 +1342,13 @@ msgid "Confirm password"
 msgstr "Confirmer le mot de passe"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Considérations"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contact"
@@ -1363,8 +1357,8 @@ msgstr "Contact"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contacts"
@@ -1373,48 +1367,48 @@ msgstr "Contacts"
 msgid "Contacts to CC"
 msgstr "CC contacts"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Conteneur"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Type de conteneur"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Types de conteneur"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Conteneurs"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Type de contenu"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Type de contenu"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Contrôle"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Contrôle QC des analyses"
 
@@ -1430,12 +1424,12 @@ msgstr "Copier les analyses"
 msgid "Copy from"
 msgstr "Copier de "
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Copier dans un  nouveau"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Compter"
 
@@ -1448,18 +1442,18 @@ msgstr "Pays"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Créer un nouvel échantillon de ce type"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Créé"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Créé par "
 
@@ -1467,7 +1461,7 @@ msgstr "Créé par "
 msgid "Created by:"
 msgstr "Créé par :"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1475,8 +1469,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Créateur"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Critère"
 
@@ -1484,12 +1478,12 @@ msgstr "Critère"
 msgid "Currency"
 msgstr "Devise"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Actuel"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Signe décimal personnalisé"
 
@@ -1502,7 +1496,7 @@ msgstr "LD"
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1516,88 +1510,88 @@ msgstr "Interface de données"
 msgid "Data Interface Options"
 msgstr "Options d'interface de données"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Cahier d'enregistrement quotidien"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Date"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Date de création"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Date de répartition"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Date de mise à disposition"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Date d'expiration"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Date d'importation"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Date de chargement"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Date d'ouverture"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Date de conservation"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Date de publication"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Date de réception"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Date de la demande"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Date d'échantillonnage"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgstr "Date jusqu'à laquelle le certificat d'étalonnage est valide"
 msgid "Date from which the instrument is under calibration"
 msgstr "Date à partir de laquelle l'équipement est étalonné"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Date à partir de laquelle l'équipement est en maintenance"
 
@@ -1631,7 +1625,7 @@ msgid "Date until the certificate is valid"
 msgstr "Date jusqu'à laquelle le certificat est valide"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Date jusqu'à laquelle l'équipement sera indisponible"
@@ -1640,11 +1634,11 @@ msgstr "Date jusqu'à laquelle l'équipement sera indisponible"
 msgid "Date when the calibration certificate was granted"
 msgstr "Date de délivrance du certificat"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Jours"
 
@@ -1656,17 +1650,17 @@ msgstr "Désactiver jusqu'au prochain étalonnage"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "signe décimal à utiliser dans les rapports pour ce client"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Défaut"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Spécifications par défaut des BA"
 
@@ -1674,49 +1668,49 @@ msgstr "Spécifications par défaut des BA"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Calcul par défaut"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "conteneur par défaut"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Type de conteneur par défaut"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Equipement par défaut"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Méthode par défaut"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Conservation par défaut"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Priorité par défaut ?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Calcul sélectionné par défaut utilisé quand la méthode par défaut est utilisée. Le calcul pour une méthode peut être attribué par la vue d'édition des méthodes."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Catégories par défaut"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Conteneur par défaut pour les nouvelles répartitions d'échantillons"
 
@@ -1725,11 +1719,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Conteneurs par défaut : ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Signe décimal par défaut"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1753,11 +1747,11 @@ msgstr "Formattage par défaut des notations scientifiques pour les rapports"
 msgid "Default scientific notation format for results"
 msgstr "Formattage par défaut des notations scientifiques pour les résultats"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valeur par défaut"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "Description des spécifications par défaut des BA"
 
@@ -1765,7 +1759,7 @@ msgstr "Description des spécifications par défaut des BA"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Définissez un code d'identification pour la méthode. Il doit être unique"
 
@@ -1773,11 +1767,11 @@ msgstr "Définissez un code d'identification pour la méthode. Il doit être uni
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Définit le nombre de décimales utilisées pour ce résultat."
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Définit la précision lors de conversions de valeurs en notation exponentielle. Le défaut est de 7."
 
@@ -1785,16 +1779,16 @@ msgstr "Définit la précision lors de conversions de valeurs en notation expone
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Définit les préfixes pour la séquence unique d'IDs que le système attribue aux objets. Dans le champ 'taille', indiquez par combien de zéros les nombres doivent être complétés. Par exemple, un préfixe 'FdT' pour feuille de travail avec une taille de 4 aura des identifiants allant de FdT-0001 à FdT-9999. Le début de la séquence indique à partir de quel nombre le prochain ID doit commencer. Il doit être supérieur aux identifiants déjà utilisés. Notez que l'écart dans la numérotation des ID ne peut pas être rempli. Remarque Importante : Notez que les échantillons et demandes d'analyse sont préfixés avec l'abbréviation de type d'échantillon et ne sont pas configurées dans cette table - la taille de celles-ci peuvent être spécifiées dans les champs ci-dessous. "
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Degrés"
 
@@ -1802,9 +1796,9 @@ msgstr "Degrés"
 msgid "Delete attachment"
 msgstr "Supprimer la pièce-jonte"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Département"
 
@@ -1817,13 +1811,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analyses dépendantes"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Décrivez la méthode en termes profanes. Cette information est rendue disponible aux clients du laboratoire."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Description"
 
@@ -1831,7 +1825,7 @@ msgstr "Description"
 msgid "Description of the actions made during the calibration"
 msgstr "Description des actions effectuées durant l'étalonnage."
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Description des actions réalisées pendant la maintenance."
 
@@ -1839,19 +1833,19 @@ msgstr "Description des actions réalisées pendant la maintenance."
 msgid "Description of the actions made during the validation"
 msgstr "Description des actions réalisées durant la validation"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Description de l'emplacement"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Descritption du meuble"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Description du site"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1859,7 +1853,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Remise %"
 
@@ -1867,16 +1861,16 @@ msgstr "Remise %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Envoyé"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Afficher la valeur"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Affiche un sélecteur de limite de détection"
 
@@ -1888,7 +1882,7 @@ msgstr "Affiche une alerte lorsqu'une nouvelle version de Bika LIMS est disponib
 msgid "Display individual sample partitions "
 msgstr "Afficher la répartition des échantillons individuels"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Date de traitement"
 
@@ -1897,8 +1891,8 @@ msgstr "Date de traitement"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "traité"
@@ -1907,54 +1901,54 @@ msgstr "traité"
 msgid "District"
 msgstr "District"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Division par zéro"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Document"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inactif"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Point (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Diminution de"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Réduit à"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Télécharger"
 
@@ -1967,20 +1961,20 @@ msgstr "Sec"
 msgid "Dry matter analysis"
 msgstr "Analyse de matière sèche"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Dû"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Echéance"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Rép Var"
 
@@ -1989,20 +1983,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Réplicat"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Réplicat de"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Analyses QC répliquées"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Variation du réplicat %"
 
@@ -2014,35 +2008,35 @@ msgstr "Réplicat d'analyse QC"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Graphes de contrôle de la qualité des réplicats"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Durée"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Ex. SANAS, APLAC, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Anticipé"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Tôt"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Hauteur"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Adresse mail"
 
@@ -2050,7 +2044,7 @@ msgstr "Adresse mail"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Sujet de l'email"
 
@@ -2070,14 +2064,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Date de fin"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Amélioration"
 
@@ -2089,16 +2083,16 @@ msgstr "Entrer un nom d'utilisateur, normalement quelque chose comme 'jsmith'. P
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Entrer une adresse email. C'est nécessaire en cas de perte du mot de passe. Nous respectons vos informations privées et ne communiquerons pas l'adresse à un tiers ni ne la diffuserons."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Saisir le taux de remise"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Saisir un pourcentage  ex: 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Saisir un pourcentage, par exemple 14,0. Ce pourcentage s'applique uniquement au profil d'analyse et remplace la TVA système "
 
@@ -2106,15 +2100,15 @@ msgstr "Saisir un pourcentage, par exemple 14,0. Ce pourcentage s'applique uniqu
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Saisir un pourcentage  (ex : 14.0). Ce pourcentage est appliqué à l'ensemble du système mais peut être écrasé sur des éléments individuels."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Saisir la valeur du pourcentage ex: 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Entrer la latitude du point d'échantillonnage en degrés (0-90), minutes (0-59), secondes (0-59), cardinalité (N/S)"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Entrer la longitude du point d'échantillonnage en degrés (0-180), minutes (0-59), secondes (0-59), cardinalité (E/W)"
 
@@ -2122,7 +2116,7 @@ msgstr "Entrer la longitude du point d'échantillonnage en degrés (0-180), minu
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Entrer le détail de chacune des analyses que vous voulez copier"
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Entrez ici le détail des accréditation de votre laboratoire. Les champs suivants sont disponibles : lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
@@ -2130,45 +2124,45 @@ msgstr "Entrez ici le détail des accréditation de votre laboratoire. Les champ
 msgid "Entity"
 msgstr "Entité"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Publication de résultat erroné pour ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Exclu de la facture"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Résultat attendu"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Valeurs attendues"
 
@@ -2177,19 +2171,19 @@ msgstr "Valeurs attendues"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Expiré"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Date d'expiration"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Précision pour le format exponentiel"
 
@@ -2197,44 +2191,40 @@ msgstr "Précision pour le format exponentiel"
 msgid "Exponential format threshold"
 msgstr "sensibilité pour le format exponentiel"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (entreprise)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Femme"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Champ"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Champ d'analyses"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Champ de conservation"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Titre du champ"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Fichier"
 
@@ -2242,19 +2232,19 @@ msgstr "Fichier"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Les fichiers attachés aux résultats (ex : photos de microscopie) seront inclus dans les emails aux destinataires si cette option est activée."
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nom du fichier"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2274,16 +2264,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Prénom"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formule"
 
@@ -2293,18 +2283,18 @@ msgstr "Formule"
 msgid "From"
 msgstr "De"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "De ${start_date} à ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Echantillons futurs"
 
@@ -2314,7 +2304,7 @@ msgstr "Echantillons futurs"
 msgid "Generate report"
 msgstr "Générer le rapport"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titre (Mr, Mrs, Dr...)"
 
@@ -2326,37 +2316,37 @@ msgstr "Groupe les analyses par catégorie dans les tables du LIMS : utile si la
 msgid "Group by"
 msgstr "Grouper par"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Période de regroupement"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Dangereux"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Caché"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Champ caché"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Heures"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBAN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2365,8 +2355,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID serveur URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID serveur indisponible"
 
@@ -2374,31 +2364,31 @@ msgstr "ID serveur indisponible"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "IMPORTANT : ne pas utiliser \"Bika\" ou \"BIKA\" comme nom d'instance, ce sont des espaces de noms réservés. Si vous obtenez \"Site Error\" citant \"AttrributeError:adapters\",  c'est la cause la plus probable."
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Si \"Autoriser la saisie de résultats par les équipements\" est sélectionné, la méthode de l'instrument par défaut sera utilisée. Sinon, seules les méthodes sélectionnées au-dessus seront affichées."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Si un échantillon est prélevé périodiquement à ce point d'échantillonnage, entrer une fréquence, par exemple hebdomadaire"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "Si coché, une liste de sélection sera affichée à coté du champ de résultants d'analyse dans les vues de résultats. En utilisant cette option, le technicien/biologiste peut positionner la valeur du résultat comme étant une Limite de Détection (LDB ou LDH). Cela remplacera la valeur numérique indiquée."
 
@@ -2410,7 +2400,7 @@ msgstr "Si coché, l'équipement sera indisponible jusqu'au prochain étalonnage
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2418,27 +2408,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Si activé, le nom de l'analyse sera écrit en italique."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "Si actif, cette analyse ainsi que ses résultats ,e seront pas affichés dans les rapports. Ce réglage peut être outrepassé dans le Profil d'analyses et/ou les Demandes d'analyse"
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "Si aucun titre n'est saisi, l'ID du lot sera utilisé"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Si requis, sélectionne un calcul pour les analyses liées à cette méthode. Les calculs peuvent être configurés par l'élément calculs dans le paramétrage du LIMS"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Si requis, sélectionnez une formule de calcul pour cette analyse. Les calculs se configurent sous l'élément calculs dans le paramétrage du LIMS."
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Si du texte est saisi ici, il sera utilisé en lieu et place du titre quand le service est utilisé dans l'en-tête des colonnes. Le format HTML peut-être utilisé."
 
@@ -2446,7 +2436,7 @@ msgstr "Si du texte est saisi ici, il sera utilisé en lieu et place du titre qu
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "S'il existe des résultats antérieurs pour un service dans le même lot de demandes d'analyses, ils seront affichés sur le rapport."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Si le conteneur est pré-conditionné, alors le la méthode de conditionnement pourra être sélectionnée ici."
 
@@ -2459,7 +2449,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Si décoché, les techniciens de laboratoire auront accès à l'ensemble des feuilles de travail."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Import"
@@ -2468,7 +2458,7 @@ msgstr "Import"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importé"
@@ -2477,8 +2467,8 @@ msgstr "Importé"
 msgid "In-lab calibration procedure"
 msgstr "Procédure d'étalonnage interne"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Inactif"
@@ -2487,7 +2477,7 @@ msgstr "Inactif"
 msgid "Include Previous Results From Batch"
 msgstr "Inclus les précédents résultats du lot"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Inclus toutes les demandes d'analyses appartenant à l'ensemble des objets sélectionnés."
 
@@ -2495,7 +2485,7 @@ msgstr "Inclus toutes les demandes d'analyses appartenant à l'ensemble des obje
 msgid "Include and display pricing information"
 msgstr "Inclus et affiche les informations tarifaires"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Inclus les descriptions"
 
@@ -2503,30 +2493,27 @@ msgstr "Inclus les descriptions"
 msgid "Include year in ID prefix"
 msgstr "Inclure l'année dans le préfixe d'ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "Numéro IBAN incorrect : %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "Code RIB incorrect : %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Résultat indéterminé"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indique soit que des fichiers joints (ex images de microscopie) sont requis soit que la fonction d'upload de fichiers sera disponible sur les écrans de capture des données."
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Hérite de "
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Révision initiale"
 
@@ -2550,7 +2537,7 @@ msgstr "Importation du certificat d'installation"
 msgid "InstallationDate"
 msgstr "Date d'installation"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instructions"
@@ -2563,17 +2550,17 @@ msgstr "Instructions internes d'étalonnage à l'intention des techniciens d'ana
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instructions de maintenance et d'entretien à destination des techniciens d'analyse."
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Équipement"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Étalonnages de l'équipement"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2586,16 +2573,16 @@ msgstr "Import de l'équipement"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Maintenance de l'équipement"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Tâches planifiées pour l'équipement"
 
@@ -2603,19 +2590,19 @@ msgstr "Tâches planifiées pour l'équipement"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Types d'équipement"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validations de l'équipement"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2659,9 +2646,9 @@ msgstr "Type d'équipement"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Équipements"
 
@@ -2685,7 +2672,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Tests d'étalonnage internes"
 
@@ -2701,24 +2688,21 @@ msgstr "Interpolation"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Invalide"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "BA invalide retesté"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Caractères génériques invalides trouvés : ${wildcards}"
 
@@ -2726,43 +2710,43 @@ msgstr "Caractères génériques invalides trouvés : ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Facture"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Date de facture"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Exclus de la facture"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "Le lot de facturation n'a pas de date de fin"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "Le lot de facturation n'a pas de date de début"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "Le lot de facturation n'a pas de titre"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "L'élément est inactif"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Éléments à inclure dans le sujet du message électronique"
 
@@ -2772,7 +2756,7 @@ msgstr "Éléments à inclure dans le sujet du message électronique"
 msgid "Job Title"
 msgstr "Profession"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Profession"
 
@@ -2780,12 +2764,12 @@ msgstr "Profession"
 msgid "Key"
 msgstr "Clé"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Clé d'erreur"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Mot clé"
@@ -2794,47 +2778,47 @@ msgstr "Mot clé"
 msgid "Keywords"
 msgstr "Mots clé"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratoire"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Analyses de laboratoire"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contacts du laboratoire"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Départements du labo"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Conservation du laboratoire"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Produits du labo"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL du laboratoire"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Libellé"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratoire"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratoire accrédité"
 
@@ -2854,13 +2838,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Dernière modification"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "En retard"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Analyses en retard"
@@ -2870,7 +2854,7 @@ msgstr "Analyses en retard"
 msgid "Late Analysis"
 msgstr "Analyses en retard"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -2892,11 +2876,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Échantillon lié"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2908,7 +2892,7 @@ msgstr "Liste de tous les échantillons reçus pour une période"
 msgid "Load Setup Data"
 msgstr "Charger les données de paramétrage"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Chargez les documents décrivant la méthode"
 
@@ -2920,41 +2904,41 @@ msgstr "Charger à partir du fichier"
 msgid "Load the certificate document here"
 msgstr "Charger le certificat ici"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Chargé"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Code de l'emplacement"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Description de l'emplacement"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Titre de l'emplacement"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Type d'emplacement"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Emplacement où l'échantillon est conservé"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Emplacement où l'échantillon a été pris"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Enregistrement"
@@ -2979,35 +2963,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitude"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "N° de lot"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Limite de Détection Basse (LDB)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Adresse d'envoi par mail"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Mainteneur"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Type de maintenance"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Mâle"
 
@@ -3015,16 +2999,16 @@ msgstr "Mâle"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Manager"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "E-mail manager"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Téléphone manager"
 
@@ -3032,31 +3016,25 @@ msgstr "Téléphone manager"
 msgid "Manual"
 msgstr "Manuel"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Saisie manuelle"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Saisie manuelle des résultats"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabriquant"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Fabricants"
 
@@ -3065,14 +3043,14 @@ msgstr "Fabricants"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Temps max"
 
@@ -3080,30 +3058,30 @@ msgstr "Temps max"
 msgid "Maximum columns per results email"
 msgstr "Nombre maximum de colonnes par mail de résultats"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Taille ou volume maximum des échantillons."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Temps maximum alloué pour réaliser toutes les analyses. Dépassé ce temps, une alerte de retard est affichée."
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Temps maximum de traitement"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Remise membre %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Application de la remise membre"
 
@@ -3112,22 +3090,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Méthode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Document de méthode"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "ID de la méthode"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instructions de méthode"
 
@@ -3139,9 +3117,9 @@ msgstr "Méthode : ${method_name}"
 msgid "Method: None"
 msgstr "Méthode : aucune"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Méthodes"
 
@@ -3149,17 +3127,17 @@ msgstr "Méthodes"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Méthodes inclues dans le programme d'accréditation ${accreditation_body} du Laboratoire. Les remarques analytiques ne sont pas accréditées."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Initiale du deuxième prénom"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Deuxième prénom"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3171,8 +3149,8 @@ msgstr "Source"
 msgid "Minimum 5 characters."
 msgstr "5 caractères minimum"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volume minimal"
 
@@ -3180,27 +3158,27 @@ msgstr "Volume minimal"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Nombre minimal de résultat pour le calcul des statistiques de QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutes"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Téléphone mobile"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modèle"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Date de modification"
 
@@ -3214,7 +3192,7 @@ msgstr ""
 msgid "More"
 msgstr "Plus"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3226,13 +3204,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "RIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nom"
 
@@ -3241,17 +3219,17 @@ msgstr "Nom"
 msgid "New"
 msgstr "Nouveau"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Non"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Pas de demande d'analyse correspondant à votre requête"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3267,18 +3245,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Pas d'actions trouvées pour l'utilisateur ${user}"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Aucune analyse sélectionnée"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Pas d'analyse correspondant à votre requête"
 
@@ -3290,23 +3268,23 @@ msgstr "Pas d'analyses ajoutées"
 msgid "No analyses were added to this worksheet."
 msgstr "Pas d'analyses ajoutées à cette feuille de travail."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Pas d'analyse sélectionnée."
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Pas de service analytique sélectionné"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Pas d'analyses sélectionnées"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Pas de changements effectués."
 
@@ -3314,7 +3292,7 @@ msgstr "Pas de changements effectués."
 msgid "No control type specified"
 msgstr "Aucun type de contrôle spécifié"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3326,17 +3304,17 @@ msgstr "Pas de conteneur par défaut spécifié pour ce service."
 msgid "No default preservations specified for this service"
 msgstr "Pas de conservation spécifiée pour ce service"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Pas de fichier sélectionné"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Pas d'actions dans l'historique correspondant à votre recherche"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Aucun article sélectionné"
 
@@ -3344,7 +3322,7 @@ msgstr "Aucun article sélectionné"
 msgid "No items selected"
 msgstr "Pas d'articles sélectionnés"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Pas de nouvel élément créé"
 
@@ -3354,16 +3332,16 @@ msgstr "Pas de nouvel élément créé"
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Aucun échantillon de référence sélectionné"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Pas de rapport spécifié dans la requête"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Pas d'échantillon correspondant à votre requête"
 
@@ -3381,25 +3359,22 @@ msgstr "Aucun utilisateur n'existe pour ${contact_fullname} et elle/il ne peut p
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Aucun"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Non autorisé"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Non disponible"
 
@@ -3419,19 +3394,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "Num colonne"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Nombre d'analyses"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Nombre de demandes d'analyses et d'analyses"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Nombre de demandes d'analyses et d'analyses par client"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3439,30 +3414,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Nombre d'analyses"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Nombre d'analyses hors spécifications pour la période"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Nombre d'analyses demandées par service analytique"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Nombre de demandes d'analyses et d'analyses par type"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Nombre d'analyses retestées pour la période"
 
@@ -3470,15 +3445,15 @@ msgstr "Nombre d'analyses retestées pour la période"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Nombre d'analyses demandées et publiées par département et exprimées comme un pourcentage de toutes les analyses réalisées."
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Nombre de demandes"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3487,31 +3462,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Nombre d'échantillons"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Valeur numérique indiquant l'ordre de tri des objets priorisés"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "ID de l'objet"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Lorsqu'il a été conservé, l'échantillon doit être éliminé à l'issue de la période. Faute de spécification, la période de rétention du type d'échantillon sera utilisée."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3519,15 +3494,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Seuls les responsables de laboratoire peuvent créer et gérer les feuilles de travail"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Champs à valeur vide ou zéro"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Ouvert"
@@ -3540,26 +3512,26 @@ msgstr ""
 msgid "Order"
 msgstr "Commande"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID commande"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Commandes"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Commandes :${orders}"
 
@@ -3567,7 +3539,7 @@ msgstr "Commandes :${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Organisme chargé de délivrer le certificat d'étalonnage"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3579,8 +3551,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Autres rapports de productivité"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Périmé"
 
@@ -3592,16 +3564,13 @@ msgstr "Format de sortie"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Répartition"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3622,8 +3591,8 @@ msgstr "Mot de passe"
 msgid "Password lifetime"
 msgstr "Durée de vie du mot de passe"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "En attente"
@@ -3648,31 +3617,31 @@ msgstr "Réalisé par"
 msgid "Period"
 msgstr "Période"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Autorisé"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Erreur autorisée %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Téléphone"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Téléphone (bureau)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Téléphone (domicile)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Téléphone (portable)"
 
@@ -3685,8 +3654,8 @@ msgid "Photo of the instrument"
 msgstr "Photo de l'instrument"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Adresse physique"
 
@@ -3694,7 +3663,7 @@ msgstr "Adresse physique"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Lister toutes les options pour les résultats analytiques si vous voulez les restreindre seulement à des options spécifiques, par exemple 'Positif', 'Négatif', et 'Indéterminé'. Les résultats des options doivent être un nombre."
 
@@ -3702,19 +3671,19 @@ msgstr "Lister toutes les options pour les résultats analytiques si vous voulez
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Merci de spécifier les conservations qui diffèrent de celles par défaut du service analytique ici."
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Uploadez le logo que vous êtes autorisé par votre organisme accréditeur à utiliser sur votre site et vos rapports de résultats. Taille maximale de 175x175 pixels."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Point de saisie"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3723,13 +3692,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Position"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Adresse postale"
 
@@ -3737,16 +3706,16 @@ msgstr "Adresse postale"
 msgid "Postal code"
 msgstr "Code postal"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Pré conservé"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Précision, comme nombre de décimales"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Précision comme le nombre de décimales significatives en accord avec l'incertitude. La position décimale sera donnée par le premier chiffre différent de zéro dans l'incertitude, à la position que le système  arrondira au-dessus l'incertitude et le résultat. Par exemple, pour un résultat de 5.243 et une incertitude de 0.22, le système affichera 5.2+/-0.2. S'il n'y a pas de plage d'incertitude pour le résultat, le système utilisera la précision spécifiée."
 
@@ -3774,7 +3743,7 @@ msgstr "Format de notation scientifique préféré pour les rapports"
 msgid "Preferred scientific notation format for results"
 msgstr "Format de notation scientifique préféré pour les résultats"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Préfixe"
 
@@ -3782,12 +3751,12 @@ msgstr "Préfixe"
 msgid "Prefixes"
 msgstr "Prefixes"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premium"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3799,17 +3768,17 @@ msgstr "Préparé par"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Conservation"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Catégorie de conservation"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3820,7 +3789,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Conservations"
 
@@ -3830,14 +3799,14 @@ msgstr "Conservations"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Personne ayant stocké"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Préventif"
 
@@ -3845,34 +3814,34 @@ msgstr "Préventif"
 msgid "Preventive maintenance procedure"
 msgstr "Procédure de maintenance préventive"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Prix"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Prix (HT)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Pourcentage de prix premium"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Prix HT"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Liste de prix pour"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Tarifs"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3887,13 +3856,13 @@ msgstr "Imprimession"
 msgid "Print date:"
 msgstr "Date d'impression"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Priorité"
 
@@ -3910,34 +3879,34 @@ msgstr "Rapports de productivité"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "SGL/SIL Professionnel Open Source"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Profil analytique"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Clé du profil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Mot-clé profil"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profils"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (pas encore facturé)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "ID du protocole"
 
@@ -3945,7 +3914,7 @@ msgstr "ID du protocole"
 msgid "Public. Lag"
 msgstr "Délai public"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Spécification de publication"
 
@@ -3960,21 +3929,21 @@ msgstr "Préférence de publication "
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publié"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Demandes d'analyses publiées non facturées"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Publié par"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Résultats publiés"
 
@@ -3987,8 +3956,8 @@ msgid "QC Analyses"
 msgstr "Analyses QC"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "ID échantillon QC"
 
@@ -4009,23 +3978,23 @@ msgstr "Quantité"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Plage de commentaires"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Plage de commentaires"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Plage max"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Plage min"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Plage de spécifications"
 
@@ -4047,9 +4016,9 @@ msgstr "Reçoit"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Reçu"
 
@@ -4057,11 +4026,11 @@ msgstr "Reçu"
 msgid "Recept. Lag"
 msgstr "Délai de réception"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Récipients"
 
@@ -4070,31 +4039,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "Se héférer à <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\">Créer un nouveau modèle de rapport</a> de la documentation du wiki Bika LIMS pour plus d'informations ou ajouter vos propres modèles."
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Référence"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Anlyses de référence"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Définition de référence"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Définitions de référence"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Echantillons de référence"
 
@@ -4102,16 +4071,16 @@ msgstr "Echantillons de référence"
 msgid "Reference Supplier"
 msgstr "Fournisseur de référence"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Type de référence"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valeurs de référence"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Analyse de référence QC"
@@ -4120,7 +4089,7 @@ msgstr "Analyse de référence QC"
 msgid "Reference analysis quality control graphs"
 msgstr "Graphes de contrôle de la qualité des analyses de référence"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Graphes de contrôle de la qualité des analyses de référence"
 
@@ -4128,21 +4097,21 @@ msgstr "Graphes de contrôle de la qualité des analyses de référence"
 msgid "Reference sample"
 msgstr "Échantillon de référence"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Les valeurs des échantillons de référence sont nulles ou vides"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "ID du groupe d'analyses de référence"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition représente une définition de référence ou un type d'échantillon utilisé pour les tests de QC"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Refs: ${references}"
 
@@ -4165,8 +4134,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4175,9 +4144,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Le pourcentage de différence relatif, ${variation_here} %, est hors plage (${variation} %)"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Remarques"
 
@@ -4185,7 +4154,7 @@ msgstr "Remarques"
 msgid "Remarks to take into account before calibration"
 msgstr "Remarques à prendre en compte avant étalonnage"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Remarques à prendre en compte avant de réaliser la tache"
 
@@ -4193,7 +4162,7 @@ msgstr "Remarques à prendre en compte avant de réaliser la tache"
 msgid "Remarks to take into account before validation"
 msgstr "Remarques à prendre en compte avant validation"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Remarques à prendre en compte avant la maintenance"
 
@@ -4202,8 +4171,8 @@ msgstr "Remarques à prendre en compte avant la maintenance"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Réparation"
 
@@ -4212,7 +4181,7 @@ msgid "Repeated analyses"
 msgstr "Analyses répétées"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Rapport"
 
@@ -4226,14 +4195,14 @@ msgstr "Date du rapport"
 msgid "Report ID"
 msgstr "ID du rapport"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Type de rapport"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Publication comme matière sèche"
 
@@ -4258,7 +4227,7 @@ msgstr "Tableau périodique du nombre d'échantillons reçus et résultats rappo
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Tableau périodique des demandes d'analyses et totaux soumis"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Type de rapport"
 
@@ -4266,7 +4235,7 @@ msgstr "Type de rapport"
 msgid "Report upload"
 msgstr "Importation du rapport"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "rapports"
 
@@ -4275,15 +4244,15 @@ msgstr "rapports"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Demande"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID demande"
 
@@ -4291,26 +4260,26 @@ msgstr "ID demande"
 msgid "Request new analyses"
 msgstr "Demander de nouvelles analyses"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Demandé"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Demandes"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Requis"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volume requis"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "Les champs requis n'ont pas de valeur : ${field_names}"
 
@@ -4318,13 +4287,13 @@ msgstr "Les champs requis n'ont pas de valeur : ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Catégories restreintes"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Résultat"
 
@@ -4332,15 +4301,15 @@ msgstr "Résultat"
 msgid "Result Footer"
 msgstr "Pied de page des résultats"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Options de résultat"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valeur résultat"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4358,11 +4327,11 @@ msgstr "Résultat hors intervalle"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Les valeurs de résultat avec au moins ce nombre de décimales significatives sont affichés en notation scientifique utilisant la lettre 'e' pour indiquer l'exposant. La précision peut-être configurée dans les analyses individuelles"
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Interprétation des résultats"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Interprétation des résultats"
 
@@ -4370,7 +4339,7 @@ msgstr "Interprétation des résultats"
 msgid "Results attachments permitted"
 msgstr "Résultats liés autorisés"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Les résultats ont été retirés"
 
@@ -4378,11 +4347,11 @@ msgstr "Les résultats ont été retirés"
 msgid "Results interpretation"
 msgstr "Interprétation des résultats"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Résultats par point d'échatillonnage"
@@ -4391,14 +4360,14 @@ msgstr "Résultats par point d'échatillonnage"
 msgid "Results per samplepoint and analysis service"
 msgstr "Résultats par point d'échantillonnage et analyse"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Période de conservation"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Retesté"
@@ -4417,11 +4386,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "Analyses retirées"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Rapport de rétractation indisponible"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Rétractations"
 
@@ -4437,12 +4406,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "Code SWIFT/BIC."
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Salutation"
 
@@ -4450,19 +4419,19 @@ msgstr "Salutation"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Identique à ci-dessus, mais définit le défaut pour les analyses. Ce paramétrage peut être défini pour une analyse individuelle lors de sa configuration"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Échantillon"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Condition d'échantillonnage"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Conditions d'échantillonnage"
 
@@ -4471,8 +4440,8 @@ msgid "Sample Due"
 msgstr "Échéance de l'échantillon"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID échantillon"
 
@@ -4484,12 +4453,12 @@ msgstr "Taille de l'ID échantillon"
 msgid "Sample ID Sequence Start"
 msgstr "Numéro de début de séquence"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Matrices d'échantillons"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Matrice d'échantillons"
 
@@ -4499,52 +4468,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Répartition d'échantillon"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Point d'échantillonnage"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Points d'échantillonnage"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Type d'échantillon"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Préfixe du type d'échantillon"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Spécifications du type d'échantillon (client)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Spécifications du type d'échantillon (labo)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Types d'échantillon"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "État de l'échantillon"
 
@@ -4554,9 +4523,9 @@ msgstr "État de l'échantillon"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Point d'échantillonnage"
 
@@ -4584,17 +4553,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Rapports relatifs à l'échantillon"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Type d'échantillon"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Matrice de l'échantillon"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Type d'échantillon"
 
@@ -4604,30 +4573,30 @@ msgstr "Type d'échantillon"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Préleveur"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Échantillons"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Les échantillons de ce type doivent être traités comme dangereux"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Échantillons reçus vs. rapportés"
@@ -4636,62 +4605,62 @@ msgstr "Échantillons reçus vs. rapportés"
 msgid "Samples received vs. samples reported"
 msgstr "Échantillons reçus vs. échantillons rapportés"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Date d'échantillonnage"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Écart d'échantillonnage"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Écarts d'échantillonnage"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Fréquence d'échantillonnage"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4701,9 +4670,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Sauver"
 
@@ -4716,17 +4685,17 @@ msgstr "Sauvegarder les remarques"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Tâches planifiées"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Nom scientifique"
 
@@ -4734,16 +4703,16 @@ msgstr "Nom scientifique"
 msgid "Search"
 msgstr "Chercher"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "secondes"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4755,11 +4724,11 @@ msgstr "Sélectionner 'Enregistrement' si vous voulez que les étiquettes soient
 msgid "Select AR Templates to include"
 msgstr "Sélectionner le  modèle de DA à inclure"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Sélectionner l'interface de données"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Sélectionnez une conservation par défaut pour cette analyse. Si la conservation dépend d'une combinaison de types d'échantillons, spécifiez une conservation par type d'échantillon dans la table ci-dessous."
 
@@ -4767,11 +4736,11 @@ msgstr "Sélectionnez une conservation par défaut pour cette analyse. Si la con
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Sélectionnez une destination et la DA à dupliquer"
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Sélectionnez un gestionnaire à partir du personnel disponible configuré dans le paramétrage 'contacts du laboratoire'. Les gestionnaires de département sont référencés sur les rapports de résultats d'analyses contenant les analyses par département"
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Sélectionnez un échantillon pour créer une DA secondaire"
 
@@ -4783,7 +4752,7 @@ msgstr "Sélectionner tous les éléments"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Sélectionnez les analyses à inclure dans ce modèle"
 
@@ -4795,11 +4764,11 @@ msgstr "Sélectionner analyste"
 msgid "Select existing file"
 msgstr "Sélectionnez un fichier existant"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Sélectionnez si des analyses doivent être exclues de la facture"
 
@@ -4807,19 +4776,19 @@ msgstr "Sélectionnez si des analyses doivent être exclues de la facture"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Sélectionnez si c'est un certificat de calibration interne"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Sélectionnez si le calcul utilisé est le calcul spécifié par défaut dans la méthode par défaut. Si non sélectionné, le calcul peut être sélectionné manuellement"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Sélectionnez si les descriptions doivent être inclues"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4845,7 +4814,7 @@ msgstr "Sélectionnez le pays dans lequel le site sera affiché par défaut"
 msgid "Select the currency the site will use to display prices."
 msgstr "Sélectionnez la devise que le site va utiliser pour afficher les tarifs."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Sélectionnez le récipient par défaut à utiliser pour cette analyse. Si le récipient à utiliser dépend de la combinaison du type d'échantillon et de la conservation, spécifiez le récipient dans la table de types d'échantillon ci-dessous."
 
@@ -4857,7 +4826,7 @@ msgstr "Sélectionnez la page d'accueil par défaut. Ceci est utilisé lorsque u
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Sélectionnez l'équipement privilégié"
 
@@ -4865,7 +4834,7 @@ msgstr "Sélectionnez l'équipement privilégié"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr "Sélectionnez pour activer les étapes du workflow de collecte d'échant
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Sélectionnez quelles analyses devraient être inclues dans la feuille de travail"
 
@@ -4905,7 +4874,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Sélectionnez quel étiquette imprimer quand l'impression automatique est activée"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4917,7 +4886,7 @@ msgstr "Envoyer email"
 msgid "Separate"
 msgstr "Séparer"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Contenants distincts"
 
@@ -4925,32 +4894,28 @@ msgstr "Contenants distincts"
 msgid "Serial No"
 msgstr "N° de série"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Service"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "Le service est inclus dans le ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Services"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Définir la tâche de maintenance comme terminée."
 
@@ -4958,31 +4923,31 @@ msgstr "Définir la tâche de maintenance comme terminée."
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Définissez le nombre maximal de demandes d'analyses par email de résultats. Trop de colonnes par email peuvent être difficiles à lire."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Définissez les spécifications à utiliser avant de publier la DA."
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Configurez les spécifications des résultats d'analyse du laboratoire"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Code du rangement"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Description du rangement"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Titre du rangement"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Adresse d'expédition"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Titre court"
 
@@ -4998,7 +4963,7 @@ msgstr "Montrer les analyses QC"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Montrer uniquement les catégories dans les vues client"
 
@@ -5010,29 +4975,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Signature"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Code du site"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Description du site"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Titre du site"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Taille"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Petite icône"
 
@@ -5040,14 +5001,14 @@ msgstr "Petite icône"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Des analyses nécessitent des équipements hors calibration ou obsolètes. Édition des résultats non autorisée."
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Clé de tri"
 
@@ -5055,41 +5016,41 @@ msgstr "Clé de tri"
 msgid "Specification"
 msgstr "Spécification"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Spécifications"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Définissez la taille de la feuille de travail (ex : correspondant au nombre d'échantillons traitable en une série sur un équipement). Puis sélectionnez une analyse type par position de la feuille de travail. Là où les échantillons QC sont sélectionnés, sélectionnez aussi quel échantillon de référence devrait être utilisé. Si une analyse dupliquée est sélectionnée, indiquez de quel position d'échantillon c'est un réplicat."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "Définissez la valeur de l'incertitude pour une plage donnée, par exemple dans une plage avec un minimum de 0 et un maximum de 10 où l'incertitude est de 0.5, un résultat de 6.67 sera reporté comme 6.67+/-0.5. Vous pouvez aussi définir une valeur d'incertitude comme un pourcentage de la valeur du résultat, en ajoutant un '%' à la valeur saisie dans la colonne «Valeur de l'incertitude», par exemple pour les résultats ayant une incertitude de 2%, un résultat de 100 sera reporté comme 100+/-2. Assurez-vous que les plages successives sont continues (ex : 0.00 - 10.00 puis 10.01 - 20.00 puis 20.01 - 30 .00 etc.)."
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Date de début"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "État"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Statut"
 
@@ -5097,33 +5058,33 @@ msgstr "Statut"
 msgid "Sticker templates"
 msgstr "Modèles d'étiquettes"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Lieu de stockage "
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Lieux de stockage "
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Sous-groupe"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Sous-groupes"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Les sous-groupes sont triés avec cette clé dans la vue des groupes"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Soumettre"
 
@@ -5131,37 +5092,34 @@ msgstr "Soumettre"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Soumettez un fichier XML ouvert (.XLSX) contenant des enregistrements paramétrés dans Bika pour continuer."
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Sous-total"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Fournisseur"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Fournisseurs"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Numéro de commande"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Nom"
 
@@ -5181,11 +5139,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Tâche"
 
@@ -5194,20 +5152,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Type de tâche"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Description technique et instructions destinées aux analystes"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Température"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5225,35 +5183,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "La sélection de profil d'analyses pour ce modèle"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "L'ID attribuée à la demande client par le laboratoire"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "L'ID attribuée à l'échantillon client par le laboratoire"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Adresse web du laboratoire"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "La limite de détection basse est la plus petite valeur que peut prendre le paramètre évalué pouvant être mesurée en utilisant la méthode de dosage spécifiée. Les résultats saisis inférieurs à cette valeur seront rapportés comme < LDB"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "La limite de détection haute est la plus grande valeur que peut prendre le paramètre évalué pouvant être mesurée en utilisant la méthode de dosage spécifiée. Les résultats saisis supérieurs à cette valeur seront rapportés comme > LDH"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Le référentiel d'accréditation appliqué (ex : ISO 17025)"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Les analyses inclues dans ce profil, groupées par catégorie"
 
@@ -5265,7 +5223,7 @@ msgstr "Les analyses utilisées pour déterminer le poids sec."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "L'analyste ou technicien responsable de la calibration"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "L'analyste ou technicien responsable de la maintenance"
 
@@ -5273,12 +5231,12 @@ msgstr "L'analyste ou technicien responsable de la maintenance"
 msgid "The analyst responsible of the validation"
 msgstr "L'analyste responsable de la validation"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Les fichiers liés à la demande analytique et aux analyses"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "La catégorie à laquelle appartient l'analyse"
 
@@ -5286,19 +5244,19 @@ msgstr "La catégorie à laquelle appartient l'analyse"
 msgid "The date the instrument was installed"
 msgstr "La date à laquelle l'instrument a été installé"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Le marqueur décimal sélectionné lors du paramétrage de Bika LIMS sera utilisé."
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Le récipient par défaut. Les nouveaux échantillons sont automatiquement assignés à un conteneur de ce type, à moins que ce soit spécifié plus en détail par analyse"
 
@@ -5310,7 +5268,7 @@ msgstr "Le pourcentage de remise entré ici s'applique aux tarifs des clients ma
 msgid "The full URL: http://URL/path:port"
 msgstr "L'URL complète : http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "La hauteur ou profondeur à laquelle l'échantillon a été pris en charge"
 
@@ -5327,24 +5285,24 @@ msgstr "numéro de modèle de l'instrument"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Le laboratoire n'est pas accrédité ou aucune accréditation n'a été configurée."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Le département du laboratoire"
@@ -5361,27 +5319,27 @@ msgstr "Le nombre de zéros des ID échantillons."
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Le nombre de zéros de la partie numérique des DA dans les ID des DA"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "La liste des points d'échantillonnage à partir duquel ce type d'échantillon peut être collecté. S'il n'y a pas de points d'échantillonnage sélectionné, alors tous les points d'échantillonnage sont disponibles"
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "La liste des types d'échantillons qui peuvent être collectés à ce point d'échantillonnage. S'il n'y a pas de type d'échantillon sélectionné, alors tous les types sont disponibles"
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Les unités de mesure pour les résultats de cette analyse, e.g. mg/l, ppm, dB, mV, etc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Le volume minimal d'échantillon requis pour l'analyse e.g. '10 ml' ou '1 kg'."
 
@@ -5405,7 +5363,7 @@ msgstr "nombre de jours avant expiration du mot de passe. 0 désactive l'expirat
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Le nombre de jours avant qu'un échantillon expire et ne puisse plus être analysé. Ce paramétrage peut être écrasé par celui du type d'échantillon individuel."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5422,11 +5380,11 @@ msgstr "nombre de demandes et d'analyses"
 msgid "The number of requests and analyses per client"
 msgstr "nombre de demandes et d'analyses par client"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "Le pourcentage utilisé pour calculer le prix des analyses réalisées à cette priorité"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "La période à l'issue de laquelle les échantillons non conservés de ce type peuvent être gardés avant qu'ils n'expirent et ne puissent plus être analysés. "
 
@@ -5443,19 +5401,19 @@ msgstr "La personne chez le fournisseur qui a réalisé la tache"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "La personne chez le fournisseur qui a préparé le certificat"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "Le prix chargé par analyse pour les clients ayant des remises de gros."
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "L'ID du commercial pour les opérations comptables"
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "Le mot-clé du profil est utilisé pour l'identifier de manière unique dans les fichiers importés. Ce doit être unique, et ne peut pas non plus être identique à un identifiant unique de champ de calcul intermédiaire."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Code de référence délivré au laboratoire par l'organisme d'accréditation"
 
@@ -5463,11 +5421,11 @@ msgstr "Code de référence délivré au laboratoire par l'organisme d'accrédit
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "Les résultats de cette analyse peuvent être saisis manuellement"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Les résultats d'analyses de terrain sont acquis lors du prélèvement au point de prélèvement, par exemple la température d'un échantillon d'eau. Les analyses de laboratoire sont faites en laboratoire."
 
@@ -5475,7 +5433,7 @@ msgstr "Les résultats d'analyses de terrain sont acquis lors du prélèvement a
 msgid "The room and location where the instrument is installed"
 msgstr "La pièce et l'endroit où l'instrument est installé"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "Les équipements sélectionnés supportent cette méthode. Utilisez la vue d'édition de l'équipement pour assigner la méthode à un instrument spécifique."
 
@@ -5487,11 +5445,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Le numéro de série qui identifie de façon unique l'instrument"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "L'ID du protocole analytique du service"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "L'ID commercial du service pour les opérations comptables"
 
@@ -5499,19 +5457,19 @@ msgstr "L'ID commercial du service pour les opérations comptables"
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "La configuration globale par défaut permet d'indiquer par demande d'analyse que des pièces-jointes sont ou non requises ou permises, "
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Temps de traitement des analyses"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "Suivi graphique temporel du temps d'analyse"
 
@@ -5523,7 +5481,7 @@ msgstr "Les temps moyens d'analyses"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "Suivi graphique temporel du temps d'analyse"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "Le mot-clé unique utilisé pour identifier l'analyse dans les fichiers importés de demandes d'analyse et fichiers de résultats importés à partir d'équipements. C'est aussi utilisé pour identifier les analyses dépendantes dans les calculs de résultats définis par l'utilisateur."
 
@@ -5535,37 +5493,37 @@ msgstr "Il n'y a pas de résultats"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Ces résultats peuvent être reportés comme poids sec."
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Ces résultats ont été écrasés et sont listés ici pour des motifs de traçabilité. S'il vous plaît suivez le lien vers le recontrôle."
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "Cette demande d'analyse a été générée automatiquement suite au retrait de la demande d'analyse ${retracted_request_id}"
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Cette demande d'analyse a été écrasée et est montrée pour des raisons de traçabilité uniquement. Recontrôle : ${retest_child_id}"
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Cette analyse ne peut pas être activée parce que son calcul est inactif"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Cette analyse ne peut pas être désactivée parce qu'un ou plusieurs calculs en dépendent"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5577,7 +5535,7 @@ msgstr "Cette analyse ne requiert pas un fractionnement."
 msgid "This service requires a separate container."
 msgstr "Cette analyse requiert un récipient séparé."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5585,13 +5543,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "Ce texte sera ajouté aux rapports d'analyse."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Cette valeur est reportée au bas de tous les résultats publiés"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5605,63 +5559,63 @@ msgstr "Cette  feuille de travail a été rejetée. La feuille de travail de rem
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Astuce. Documents joints ne seront pas chargés à moins qu'il soient présents dans l'instance."
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Titre"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Titre de la localisation"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Titre du meuble"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Titre du site"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Jusqu'à"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "A conserver"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "A échantillonner"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Pour être affiché en dessous de chaque section \"catégorie d'analyses\" sur les comptes rendus"
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "A vérifier"
 
@@ -5673,13 +5627,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5687,22 +5641,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr "Délai total"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Prix Total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Total analyses"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Total points de données"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Prix total"
 
@@ -5714,11 +5668,11 @@ msgstr "Total :"
 msgid "Traceability"
 msgstr "Traçabilité"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5726,61 +5680,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Activez ceci uniquement si vous voulez travailler avec des aliquots"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Période (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Type"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Type d'erreur "
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Type de localisation"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Impossible de charger le modèle"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Impossible d'envoyer un email alertant les contacts client du laboratoire qu'une analyse a été invalidée : ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Non assigné"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incertitude"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valeur d'incertitude"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Non défini"
 
@@ -5788,13 +5736,13 @@ msgstr "Non défini"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unité"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "Le pays de l'IBAN est inconnu %s"
 
@@ -5819,17 +5767,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Non publié"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Format de fichier non reconnu ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Format de fichier non reconnu ${file_format}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5841,11 +5789,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Uploadez une signature qui sera utilisée à l'impression des rapports de résultats d'analyse. La taille idéale est de 250 pixels de large par 150 de haut."
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "Limite de Détection Haute (LDH)"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "Utiliser le prix du profil de l'analyse"
 
@@ -5853,7 +5801,7 @@ msgstr "Utiliser le prix du profil de l'analyse"
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Utilise le calcul par défaut"
 
@@ -5865,13 +5813,13 @@ msgstr "Utilisation d'un serveur ID externe"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Utilisez ce champ pour passer des paramètres arbitraires aux modules d'import/export."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Utilisateur"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nom utilisateur"
@@ -5884,7 +5832,7 @@ msgstr "Historique utilisateur"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Historique utilisateurs"
@@ -5893,27 +5841,27 @@ msgstr "Historique utilisateurs"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "L'utilisation de trop peu de points ne permet pas de donner un sens aux statistiques. Paramétrez un nombre minimal acceptable de résultats avant que les statistiques de QC soient calculées et représentées."
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "Taxes"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "Taxes %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Montant TVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "Total TVA"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "N° TVA"
 
@@ -5921,11 +5869,11 @@ msgstr "N° TVA"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Valide à partir de"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Valide jusqu'au"
 
@@ -5933,181 +5881,181 @@ msgstr "Valide jusqu'au"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validation"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Echec de la validation : '${keyword}' : mot clé dupliqué"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Échec de la validation : '${title}' : ce mot-clé est déjà utilisé par le calcul '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Échec de la validation : '${title}' : ce mot-clé est déjà utilisé par le service '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Échec de la validation : '${title}' : titre dupliqué"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Échec de validation : '${value}' n'est pas unique"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Échec à la validation: la direction doit être Est/Ouest"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Échec à la validation: la direction doit être Nord/Sud"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "échec de la validation. Le pourcentage d'erreur doit être compris entre 0 et 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Échec de la validation : la valeur d'erreur doit être supérieure ou égale à 0"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Échec de la validation : les valeurs d'erreur doivent être numériques"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "échec de la validation. Les valeurs attendues doivent être comprises entre les valeurs Min et Max"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "échec de la validation. Les valeurs attendues doivent être numériques"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Échec de la validation : le mot-clé '${keyword}' n'est pas valide"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "échec de la validation. Les valeurs Max doivent être supérieures au valeurs Min"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "échec de la validation. Les valeurs Max doivent être numériques"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Échec de la validation : les valeurs Min doivent être numériques"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Échec de la validation : les valeurs de pourcentage d'erreur doivent être entre 0 et 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Échec de la validation : les valeurs de pourcentage d'erreur doivent être numériques"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Échec de la validation : les conteneurs pré-conservés doivent avoir une conservation sélectionnée."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Échec de la validation : le résultat texte ne peut pas être vide."
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Echec à la validation: Les valeurs de résultat doivent être numériques"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Échec de la validation : la sélection nécessite que les catégories suivantes soient sélectionnées : ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Échec de la validation : les valeurs doivent être des nombres"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Échec de la validation : le titre de la colonne '${title}' doit avoir le mot-clé '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Échec de la validation : les degrés sont de 180 ; les minutes doivent être 0."
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Échec de la validation : les degrés sont 180; les minutes doivent être 0"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Échec de la validation : 90 degrés ; les minutes doivent être 0"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Échec de la validation : 90 degrés : les secondes doivent être 0"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Échec de la validation : les degrés doivent entre 0 et 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Echec à la validation: Le degré d'angle doit être entre 0 - 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Echec à la validation: un résultat en degrés doit être numérique"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Echec de la validation : le mot-clé '${keyword}' doit avoir un titre de colonne '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Echec à la validation: Le mot clé contient des caractères non-autorisés"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Echec de la validation : le mot-clé est requis"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Echec à la validation: Les minutes doivent être comprises entre 0 - 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Echec à la validation: un résultat en minutes doit être numérique"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Echec de la validation : les pourcentages doivent être compris entre 0 et 100"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Echec de la validation : les pourcentages doivent être des nombres"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Echec à la validation: Les secondes sont comprises entre 0 - 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Echec à la validation: un résultat en secondes doit être numérique"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Echec de la validation : le titre est requis"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6115,7 +6063,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "Date de validation du rapport"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Apporbateur "
@@ -6126,12 +6074,12 @@ msgstr "Apporbateur "
 msgid "Value"
 msgstr "Valeur"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Les valeurs rentrées ici remplaceront celles par défaut spécifiées dans les champs de calcul provisoires"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Vérifié"
@@ -6142,7 +6090,7 @@ msgstr "Vérifié"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Version"
 
@@ -6152,11 +6100,11 @@ msgstr "Version"
 msgid "Volume"
 msgstr "Volume"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Site Web de l'organisme d'accréditation"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Site Web"
 
@@ -6164,24 +6112,24 @@ msgstr "Site Web"
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Semaines avant expiration"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "Lorsque défini, le système utilise le prix indiqué dans le profil de l'analyse pour évaluer et la TVA définie dans le système est remplacée par celle indiquée dans le profil de l'analyse"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Lorsque dans des listes de travail, des résultats issus de doublons d'analyses effectués sur le même échantillon diffèrent de plus que ce pourcentage, une alerte est levée"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "Les caractères génériques ne sont pas autorisés pour les calculs provisoires : ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Travail effectué"
@@ -6192,25 +6140,25 @@ msgstr "Workflow"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Feuille de travail"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Présentation de la feuille de travail"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Modèles de feuille de travail"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Feuilles de travail"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6218,9 +6166,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Oui"
 
@@ -6232,7 +6180,7 @@ msgstr "Vous n'avez pas les privilèges suffisants pour gérer les feuilles de t
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "Vous n'avez pas de privilèges suffisants pour visualiser la feuille de travail ${worksheet_title}"
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "Vous devez assigner cette requête à un client"
 
@@ -6240,11 +6188,11 @@ msgstr "Vous devez assigner cette requête à un client"
 msgid "You must select an instrument"
 msgstr "Vous devez sélectionner un équipement"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "Action"
 
@@ -6260,15 +6208,15 @@ msgstr "analyse"
 msgid "analysis requests selected"
 msgstr "Demandes d'analyses sélectionnées"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6289,7 +6237,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6297,36 +6245,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6338,7 +6258,7 @@ msgstr "desactiver"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6386,19 +6306,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6406,19 +6326,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "Se répète tous les"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6437,19 +6357,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6461,7 +6370,7 @@ msgstr ""
 msgid "to"
 msgstr "à"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6469,7 +6378,7 @@ msgstr ""
 msgid "type"
 msgstr "type"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "jusqu'à"
 
@@ -6494,7 +6403,7 @@ msgstr "valeur"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6506,6 +6415,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/hi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hi/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hindi (http://www.transifex.com/bikalabs/bika-lims/language/hi/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} '${contact_username}' के नाम पर LIMS में लॉगिन कर सक्ते हैं। कांटेक्ट लोगों को अपने पासवर्ड बदलने चाहिए।  पासवर्ड भूल गया तो, प्रवेश फार्म से एक नया पासवर्ड अनुरोध कर सकते हैं। "
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} में परिरक्षक और संरक्षण की तारीख नहीं हैं।"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} संरक्षित होने की प्रतीक्षा कर रहे हैं। "
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} प्राप्त होने की प्रतीक्षा कर रहे हैं। "
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} अवैध गया है।"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} को सफलतापूर्वक बनाया गया था।"
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: विभाजनों को प्राप्त होने की प्रतीक्षा कर रहे हैं।"
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} में परिरक्षक और संरक्षण की तारीख नहीं है।"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} संरक्षित होने की प्रतीक्षा कर रहा है।"
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} प्राप्त होने की प्रतीक्षा कर रहा है।"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item}  बनाया गया था।"
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} प्राप्त होने की प्रतीक्षा कर रहा है।"
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(खाली)"
@@ -136,7 +136,7 @@ msgstr "(नियंत्रण)"
 msgid "(Duplicate)"
 msgstr "(नक़ल)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(खतरनाक)"
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr "(आवश्यक)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -210,17 +204,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "खातेदार"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "खाता संख्या"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "खाते का प्रकार"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -323,11 +317,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -388,7 +378,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -479,7 +469,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -520,52 +510,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -640,46 +630,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -813,25 +803,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1096,17 +1090,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1207,59 +1201,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1268,39 +1262,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1346,8 +1340,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1356,48 +1350,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1785,9 +1779,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2033,7 +2027,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2225,19 +2215,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2276,18 +2266,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2348,8 +2338,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2460,8 +2450,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2486,30 +2476,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2763,12 +2747,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2777,47 +2761,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2853,7 +2837,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2998,16 +2982,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3015,31 +2999,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3063,30 +3041,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4040,11 +4009,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4085,16 +4054,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4168,7 +4137,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4274,26 +4243,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4315,15 +4284,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5670,22 +5624,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5904,11 +5852,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6125,7 +6073,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6135,11 +6083,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/hu/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (http://www.transifex.com/bikalabs/bika-lims/language/hu/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} are missing Preserver or Date Preserved"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "megőrzésre várnak: ${items}."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "beérkeztetésre várnak: ${items}."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "érvénytelenítettek ${items}."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} sikeresen létrehozva"
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: partitions are waiting to be received."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} megőrzésre vár."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "beérkeztetésre vár: ${items}."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} sikeresen létrehozva."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} beérkeztetésre vár."
 
@@ -82,7 +82,7 @@ msgstr "${nr_items} tétel"
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Hiba"
 
@@ -96,15 +96,15 @@ msgstr "% Elvégzett"
 msgid "% Published"
 msgstr "% Közzétett"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s visszautasított"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s -nek nincs '%s' oszlopa."
 
@@ -116,15 +116,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(üres)"
@@ -137,7 +137,7 @@ msgstr "(ellenőrzés)"
 msgid "(Duplicate)"
 msgstr "(másolat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(kockázatos)"
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr "(kötelező)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "listákban ezen fontossághoz 16x16 pixel ikon használt."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "tárgy nézetben ezen fontossághoz 32x32 pixel ikon használt."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< legkisebb"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> legnagyobb"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "AR ${ar_number}"
 
@@ -203,7 +197,7 @@ msgstr "AR csatolmány beállítás"
 msgid "AR ID Padding"
 msgstr "AR ID helykitöltés"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "AR import"
 
@@ -211,17 +205,17 @@ msgstr "AR import"
 msgid "AR Import options"
 msgstr "AR import beállítások"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr "AR sablon fejléc"
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "AR sablonok"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "AR az újravizsgálatt eredményhez"
 
@@ -229,54 +223,54 @@ msgstr "AR az újravizsgálatt eredményhez"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "AR-ek: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Bankszámla neve"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Bankszámla száma"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Bankszámla típusa"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akkreditáció"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akkreditáló testület rövidítése"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akkreditáló testület URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akkreditálás logo"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akkreditáció hivatkozás"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Akkreditáció lap fejléc"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akkreditált"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr "Felhasználók (vagy meghatározott felhasználó) által egy időtartam
 msgid "Activate"
 msgstr "Aktivál"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Működő"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Véletlenszerű"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Hozzáadás"
 
@@ -324,11 +318,7 @@ msgstr "Ellenőrző referencia hozzáadása"
 msgid "Add Duplicate"
 msgstr "Másolat hozzáadása"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Megjegyzés hozzáadás"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Sablon hozzáadás"
 
@@ -336,16 +326,16 @@ msgstr "Sablon hozzáadás"
 msgid "Add a remarks field to all analyses"
 msgstr "Megjegyzés mező hozzáadás minden vizsgálathoz"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Új hozzáadása"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "További megjegyzések:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Cím"
@@ -358,26 +348,26 @@ msgstr "Két számjegyű évszám hozzáadás az ID előtag után"
 msgid "Administrative Reports"
 msgstr "Adminisztratív jelentések"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "${end_date} után"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Ügynökség"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Mind"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Az összes akkreditált vizsgálati szolgáltatás listája"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Az összes vizsgálat hozzárendelve"
 
@@ -389,7 +379,7 @@ msgstr "Az összes adott típusú vizsgálat"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Ügyfél felvétel és módosítás engedélyezése a labor ügyintéző számára"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Kézi érzékelés határ bevitele megengedett"
 
@@ -397,15 +387,15 @@ msgstr "Kézi érzékelés határ bevitele megengedett"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Kézi bizonytalanság érték beviteli megengedett"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Mannyiség"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Vizsgálatok"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr "Vizsgálat folyamatban"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Vizsgálat szolgáltatásonkénti vizsgálatok "
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Minta típusonkénti vizsgálatok"
@@ -480,7 +470,7 @@ msgstr "Szolgáltatásonkénti vizsgálatok"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -493,27 +483,27 @@ msgstr "Vizsgálathoz kapcsolódó jelentések"
 msgid "Analyses repeated"
 msgstr "Megismételt vizsgálatok"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Vizsgálat"
 
@@ -521,52 +511,52 @@ msgstr "Vizsgálat"
 msgid "Analysis Attachment Option"
 msgstr "Vizsgálat csatolmány beállítás"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Vizsgálat kategóriák"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Vizsgálat kategória"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Vizsgálat kulcsszó"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Vizsgálat profil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Vizsgálat profilok"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Vizsgálat kérés"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Vizsgálat kérés ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Vizsgálat kérés importok"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Vizsgálat kérések fontossága"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Vizsgálat kérések meghatározása"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr "Vizsgálat kérés sablonok"
 
@@ -574,65 +564,65 @@ msgstr "Vizsgálat kérés sablonok"
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Vizsgálat kérések"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Vizsgálati kérelmek függőben levő eredményekkel"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Vizsgálat szolgáltatás"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Vizsgálat szolgáltatások"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Vizsgálat meghatározás"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Vizsgálat meghatározások"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Vizsgálat állapot"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Vizsgálat típus"
@@ -641,46 +631,46 @@ msgstr "Vizsgálat típus"
 msgid "Analysis category"
 msgstr "Vizsgálat kategória"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Vizsgálat eredmények"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -688,12 +678,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Vizsgálat szolgáltatás"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -709,17 +699,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Vizsgáló"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "bármely"
 
@@ -740,7 +730,7 @@ msgstr "Alkalmaz"
 msgid "Apply template"
 msgstr "Sablon alkalmazása"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr "Leltári szám"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Kijelölt/hozzárendelt"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Munkanaplóhoz rendelve"
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Csatolja hozzá"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Csatolmány"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Csatolmány kulcs"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Csatolmány beállítás"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Csatolmány típus"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Csatolmány típusok"
 
@@ -814,25 +804,25 @@ msgstr "Csatolmány típusok"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Csatolmány nem megengedett"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Csatolmány szükséges"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Csatolmány típus"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Csatolmányok"
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Automatikus kitöltés"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Autoimport"
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr "Elérhető sablonok"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Hibás állapot formátum:: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Bank üzletág"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Bank név"
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr "Alap"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Köteg"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Köteg ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Köteg címke"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Kötegek"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Fontosság"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "${start_date} előtt"
 
@@ -922,7 +912,7 @@ msgstr "${start_date} előtt"
 msgid "Biannual"
 msgstr "Féléves"
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Nagy ikon"
 
@@ -930,7 +920,7 @@ msgstr "Nagy ikon"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS konfiguráció"
 
@@ -938,63 +928,67 @@ msgstr "Bika LIMS konfiguráció"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Számlázási cím"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Üres"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Üres QC vizsgálat"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Védjegy"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Csoportos kedvezmény alkalmazás"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Ömlesztett ár (Áfa nélkül)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Üzleti telefon"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Számítás"
 
@@ -1002,8 +996,8 @@ msgstr "Számítás"
 msgid "Calculation Formula"
 msgstr "Számítási képlet"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Számítás ideiglenes mezők"
@@ -1016,11 +1010,11 @@ msgstr "Számítás: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Számítás: nincs"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Számítások"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Hitelesítés"
 
@@ -1032,12 +1026,12 @@ msgstr "Hitelesítés tanúsítvány"
 msgid "Calibration report date"
 msgstr "Hitelesítés jelentés kelte"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Hitelesítő"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégse"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Visszavont"
 
@@ -1069,18 +1063,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Kapacitás"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Elfogott"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr "Sarkalatos"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalógus szám"
 
@@ -1097,17 +1091,17 @@ msgstr "Katalógus szám"
 msgid "Categorise analysis services"
 msgstr "Vizsgálat szolgáltatások osztályozása"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategória"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Jelölje itt, ha ez a tároló már megőrzött. Ha eszt beállítja, ez rövidre zárja a megőrzési munkafolyamatot azon minta részekre, amelyek ebben a tárolóban vannak elhelyezve."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Jelölje itt, ha az Ön laboratóriuma akkreditált"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr "Város"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klasszikus"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "Kattintson a letöltéshez"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Ügyfél"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "Ügyfél köteg ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Ügyfél ID"
 
@@ -1208,59 +1202,59 @@ msgstr "Ügyfél ID"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Ügyfél neve"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Ügyfél rendelés"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Ügyfél rendelés szám"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ügyfél hiv."
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Ügyfél hivatkozás"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Ügyfél SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Ügyfél minta ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "A kérelem beadáshoz ügyfél kapcsolat szükséges"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Ügyfelek"
 
@@ -1269,39 +1263,39 @@ msgstr "Ügyfelek"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Lezárt"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "A hely kódja"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "A polc kódja"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Vessző (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Megjegyzések"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "Kereskedelmi ID"
 
@@ -1309,21 +1303,21 @@ msgstr "Kereskedelmi ID"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Összetett"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Hihetőség szint %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "Jelszó jóváhagyás"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Megfontolások"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kapcsolat"
@@ -1347,8 +1341,8 @@ msgstr "Kapcsolat"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kapcsolatok"
@@ -1357,48 +1351,48 @@ msgstr "Kapcsolatok"
 msgid "Contacts to CC"
 msgstr "Kapcsolatok CC-hez"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Tároló"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tároló típus"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tároló típusok"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Tárolók"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tartalom típus"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tartalom típus"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Felügyelet"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr "Vizsgálat szolgáltatás másolás"
 msgid "Copy from"
 msgstr "Másol innen"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Új másolat létrehozás"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Szám (végösszeg)"
 
@@ -1432,18 +1426,18 @@ msgstr "Ország"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Új azonos típusú minta létrehozása"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Létrehozva"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Létrehozta"
 
@@ -1451,7 +1445,7 @@ msgstr "Létrehozta"
 msgid "Created by:"
 msgstr "Létrehozta:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Létrehozó"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Követelmény"
 
@@ -1468,12 +1462,12 @@ msgstr "Követelmény"
 msgid "Currency"
 msgstr "Pénznem"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Jelenlegi"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Felhasználó által meghatározott tizedes pont"
 
@@ -1486,7 +1480,7 @@ msgstr "DL"
 msgid "Daily"
 msgstr "Napi"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr "Adat interfész"
 msgid "Data Interface Options"
 msgstr "Adat interfész beállítások"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Dátum"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Létrehozás ideje"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Feladás kelte"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Date Disposed"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Lejárat kelte"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Importálás kelte"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Feltöltés kelte"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Megnyitás kelte"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Megőrzés kelte"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Kiadás kelte"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Átvétel kelte"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Igényelt dátum"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Mintavétel kelte"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr "A hitelesítés tanúsítvány érvényességének kezdete"
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr "A tanúsítvány érvényességi ideje"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Napok"
 
@@ -1640,17 +1634,17 @@ msgstr "A következő hitelesítés ellenőrzésig deaktiválás"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Alapértelmezett"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Alapértelmezett AR specifikációk"
 
@@ -1658,49 +1652,49 @@ msgstr "Alapértelmezett AR specifikációk"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Alapértelmezett számítás"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Alapértelmezett tároló"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Alapértelmezett tároló típus"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Alapértelmezett műszer"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Alapértelmezett módszer"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Alapértelmezett megőrzés"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Alapértelmezett sürgősség"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Alapértelmezett kategóriák"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Alapértelmezett tizedes pont"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Alapértelmezett érték"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Fok(ozat)ok"
 
@@ -1786,9 +1780,9 @@ msgstr "Fok(ozat)ok"
 msgid "Delete attachment"
 msgstr "Csatolmány törlése"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Osztály"
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Függő vizsgálatok"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Leírás"
 
@@ -1815,7 +1809,7 @@ msgstr "Leírás"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "A polc leírása"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "A hely leírása"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Engedmény %"
 
@@ -1851,16 +1845,16 @@ msgstr "Engedmény %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Feladva"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Érték megjelenítés"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Leszállítás kelte"
 
@@ -1881,8 +1875,8 @@ msgstr "Leszállítás kelte"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Leszállítva"
@@ -1891,54 +1885,54 @@ msgstr "Leszállítva"
 msgid "District"
 msgstr "Kerület"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Nullával osztás"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Dokumentum"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Alvó"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Pont (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Innen"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Ide"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Letölt"
 
@@ -1951,20 +1945,20 @@ msgstr "Száraz"
 msgid "Dry matter analysis"
 msgstr "Szárazanyag vizsgálat"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Esedékesség"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Esedékesség kelte"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Másolat"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Ennek a másolata"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Időtartam"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Korai"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Emelés"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Email cím"
 
@@ -2034,7 +2028,7 @@ msgstr "Email cím"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Email tárgy sor"
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Határidő"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Fokozás"
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Írja be az engedmény százalék értékét"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Írja be az Ön labor szolgáltatása akkreditációjának részleteit. A következő mező jelölések használhatók:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
@@ -2114,45 +2108,45 @@ msgstr "Írja be az Ön labor szolgáltatása akkreditációjának részleteit. 
 msgid "Entity"
 msgstr "Jogi személy"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Számlából  kizár"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Várt eredmény"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Várt értékek"
 
@@ -2161,19 +2155,19 @@ msgstr "Várt értékek"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Lejárt"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Lejárat kelte"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (üzleti)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Nő"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Terület"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Mező vizsgálat"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Területi megőrzés"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "File"
 
@@ -2226,19 +2216,19 @@ msgstr "File"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Fájl név"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Keresztnév"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Képlet"
 
@@ -2277,18 +2267,18 @@ msgstr "Képlet"
 msgid "From"
 msgstr "Tól"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "${start_date}-tól ${end_date}-ig"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Teljes név"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr "Jelentés létrehozás"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Üdvözlő cím, mint Úr, Asszony, Dr"
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr "Csoport képző"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Csoportosítási időtartam"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Kockázatos"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Rejtett"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Rejtett mező"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Órák"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Ha a mintát ismételten veszik erről a mintavételi ponton, akkor itt adja meg a gyakoriságot, pl.: hetente"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr "Ha bejelöli, az eszköz nem lesz elérhető amíg a követjező hiteles
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Ha a tároló előre megőrzött, itt lehet kiválasztani a megőrzési módot."
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Import"
@@ -2452,7 +2442,7 @@ msgstr "Import"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importált"
@@ -2461,8 +2451,8 @@ msgstr "Importált"
 msgid "In-lab calibration procedure"
 msgstr "Laboron belüli hitelesítő eljárás"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Nem működő"
@@ -2471,7 +2461,7 @@ msgstr "Nem működő"
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Leírás hozzávétele"
 
@@ -2487,30 +2477,27 @@ msgstr "Leírás hozzávétele"
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Öröklés innen"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr "Telepítés kelte"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Előírások"
@@ -2547,17 +2534,17 @@ msgstr "Előírások a vizsgáló számára a laboron belüli rendszeres hiteles
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Előírások a vizsgáló számára a rendszeres megelőző és karbantartási eljáráshoz"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Műszer"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Belső hitelesítések"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr "Műszer import"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Műszer karbantartás"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Műszer típusok"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Műszer hitelesítések"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr "Műszer típus"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Műszerek"
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Belső hitelesítés ellenőrzések"
 
@@ -2685,24 +2672,21 @@ msgstr "Interpoláció"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Érvénytelen"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Számla"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Számla kelte"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Számlaszám"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Nem működő tétel"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr "Foglalkozás"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Foglalkozás"
 
@@ -2764,12 +2748,12 @@ msgstr "Foglalkozás"
 msgid "Key"
 msgstr "Kulcs"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Kulcs hiba"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Kulcsszó"
@@ -2778,47 +2762,47 @@ msgstr "Kulcsszó"
 msgid "Keywords"
 msgstr "Kulcsszavak"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Labor"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Labor vizsgálatok"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Labor kapcsolatok"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Labor osztályok"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Labor megőrzések"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Labor termékek"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Labor URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Címke"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratórium"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Akkreditált laboratórium"
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Utolsó módosítás kelte"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Kapcsolt minta"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr "Beállítási adatok feltöltése"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr "Feltöltés fájlból"
 msgid "Load the certificate document here"
 msgstr "A tanúsítvány dokumentumot itt töltse fel"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Feltöltve"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Hely kód"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Hely leírás"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Hely felirat"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Hely típus"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "A minta tárolás helye"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Minta vétel helye"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Napló"
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Vezető"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Vezető telefon"
 
@@ -3016,31 +3000,25 @@ msgstr "Vezető telefon"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Kézi adatbevitel"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "A lehetséges legnagyobb minta mérete, terjedelme."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Tagsági kedvezmény alkalmazás"
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Módszer"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Eljárás dokumentum"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "Módszer ID"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr "Módszer: ${method_name}"
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Második keresztnév"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Legkevesebb mennyiség"
 
@@ -3164,27 +3142,27 @@ msgstr "Legkevesebb mennyiség"
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Percek"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Mobil telefon"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr "Több"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Név"
 
@@ -3225,17 +3203,17 @@ msgstr "Név"
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Nincs kiválasztott fájl"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "Azonosító"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "A megőrzött mintát ezen időtartam alatt kell elrendezni (dispose). Ha nincs megadva, akkor a mintatípusbeli adatmegőrzési időszak lesz használva."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Nyitott"
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Függőben"
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr "Periódus"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefon (üzleti)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefon (magán)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefon (mobil)"
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Tényleges cím"
 
@@ -3678,7 +3647,7 @@ msgstr "Tényleges cím"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Töltse fel a web lapjánés az eredmény jelentésekben engedélyezett logót. Maximális méret 175 x 175 pixel."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Helyzet"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Posta cím"
 
@@ -3721,16 +3690,16 @@ msgstr "Posta cím"
 msgid "Postal code"
 msgstr "Irányítószám"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Előre megőrzött"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Megőrzés"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Megőrzés kategória"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Megőrzések"
 
@@ -3814,14 +3783,14 @@ msgstr "Megőrzések"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr "Megelőző karbantartási eljárás"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Ár (Áfa nélkül)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Ár Áfa nélkül"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Árlista ehhez:"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Sürgősség"
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr "Közzététel beállítás"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Negyedévenkénti"
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Érkezett"
 
@@ -4041,11 +4010,11 @@ msgstr "Érkezett"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr "Átvétel függőben"
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr "Referencia szállító"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "A referencia meghatározás a minőség ellenőrzéskor használt referencia meghatározás, vagy minta típus"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Megjegyzések"
 
@@ -4169,7 +4138,7 @@ msgstr "Megjegyzések"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Szárazanyagként jelentse"
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Jelentések"
 
@@ -4259,15 +4228,15 @@ msgstr "Jelentések"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Szűkítse a kategóriákat"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr "Eredmények függőben"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Adatmegőrzési időszak"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Minta mátrix"
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Mintavételi pont"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Mintavételi pontok"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Minta típus előtag"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Mintavételi pont"
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Minta mátrix"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Mintavevő"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Az ilyen típusú mintákat kockázatosnak kell kezelni"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Mintavétel kelte"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Mintavételi eltérés"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Mintavételi eltérések"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Mintavétel gyakoriság"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr "Megjegyzés mentése"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Tudományos neve"
 
@@ -4718,16 +4687,16 @@ msgstr "Tudományos neve"
 msgid "Search"
 msgstr "Keresés"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr "Jelölje ki a hozzáveendő AR sablonokat"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Válassza ki a vezetőt a rendelkezésre álló személyek közül, akiket a 'labor kapcsolatok' pontban beállított. Az osztály vezetői az osztályuk által végzett vizsgálatokat tartalmazó jelentésekben bekerölnek,"
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Jelölje meg, hogy mely vizsgálatot kerüljenek be a sablonba"
 
@@ -4779,11 +4748,11 @@ msgstr "Válasszon vizsgálót"
 msgid "Select existing file"
 msgstr "Válasszon létező fájlt"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Válassza ki a hozzáveendő leírásokat"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Válassza ki a az előnyben részesített eszközt"
 
@@ -4849,7 +4818,7 @@ msgstr "Válassza ki a az előnyben részesített eszközt"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Jelölje, hogy mely vizsgálatok legyenek a munkalapon"
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "Sorozatszám"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Polc kód"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Polc leírás"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Polc név"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr "Több megjelenítés"
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr "Mutat/letakar idő összegzés"
 msgid "Signature"
 msgstr "Aláírás"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Hely kód"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Hely leírás"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Hely neve"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Rendező kulcs"
 
@@ -5039,41 +5000,41 @@ msgstr "Rendező kulcs"
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Kezdő időpont"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Megye"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr "Megállapítások"
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Az alcsoportok ezen kulcs szerinti rendezettségben jelennek meg a csoport nézetben"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Szállító"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Szállítók"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Családnév"
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr "Rendszer műszerfal"
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "A vizsgálati profil kiválasztása a sablonhoz"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "A laboratórium web lapjának címe"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Az alkalmazott akkreditációs szabvány, pl. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Az alapértelmezett tároló. Az új minta részek automatikusan ilyen típusú tárolóhoz rendelődnek, hacsak eznincs részletesebben maghatározva vizsgálat szolgáltatásonként."
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr "Az eszköz model száma"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "A laboratórium osztálya"
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Mintavételi pontok listája, ahonnan ez a mintatípus összegyüjthető. Ha nincs kiválasztva, akkor minden mintavételi pont rendelkezésre áll."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "A legkevesebb minta mennyiség, ami szükséges a vizsgálathoz, pl. '10 ml§, vagy '1 kg'."
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Az az időtartam, amíg az ilyen típusú nem megőrzött minták megőrízhetők mielőtt lejárnának és tovább nem vizsgálhatók"
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Az akkreditáló testület által a labornak kiadott hivatkozási szám."
 
@@ -5447,11 +5405,11 @@ msgstr "Az akkreditáló testület által a labornak kiadott hivatkozási szám.
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "A sorozatszám az eszköz egyedi azonosítója"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Az eredmény száraz anyagként lesz jelentve"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,13 +5527,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Ez az érték minden kiadott eredmény(lap) alján megjelenik"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Cím"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Hely neve"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "A polc neve"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "A hely neve"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Megőrzendő"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Mintavételezendő"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Az eredmény jelentés minden vizsgálat kategória szakaszában megjelenítődik."
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Megőrzendő"
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr "Közzéteendő"
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Mintavételezendő"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Ellenőrzendő"
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5671,22 +5625,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5698,11 +5652,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Mértékegység"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "Ismeretlen IBAN ország %s"
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Nem kibocsájtott"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Ismeretlen fájl formátum ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Ismeretlen fájl formátum ${file_format}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Töltse fel a szkennelt aláírást, amit a nyomtatott vizsgálati jelentésekben kell használni. Az ideális mérte 250 pixel széles és 150 pixel magas."
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr "Használja a műszerfalat főoldalként"
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Alapértelmezett számítás használata"
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Felhasználó"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Felhasználó név"
@@ -5868,7 +5816,7 @@ msgstr "Felhasználó történet"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Felhasználók története"
@@ -5877,27 +5825,27 @@ msgstr "Felhasználók története"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "Áfa"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "Áfa %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Áfa mennyiség"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Áfa szám"
 
@@ -5905,11 +5853,11 @@ msgstr "Áfa szám"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Érvényesség kezdete"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Érvényesség vége"
 
@@ -5917,181 +5865,181 @@ msgstr "Érvényesség vége"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Érvényesítés"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Ellenőrzött"
@@ -6126,7 +6074,7 @@ msgstr "Ellenőrzött"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Változat"
 
@@ -6136,11 +6084,11 @@ msgstr "Változat"
 msgid "Volume"
 msgstr "Mennyiség"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Akkreditáló testület web lapjának címe"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Weblap."
 
@@ -6148,24 +6096,24 @@ msgstr "Weblap."
 msgid "Weekly"
 msgstr "Heti"
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Munkalap"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Munkalap elrendezés"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Munkalap sablonok"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Munkalap"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr "Éves"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6281,36 +6229,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr "hatástalanít"
 msgid "heading_arpriority"
 msgstr "AR sürgősség"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "hatástalan"
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "ismétlési idő"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr "Alapértelmezett hely név"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr "cím_kötelező"
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr "típus"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6478,7 +6387,7 @@ msgstr "érték"
 msgid "verification(s) pending"
 msgstr "Ellenőrzés(ek) függőben"
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/hu_HU/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/hu_HU/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/bikalabs/bika-lims/language/hu_HU/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/id/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/id/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/bikalabs/bika-lims/language/id/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} siap untuk proses pengawetan."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} menunggu untuk proses penerimaan."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} berhasil dibuat."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} siap untuk diawetkan."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s telah ditolak"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -136,7 +136,7 @@ msgstr "(Kontrol)"
 msgid "(Duplicate)"
 msgstr "(Duplikat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Berbahaya)"
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr "(Dibutuhkan)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -210,17 +204,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -323,11 +317,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -388,7 +378,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -479,7 +469,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -520,52 +510,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -640,46 +630,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -813,25 +803,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1096,17 +1090,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1207,59 +1201,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1268,39 +1262,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1346,8 +1340,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1356,48 +1350,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1785,9 +1779,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2033,7 +2027,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2225,19 +2215,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2276,18 +2266,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2348,8 +2338,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2460,8 +2450,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2486,30 +2476,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2763,12 +2747,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2777,47 +2761,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2853,7 +2837,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2998,16 +2982,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3015,31 +2999,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3063,30 +3041,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4040,11 +4009,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4085,16 +4054,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4168,7 +4137,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4274,26 +4243,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4315,15 +4284,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5670,22 +5624,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5904,11 +5852,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6125,7 +6073,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6135,11 +6083,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/it/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/it/LC_MESSAGES/bika.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Italian (http://www.transifex.com/bikalabs/bika-lims/language/it/)\n"
@@ -30,49 +30,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} puoi accedere al LIMS utilizzando ${contact_username} come nome utente. l'utenti devono modificare le proprie passwords. Se la password viene dimenticata un utente può richiedere una nuova password dalla pagina di accesso."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} mancano Conservatore o Data di Conservazione"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} sono in attesa della conservazione."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} sono in attesa di essere ricevuti."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} invalidati."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} è stato creato con successo."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: le suddivisioni sono in attesa di essere ricevute."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} manca Conservatore o Data di Conservazione"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} è in attesa della conservazione."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} è in attesa di essere ricevuto."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} è stato creato con successo."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} è in attesa di essere ricevuto."
 
@@ -88,7 +88,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Errore"
 
@@ -102,15 +102,15 @@ msgstr "% Eseguito"
 msgid "% Published"
 msgstr "% Pubblicato"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s ha n. '%s' colonne."
 
@@ -124,15 +124,15 @@ msgstr ""
 "'Classico' indica l'importazione di richieste analisi per campione e selezione di servizi di analisi.\n"
 "Con 'Profili', le parole chiave profilo analisi sono utilizzate per selezionare servizi di analisi multipli insieme"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(vuoto)"
@@ -145,7 +145,7 @@ msgstr "(Controllo)"
 msgid "(Duplicate)"
 msgstr "(Duplicato)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Pericoloso)"
 
@@ -154,32 +154,26 @@ msgid "(Required)"
 msgstr "(Richiesto)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Icona da 16x16 pixel utilizzata per questa priorità negli elenchi"
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Icona da 32x32 utilizzata per questa priorità nelle viste di oggetti."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -190,16 +184,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "RA ${ar_number}"
 
@@ -211,7 +205,7 @@ msgstr "Opzione per gli allegati RA"
 msgid "AR ID Padding"
 msgstr "RA ID Padding"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importazione RA"
 
@@ -219,17 +213,17 @@ msgstr "Importazione RA"
 msgid "AR Import options"
 msgstr "Opzioni di importazione RA"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Modelli RA"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "RA per risultati rianalizzati"
 
@@ -237,54 +231,54 @@ msgstr "RA per risultati rianalizzati"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "RA: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nome Account"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Numero Account"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo Account"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Accreditamento"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abbreviazione Corpo Accreditamento"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL Corpo Accreditamento"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logo Accreditamento"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Riferimento Accreditamento"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Intestazione pagina accreditamento"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Accreditato"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -298,21 +292,21 @@ msgstr "Azione eseguita dagli utenti (o specifico utente) all'interno di un peri
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Attivo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad Hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Aggiungi"
 
@@ -332,11 +326,7 @@ msgstr "Aggiungi referenza di controllo"
 msgid "Add Duplicate"
 msgstr "Aggiungi duplicato"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Aggiungi un template"
 
@@ -344,16 +334,16 @@ msgstr "Aggiungi un template"
 msgid "Add a remarks field to all analyses"
 msgstr "Aggiungi un campo note a tutte le analisi"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Aggiungi nuovo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Note aggiuntive:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Indirizzo"
@@ -366,26 +356,26 @@ msgstr "Aggiungi due cifre dell'anno dopo il prefisso ID"
 msgid "Administrative Reports"
 msgstr "Reports Amministrativi"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Dopo il ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agenzia"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Tutto"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Di seguito sono elencati tutti i servizi di analisi accreditati."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Tutte le analisi assegnate"
 
@@ -397,7 +387,7 @@ msgstr "Tutte le analisi per tipo"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Permetti agli Addetti di Laboratorio ndi creare e modificare i clienti"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Permetti inserimento Limite Rilevamento Manuale"
 
@@ -405,15 +395,15 @@ msgstr "Permetti inserimento Limite Rilevamento Manuale"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Permetti l'accesso al foglio di lavoro solo alle analisi assegnate"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Permetti l'inserimento manuale dei valori di incertezza"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -421,11 +411,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Permetti all'analista di sostituire manualmente i limiti predefiniti di rivelazione (inferiore LDL e superiore UDL) nella vista di inserimento risultati"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Permetti all'analista di sostituire manualmente il valore predefinito di incertezza."
 
@@ -433,48 +423,48 @@ msgstr "Permetti all'analista di sostituire manualmente il valore predefinito di
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Calcolo Alternativo"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Espandere sempre la categoria selezionata nella vista cliente"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Quantità"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analisi"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Analisi in errore marginale dell'intervallo"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analisi fuori scala"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Analisi per servizio di analisi"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analisi per tipo di campione"
@@ -488,7 +478,7 @@ msgstr "Analisi per servizio"
 msgid "Analyses performed and published as % of total"
 msgstr "Analisi eseguite e pubblicate come % del totale"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Analisi eseguite come % del totale"
 
@@ -501,27 +491,27 @@ msgstr "Analisi correlate ai reports"
 msgid "Analyses repeated"
 msgstr "Analisi ripetute"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Risultato analisi fuori dall'intervallo specificato"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Analisi rieffettuata"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Sintesi analisi per dipartimento"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Analisi che sono state rieseguite"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analisi"
 
@@ -529,52 +519,52 @@ msgstr "Analisi"
 msgid "Analysis Attachment Option"
 msgstr "Opzioni Allegati per Analisi"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorie per analisi"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoria analisi"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Parole chiavi per Analisi"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Profilo analisi"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Profili di Analisi"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Richiesta Analisi"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID Richiesta Analisi"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importazioni di richieste di analisi"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Priorità Richiesta Analisi"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Specifiche Richiesta Analisi"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -582,65 +572,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Richieste di Analisi"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Servizio di Analisi"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Servizi di analisi"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Specifiche delle Analisi"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Specifiche delle analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Stato Analisi"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo Analisi"
@@ -649,46 +639,46 @@ msgstr "Tipo Analisi"
 msgid "Analysis category"
 msgstr "Categoria analisi"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "La richiesta analisi ${AR} è stata creata con successo."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Le richieste analisi ${ARs} sono state create con successo."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Richieste di analisi e analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Richieste di analisi e analisi per cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Richieste di analisi non fatturate"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Risultato analisi nell'intervallo di errore"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Risultati analisi"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Risultati analisi per ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Risultati analisi per punto di campionamento e servizio di analisi"
 
@@ -696,12 +686,12 @@ msgstr "Risultati analisi per punto di campionamento e servizio di analisi"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Risultati analisi fuori dallo specifico intervallo di laboratorio o committente. Si noti che questo può richiedere diversi minuti"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Servizio di analisi"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Le specifiche dell'analisi sono state riportate ai valori predefiniti del laboratorio."
 
@@ -717,17 +707,17 @@ msgstr "Tempo di risposta analisi"
 msgid "Analysis turnaround time over time"
 msgstr "Tempo di risposta analisi fuori limite"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Tempi di risposta analisi"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Tempi di risposta analisi fuori limite"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -736,7 +726,7 @@ msgid "Analyst must be specified."
 msgstr "Deve essere specificato l'Analista."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Qualunque"
 
@@ -748,7 +738,7 @@ msgstr "Applica"
 msgid "Apply template"
 msgstr "Applica il template"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Apllica ampiamente"
 
@@ -766,15 +756,15 @@ msgstr "Bene Numero"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Assegnato"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Assegnato al foglio di lavoro"
 
@@ -792,27 +782,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Collega a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Allegato"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Chiavi Allegate"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opzioni Allegato"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipo Allegato"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipo allegati"
 
@@ -822,25 +812,25 @@ msgstr "Tipo allegati"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Allegato non consentito"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Allegato richiesto"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipo allegato"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Allegati"
 
@@ -852,7 +842,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Riempimento automatico"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Importazione automatica"
 
@@ -869,27 +859,27 @@ msgstr "Stampa etichette automatica"
 msgid "Available templates"
 msgstr "Modelli disponibili"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Media TAT"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Media vicino"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Media superiore"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Stato malformato: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Filiale Banca"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nome banca"
 
@@ -898,31 +888,31 @@ msgid "Basis"
 msgstr "Base"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Batch"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID Batch"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etichette Batch"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Batches"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Posizione"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Prima del ${start_date}"
 
@@ -930,7 +920,7 @@ msgstr "Prima del ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Icona Grande"
 
@@ -938,7 +928,7 @@ msgstr "Icona Grande"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configurazione Bika LIMS"
 
@@ -946,63 +936,67 @@ msgstr "Configurazione Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Indirizzo fatturazione"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Vuoto"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Controllo qualità analisi vuoto"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Scontistica grandi quantità applicata"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Prezzo grandi quantità (IVA esclusa)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Telefono Ufficio"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Da"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC Contatti"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calcola Precisione da Incertezze"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Calcoli"
 
@@ -1010,8 +1004,8 @@ msgstr "Calcoli"
 msgid "Calculation Formula"
 msgstr "Formula di Calcolo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campi Calcolo Provvisorio"
@@ -1024,11 +1018,11 @@ msgstr "Calcolo: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Calcolo: Nessuno"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Calcoli"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibrazione"
 
@@ -1040,12 +1034,12 @@ msgstr "Certificati di Calibrazione"
 msgid "Calibration report date"
 msgstr "Data report calibrazione"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibratore"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1059,9 +1053,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancellato"
 
@@ -1077,18 +1071,18 @@ msgstr "Impossibile disattivare il calcolo, perché è in uso da parte dei segue
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Non è possibile verificare: Inserito dall'utente corrente"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacità"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Catturato"
 
@@ -1097,7 +1091,7 @@ msgid "Cardinal"
 msgstr "Cardinale"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Numero di Catalogo"
 
@@ -1105,17 +1099,17 @@ msgstr "Numero di Catalogo"
 msgid "Categorise analysis services"
 msgstr "Categorie servizi di analisi"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "La categoria non può essere disattivata poichè contiene Servizi di analisi"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Cert. Num"
 
@@ -1128,31 +1122,31 @@ msgstr "Codice Certificato"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Verifica se il metodo è stato accreditato"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Seleziona questa casella se il servizio di analisi è compreso nel programma del laboratorio di analisi accreditate"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Seleziona questa casella se i campioni prelevati sono 'composito' e messi insieme da più di un sotto campione, ad esempio diversi campioni di superficie di una diga mescolati insieme per essere un campione rappresentativo per la diga. Il valore predefinito, non selezionato, indica campioni 'acquisiti'"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Seleziona questa casella se questo contenitore è già conservato. Questa impostazione farà evitare il flusso di lavoro della conservazione per i campioni suddivisi conservati in questo contenitore."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Seleziona questa casella se questa è la priorità predefinita"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Seleziona questa casella se il laboratorio è accreditato"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Seleziona questa casella per garantire che un contenitore campione separato venga usato per questo servizio di analisi"
 
@@ -1160,7 +1154,7 @@ msgstr "Seleziona questa casella per garantire che un contenitore campione separ
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Seleziona questo se vuoi utilizzare un ID server separato. I prefissi sono configurabili separatamente in ogni sito Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Scegli i valori predefiniti delle specifiche dei RA"
 
@@ -1176,19 +1170,19 @@ msgstr ""
 msgid "City"
 msgstr "Città"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Classico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Cliccare nelle Categorie Analisi (sfondo ombreggiato) per vedere i Servizi di Analisi in ogni categoria. Inserire i valori minimo e massimo per indicare un intervallo di risultati validi. Ogni risultato fuori da questo intervallo genererà un alert. Il campo % Errore permette per una percentuale di incertezza di considerare quando si valutano i risultati rispetto ai valori minimo e massimo. Un risultato fuori intervallo ma ancora nella percentuale di errore  viene preso in considerazione, comunque verrà generato un alert meno severo."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Cliccare nelle Categorie Analisi (sfondo ombreggiato) per vedere i Servizi di Analisi in ogni categoria. Inserire i valori minimo e massimo per indicare un intervallo di risultati validi. Ogni risultato fuori da questo intervallo genererà un alert. Il campo % Errore permette per una percentuale di incertezza di considerare quando si valutano i risultati rispetto ai valori minimo e massimo. Un risultato fuori intervallo ma ancora nella percentuale di errore  viene preso in considerazione, comunque verrà generato un alert meno severo."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Cliccare nelle Categorie Analisi (sfondo ombreggiato) per vedere i Servizi di Analisi in ogni categoria. Inserire i valori minimo e massimo per indicare un intervallo di risultati validi. Ogni risultato fuori da questo intervallo genererà un alert. Il campo % Errore permette per una percentuale di incertezza di considerare quando si valutano i risultati rispetto ai valori minimo e massimo. Un risultato fuori intervallo ma ancora nella percentuale di errore  viene preso in considerazione, comunque verrà generato un alert meno severo. Se il risultato è inferiore '< Min' il risultato verrà mostrato come '< [min]'. Lo stesso vale per i risultati superiori '> Max'"
 
@@ -1196,19 +1190,19 @@ msgstr "Cliccare nelle Categorie Analisi (sfondo ombreggiato) per vedere i Servi
 msgid "Click to download"
 msgstr "Clicca per scaricare"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID Batch Cliente"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID Cliente"
 
@@ -1216,59 +1210,59 @@ msgstr "ID Cliente"
 msgid "Client Landing Page"
 msgstr "Pagina Destinazione Cliente"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nome Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Ordine Cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Numero Ordine Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Rif. Cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Riferimento Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID Cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "ID Campione Cliente"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Il contatto cliente è necessario prima che sia presentata una richiesta"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clienti"
 
@@ -1277,39 +1271,39 @@ msgstr "Clienti"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Chiuso"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Codice per la posizione"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Codice per l'ubicazione"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Codice per lo scaffale"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Virgola (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Commenti"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Commenti o interpretazione risultati"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "ID Commerciale"
 
@@ -1317,21 +1311,21 @@ msgstr "ID Commerciale"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composito"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Livello di Fiducia %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configura le suddivisioni e conservazioni campione per questo modello. Assegna le analisi per le differenti suddivizioni nella tab Analisi modello"
 
@@ -1340,13 +1334,13 @@ msgid "Confirm password"
 msgstr "Conferma password"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Considerazioni"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contatto"
@@ -1355,8 +1349,8 @@ msgstr "Contatto"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contatti"
@@ -1365,48 +1359,48 @@ msgstr "Contatti"
 msgid "Contacts to CC"
 msgstr "Contatti in CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Contenitore"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipo di contenitore"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipi di contenitore"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Contenitori"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo Contenuto"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipo contenuto"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Controllo"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Analisi di controllo QC"
 
@@ -1422,12 +1416,12 @@ msgstr "Copia servizi di analisi"
 msgid "Copy from"
 msgstr "Copia da"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Copia su nuovo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Conteggio"
 
@@ -1440,18 +1434,18 @@ msgstr "Nazione"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Crea un nuovo campione di questo tipo"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creato"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creato da"
 
@@ -1459,7 +1453,7 @@ msgstr "Creato da"
 msgid "Created by:"
 msgstr "Creato da:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1467,8 +1461,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Creatore"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criterio"
 
@@ -1476,12 +1470,12 @@ msgstr "Criterio"
 msgid "Currency"
 msgstr "Valuta"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Attuale"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Separatore decimale personalizzato"
 
@@ -1494,7 +1488,7 @@ msgstr "DL"
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1508,88 +1502,88 @@ msgstr "Data interfaccia"
 msgid "Data Interface Options"
 msgstr "Opzioni Interfaccia Data"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Immissione dati libro giornale"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Data Creato"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Data di spedizione"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Data cancellazion"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Data di scadenza"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Data di importazione"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Data di caricamento"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Data di apertura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Data Conservato"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Data di pubblicazione"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Data di ricezione"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Data di richiesta"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Data di campionamento"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1605,7 +1599,7 @@ msgstr "Data dalla quale il certificato di calibrazione è valido"
 msgid "Date from which the instrument is under calibration"
 msgstr "Data dalla quale lo strumento è sotto calibrazione"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Data dalla quale lo strumento è sotto manutenzione"
 
@@ -1623,7 +1617,7 @@ msgid "Date until the certificate is valid"
 msgstr "Data fino a quando il certificato è valido"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Data fino a quando lo strumento non è disponibile"
@@ -1632,11 +1626,11 @@ msgstr "Data fino a quando lo strumento non è disponibile"
 msgid "Date when the calibration certificate was granted"
 msgstr "Data in cui il certificato di calibrazione è stato concesso"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Giorni"
 
@@ -1648,17 +1642,17 @@ msgstr "Disattivare fino al prossimo test di calibrazione"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Il separatore decimale da utilizzare nei reports da questo Cliente."
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Predefinito"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Specifiche RA Predefinite"
 
@@ -1666,49 +1660,49 @@ msgstr "Specifiche RA Predefinite"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Calcolo Predefinito"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Contenitore Predefinito"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tipo Contenitore Predefinito"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Strumento Predefinito"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Metodo Predefinito"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Conservazione Predefinita"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Priorità Predefinita?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Il caldolo predefinito da utilizzare per il Metodo predefinito selezionato. Il Calcolo per un metodo può essere assegnato in modalità modifica del Metodo."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categoria predefinita"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Contenitore predefinito per nuove suddivisioni campione"
 
@@ -1717,11 +1711,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Contenitori predefiniti: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Separatore decimale predefinito"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1745,11 +1739,11 @@ msgstr "Notazione scientifica predefinita per reports"
 msgid "Default scientific notation format for results"
 msgstr "Notazione scientifica predefinita per risultati"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valore predefinito"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "DefaultARSpecs_description"
 
@@ -1757,7 +1751,7 @@ msgstr "DefaultARSpecs_description"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definisci un codice di identificazione per il metodo. Deve essere unico."
 
@@ -1765,11 +1759,11 @@ msgstr "Definisci un codice di identificazione per il metodo. Deve essere unico.
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Definisci il numero di decimali da utilizzare per questo risultato."
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Definisci la precisione nella conversione dei valori in notazione esponenziale. Il predefinito è 7."
 
@@ -1777,16 +1771,16 @@ msgstr "Definisci la precisione nella conversione dei valori in notazione espone
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Definisci i prefissi per gli ID univoci sequenziali ai problemi del sistema per gli oggetti. Nel campo 'Padding', indica con quanti zeri iniziali devono essere formattati i numeri. Ad esempio un prefisso di WS per i fogli di lavoro con un padding di 4, li vedremmo numerati da WS-0001 a WS-9999. la Sequenza Iniziale indica il numero dal quale il successivo ID dovrebbe iniziare. Questo è impostato solo se è maggiore dei numeri ID esistenti. Da notare che il divario creato dal salto di ID non verrà colmato. NB: Da notare che campioni e ricgieste di analisi sono precedute con l'abbreviazioni del tipo campione e non sono configurate in questa tabella - i loro padding possono essere impostati negli specifici campi sotto"
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Gradi"
 
@@ -1794,9 +1788,9 @@ msgstr "Gradi"
 msgid "Delete attachment"
 msgstr "Cancella allegato"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Dipartimento"
 
@@ -1809,13 +1803,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analisi Dipendente"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Descrivi il metodo in termini semplici. Questa informazione vengono messe a disposizione dei clienti del laboratorio"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descrizione"
 
@@ -1823,7 +1817,7 @@ msgstr "Descrizione"
 msgid "Description of the actions made during the calibration"
 msgstr "Descrizione delle azioni fatte durante la calibrazione"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Descrizione dellle azioni fatte durante il processo di manutenzione"
 
@@ -1831,19 +1825,19 @@ msgstr "Descrizione dellle azioni fatte durante il processo di manutenzione"
 msgid "Description of the actions made during the validation"
 msgstr "Descrizione delle azioni fatte durante la validazione"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Descrizione della posizione"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Descrizione dello scaffale"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Descrizione dell'ubicazione"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1851,7 +1845,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Sconto %"
 
@@ -1859,16 +1853,16 @@ msgstr "Sconto %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Spediti"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Valore di visualizzazione"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Mostra un selettore del limite di rilevabilità (DL)"
 
@@ -1880,7 +1874,7 @@ msgstr "Mostra un alert sulle nuove versioni di Bika LIMS"
 msgid "Display individual sample partitions "
 msgstr "Mostra singole suddivisioni campione"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Data Smaltimento"
 
@@ -1889,8 +1883,8 @@ msgstr "Data Smaltimento"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Eliminato"
@@ -1899,54 +1893,54 @@ msgstr "Eliminato"
 msgid "District"
 msgstr "Distretto"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Divisione per zero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Documento"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Dormiente"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Punto (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Giù da"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Giù verso"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Scarica"
 
@@ -1959,20 +1953,20 @@ msgstr "Secco"
 msgid "Dry matter analysis"
 msgstr "Analisi di sostanza secca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Scadenza"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Data di scadenza"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Dup Var"
 
@@ -1981,20 +1975,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplicato"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicato del"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Analisi in doppio QC"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Duplicati Variazione %"
 
@@ -2006,35 +2000,35 @@ msgstr "Analisi in doppio QC"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Duplicare i grafici di controllo della qualità di analisi"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Durata"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Es. SANAS, APLAC, ecc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Precocità"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Prossimo"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Elevazione"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Indirizzo email"
 
@@ -2042,7 +2036,7 @@ msgstr "Indirizzo email"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Oggetto email"
 
@@ -2062,14 +2056,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Data Fine"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Accrescimento"
 
@@ -2081,16 +2075,16 @@ msgstr "Inserire un nome utente, normalmente qualscoca simile a 'mrossi'. Non sp
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Inserire un indirizzo email. Questo è necessario nel caso di perdita della password. Noi rispettiamo la tua privacy, e non forniamo l'indirizzo a terzi o esponiamo in nessuna parte."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Inserire la percentuale di sconto"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Inserire un valore percentuale, ad esempio 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Inserire un valore percentuale, ad esempio 14.0. Questa percentuale è applicata solo nel Profilo Analisi, ignorando l'applicazione dell'IVA"
 
@@ -2098,15 +2092,15 @@ msgstr "Inserire un valore percentuale, ad esempio 14.0. Questa percentuale è a
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Inserire un valore percentuale, ad esempio 14.0. Questa percentuale è applicato in tutto il software, può essere sovrascritto sui singoli elementi"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Inserire un valore percentuale, ad esempio 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Inserire latitudine del punto di campionamento in 0-90 gradi, minuti 0-59, 59-0 secondi e indicatore N/S"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Inserire la longitudine del punto di campionamento in 0-180 gradi, minuti 0-59, 59-0 secondi e indicatore di E/W"
 
@@ -2114,7 +2108,7 @@ msgstr "Inserire la longitudine del punto di campionamento in 0-180 gradi, minut
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Inserire il dettaglio di ogni servizio di analisi che si vuole copiare."
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Inserire i dettagli di accreditamento del tuo servizio di laboratorio qui. I seguenti campi sono disponibili:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
@@ -2122,45 +2116,45 @@ msgstr "Inserire i dettagli di accreditamento del tuo servizio di laboratorio qu
 msgid "Entity"
 msgstr "Ente"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr " Erronea pubblicazione risultato da ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Escludere dalla fattura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Risultato Atteso"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Valori Attesi"
 
@@ -2169,19 +2163,19 @@ msgstr "Valori Attesi"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Scaduto"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Data Scadenza"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Precisione formato esponenziale"
 
@@ -2189,44 +2183,40 @@ msgstr "Precisione formato esponenziale"
 msgid "Exponential format threshold"
 msgstr "Soglia formato esponenziale"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax (ufficio)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Femmina"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Campo"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Campo delle analisi"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Condizione di conservazione"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Titolo del campo"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "File"
 
@@ -2234,19 +2224,19 @@ msgstr "File"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "File allegati ai risultati, ad esempio le foto del microscopio, saranno incluse nelle email al destinatario se questa opzione è selezionata"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nome del file"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2266,16 +2256,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Nome"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formula"
 
@@ -2285,18 +2275,18 @@ msgstr "Formula"
 msgid "From"
 msgstr "Da"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Dal ${start_date} al ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Campione datato nel futuro"
 
@@ -2306,7 +2296,7 @@ msgstr "Campione datato nel futuro"
 msgid "Generate report"
 msgstr "Genera report"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Titolo. Ad esempio Sig., Sig.ra, Dott."
 
@@ -2318,37 +2308,37 @@ msgstr "Raggruppa i servizi di analisi per categoria nelle tabelle LIMS, utile q
 msgid "Group by"
 msgstr "Raggruppa per"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Periodo di raggruppamento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Pericolosi"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Campo Nascosto"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Ore"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2357,8 +2347,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID Server"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID Server non disponibile"
 
@@ -2366,31 +2356,31 @@ msgstr "ID Server non disponibile"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "IMPORTANTE: Non usare \"Bika\" o \"BIKA\" come nome istanza, questo è un nome riservato. Se si ottiene \"Site Error\" riferito a \"AttributeError: adapters\", questa è la causa più probabile."
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Se 'Permetti inserimento dei risultati strumentali' è selezionato, verrà utilizzato il metodo dallo strumento predefinito . Altrimenti verranno visualizzati solo i metodi selezionati sopra."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Se un campione viene acquisito periodicamente su questo punto di campionamento, inserire la frequenza qui, ad esempio settimanalmente"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "Se selezionato, un elenco verrà visualizzato accanto al campo risultato analisi nella vista inserimento risultati. Utilizzando questa selezione, l'analista potra impostare il valore come limite di rilevazione (LDL o UDL) invece di un risultato normale"
 
@@ -2402,7 +2392,7 @@ msgstr "Se nselezionato, lo strumento sarà disponibile fino a che non sarà eff
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2410,27 +2400,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Se abilitato, il nome delle analisi verranno scritte in corsivo."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "Se abilitato, queste analisi e i loro risultati non saranno visualizzati per default nei reports. Questa impostazione può essere ignorata nel Profilo Analisi e/o Richieste Analisi"
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "Se non viene inserito il valore Titolo, verrà utilizzato l'ID Batch."
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Se necessario, selezionare un calcolo per i servizi di analisi collegati a questo metodo. I calcoli possono essere configurati sotto la voce \"calcoli\" nel LIMS setup"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Se necessario, selezionare un calcolo per l'analisi qui. I calcoli possono essere configurati alla voce \"calcoli\" nel setup del LIMS."
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Se viene inserito del testo qui, verrà usato invece del titolo quando il servizio è elencato in intestazioni di colonna. La formattazione HTML è permessa."
 
@@ -2438,7 +2428,7 @@ msgstr "Se viene inserito del testo qui, verrà usato invece del titolo quando i
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "Se ci sono risultati precedenti per un servizio nello stesso batch di Richieste Analisi, essi verranno mostrati nel report."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Se questo contenitore è pre-conservato, qallora il metodo di conservazione può essere selezionato qui."
 
@@ -2451,7 +2441,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Se non selezionata, gli analisti avranno accesso a tutti i fogli di lavoro."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importazione"
@@ -2460,7 +2450,7 @@ msgstr "Importazione"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importati"
@@ -2469,8 +2459,8 @@ msgstr "Importati"
 msgid "In-lab calibration procedure"
 msgstr "Procedura di calibrazione in-lab"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Inattivo"
@@ -2479,7 +2469,7 @@ msgstr "Inattivo"
 msgid "Include Previous Results From Batch"
 msgstr "Includere Precedenti Rsisultati Dal Batch"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Includere tutte le richieste analisi apartenenti agli oggetti selezionati."
 
@@ -2487,7 +2477,7 @@ msgstr "Includere tutte le richieste analisi apartenenti agli oggetti selezionat
 msgid "Include and display pricing information"
 msgstr "Includere e visualizzare le informazioni sui prezzi"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Includere descrizioni"
 
@@ -2495,30 +2485,27 @@ msgstr "Includere descrizioni"
 msgid "Include year in ID prefix"
 msgstr "Includere l'anno come prefisso nell'ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "IBAN non corretto: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "NIB non corretto: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Risultato non determinato"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indicare se i file allegati, ad esempio le immagini al microscopio, sono richieste per queste analisi e se l'opzione di caricamento file sarà disponibile per esse sui dati di cattura schermo"
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Ereditare da"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisione iniziale"
 
@@ -2542,7 +2529,7 @@ msgstr "Installazione caricamento del certificato"
 msgid "InstallationDate"
 msgstr "Data Installazione"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Istruzioni"
@@ -2555,17 +2542,17 @@ msgstr "Istruzioni per la regolare procedura di calibrazione in-lab destinate ag
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Istruzioni per la regolare procedura di prevenzione e manutenzione destinate agli analisti"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Strumento"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Calibrazioni Strumento"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2578,16 +2565,16 @@ msgstr "Importazione strumentale"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Manutenzione strumentale"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Attività programmate sullo strumento"
 
@@ -2595,19 +2582,19 @@ msgstr "Attività programmate sullo strumento"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Tipi Strumento"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validazioni strumentali"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2651,9 +2638,9 @@ msgstr "Tipo di strumento"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Strumenti"
 
@@ -2677,7 +2664,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Prove Interne Calibrazione"
 
@@ -2693,24 +2680,21 @@ msgstr "Interpolazione"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Non valido"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "RA di riesame non valida"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Trovati metacaratteri non validi: ${wildcards}"
 
@@ -2718,43 +2702,43 @@ msgstr "Trovati metacaratteri non validi: ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Fattura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Data Fattura"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Escludi fattura"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Numero Fattura"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "La fattura Batch non ha Data Fine"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "La fattura Batch non ha Data Inizio"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "La fattura Batch non ha Titolo"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "L'elemento è inattivo."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Elementi da inserire nell'oggetto dell'e-mail"
 
@@ -2764,7 +2748,7 @@ msgstr "Elementi da inserire nell'oggetto dell'e-mail"
 msgid "Job Title"
 msgstr "Titolo Lavorativo"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Titolo lavorativo"
 
@@ -2772,12 +2756,12 @@ msgstr "Titolo lavorativo"
 msgid "Key"
 msgstr "Chiave"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Errore Chiave"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Parola chiave"
@@ -2786,47 +2770,47 @@ msgstr "Parola chiave"
 msgid "Keywords"
 msgstr "Parole chiavi"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratorio"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Analisi di laboratorio"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contatti laboratorio"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Dipartimenti Laboratorio"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Conservazione di laboratorio"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Prodotti Lab"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Laboratorio URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etichetta"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorio"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorio accreditato"
 
@@ -2846,13 +2830,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Ultima modifica"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Ritardo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Ritardo delle analisi"
@@ -2862,7 +2846,7 @@ msgstr "Ritardo delle analisi"
 msgid "Late Analysis"
 msgstr "Ritardo dell'analisi"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitudine"
 
@@ -2884,11 +2868,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Campione collegato"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2900,7 +2884,7 @@ msgstr "Elenca tutti i campioni ricevuti in un intervallo di date"
 msgid "Load Setup Data"
 msgstr "Caricamento dei dati di installazione"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Caricare documenti che descrivono il metodo"
 
@@ -2912,41 +2896,41 @@ msgstr "Carica da file"
 msgid "Load the certificate document here"
 msgstr "Carica il documento di certificato qui"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Caricato"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Codice Posizione"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Descrizione Posizione"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Titolo Posizione"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Tipo Posizione"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Posizione dove viene preso il campione"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Posizione dove è stato preso il campione"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Log"
@@ -2971,35 +2955,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitudine"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Numero di lotto"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Limite Rilevazione Basso (LDL)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Indirizzo per comunicazioni e.mail"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Manutentore"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Tipo manutentore"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Uomo"
 
@@ -3007,16 +2991,16 @@ msgstr "Uomo"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Manager"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Email manager"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telefono manager"
 
@@ -3024,31 +3008,25 @@ msgstr "Telefono manager"
 msgid "Manual"
 msgstr "Manuale"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Inserimento manuale"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Inserimento risultati manuale"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Produttore"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Produttori"
 
@@ -3057,14 +3035,14 @@ msgstr "Produttori"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Tempo massimo"
 
@@ -3072,30 +3050,30 @@ msgstr "Tempo massimo"
 msgid "Maximum columns per results email"
 msgstr "Massimo numero di colonne per risultato nelle email"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Dimensione o volume massimo possibile per campioni."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Tempo massimo di completamento analisi. Viene elevato un alert di ritardo analisi quando questo periodo è scaduto"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Massimo turn-around time"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "% Sconto membri"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Sconto applicato agli iscritti"
 
@@ -3104,22 +3082,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Metodo."
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Testo del metodo"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "ID Metodo"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Istruzioni operative del metodo"
 
@@ -3131,9 +3109,9 @@ msgstr "Metodo: ${method_name}"
 msgid "Method: None"
 msgstr "Metodo: Nessuno"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Metodi"
 
@@ -3141,17 +3119,17 @@ msgstr "Metodi"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Metodi inclusi nella pianificazione dell'Accreditamento ${accreditation_body} per questo Laboratorio. Le analisi rilevate non sono state accreditate"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Iniziali secondo nome"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Secondo nome"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3163,8 +3141,8 @@ msgstr "Miniera"
 msgid "Minimum 5 characters."
 msgstr "Minimo 5 caratteri."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volume Minimo"
 
@@ -3172,27 +3150,27 @@ msgstr "Volume Minimo"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Numero minimo di risultati per il calcolo statistico QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minuti"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Telefono cellulare"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modello"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Data di modifica"
 
@@ -3206,7 +3184,7 @@ msgstr ""
 msgid "More"
 msgstr "più"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3218,13 +3196,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "NIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nome"
 
@@ -3233,17 +3211,17 @@ msgstr "Nome"
 msgid "New"
 msgstr "Nuovo"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "No"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Nessuna Richiesta Analisi soddisfa la tua richiesta"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3259,18 +3237,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Nessuna azione trovata per l'utente ${user}"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Non è stata selezionata un analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Nessuna analisi soddisfa lka tua richiesta"
 
@@ -3282,23 +3260,23 @@ msgstr "Non sono state aggiunte le analisi"
 msgid "No analyses were added to this worksheet."
 msgstr "Nessuna analisi è stata aggiunta a questo foglio di lavoro."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Nessuna analisi selezionata"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Nessun servizio analisi selezionato"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Nessun servizio analisi è stato selezionato."
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Nessuna modifica effettuata."
 
@@ -3306,7 +3284,7 @@ msgstr "Nessuna modifica effettuata."
 msgid "No control type specified"
 msgstr "Nessun tipo di controllo specificato"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3318,17 +3296,17 @@ msgstr "Nessun contenitore predefinito è stato specificato per questo servizio"
 msgid "No default preservations specified for this service"
 msgstr "Nessuna conservazione predefinita è stata specificata per questo servizio"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Nessun file selezionato"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Nessuna azione storica soddisfa la qua richiesta"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Nessun elemento è stata selezionato"
 
@@ -3336,7 +3314,7 @@ msgstr "Nessun elemento è stata selezionato"
 msgid "No items selected"
 msgstr "Nessun elemento selezionato"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Nessun nuovo elemento è stato creato"
 
@@ -3346,16 +3324,16 @@ msgstr "Nessun nuovo elemento è stato creato"
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Nessun campione di riferimento è stato selezionato"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Non è stato specificato un report nella richiesta"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Nessun campione soddisfa la tua richiesta"
 
@@ -3373,25 +3351,22 @@ msgstr "Non esiste alcun utente ${contact_fullname} e non è in grado di acceder
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Nessuno"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Non consentito"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Non disponibile"
 
@@ -3411,19 +3386,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "Numero colonne"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Numero di Analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Numero di richieste analisi e analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Numero di richieste analisi e analisi per cliente"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3431,30 +3406,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Numero di analisi"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Numero di analisi fuori intervallo nel periodo"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Numero di analisi richieste per servizio analisi"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Numero di analisi richieste per tipo di campione"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Numero di analisi rieseguite nel periodo"
 
@@ -3462,15 +3437,15 @@ msgstr "Numero di analisi rieseguite nel periodo"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Numero di analisi richieste e pubblicate per dipartimento e espresse come percentuale su tutte le analisi eseguite"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Numero di richieste"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3479,31 +3454,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Numero di campioni"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Valore numerico indicante l'ordine di oggetti con priorità"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "ID Oggetto"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Una volta conservato, il campione deve essere smaltito entro questo periodo di tempo. Se non specificato, verrà utilizzato il periodo di conservazione del tipo di campione."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3511,15 +3486,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Solo il manager del laboratorio può creare e gestire i fogli di lavoro"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Solo per campi vuoti o pari a zero"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Aperto"
@@ -3532,26 +3504,26 @@ msgstr ""
 msgid "Order"
 msgstr "Ordine"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Data dell'ordine"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID ordine"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Numero d'ordine"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Ordini"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Ordini: ${orders}"
 
@@ -3559,7 +3531,7 @@ msgstr "Ordini: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Organizzazione responsabile della garanzia del certificato di calibrazione"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3571,8 +3543,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Altri report produttività"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Scaduto"
 
@@ -3584,16 +3556,13 @@ msgstr "Formato di output"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Suddivisione"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3614,8 +3583,8 @@ msgstr "Password"
 msgid "Password lifetime"
 msgstr "Durata della password"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "In sospeso"
@@ -3640,31 +3609,31 @@ msgstr "Eseguito da"
 msgid "Period"
 msgstr "Periodo"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Consentito"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "% di errore consentita"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefono"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefono (business)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Phone (pesronale)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefono (cellulare)"
 
@@ -3677,8 +3646,8 @@ msgid "Photo of the instrument"
 msgstr "Foto dello strumento"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Indirizzo fisico"
 
@@ -3686,7 +3655,7 @@ msgstr "Indirizzo fisico"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Prego elencare tutte le opzioni per il risultato analisi se lo si vuole limitare solo a specifiche opzioni, ad esempio 'Positivo', 'Negativo' e 'Indeterminabile'. Il valore del risulato dell' opzione deve essere numerico"
 
@@ -3694,19 +3663,19 @@ msgstr "Prego elencare tutte le opzioni per il risultato analisi se lo si vuole 
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Prego specificare qui le conservazioni che differiscono dalla conservazione predefinita dei servizi analisi per tipo campione."
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Prego caricare il logo autorizzato per l'utilizzo sul tuo sito web e le stampe risultati dal vostro ente di accreditamento. Dimensione massima 175 x 175 pixels."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Punto di cattura"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3715,13 +3684,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posizione"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Indirizzo postale"
 
@@ -3729,16 +3698,16 @@ msgstr "Indirizzo postale"
 msgid "Postal code"
 msgstr "Cap"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Pre-conservato"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Precisione come numero di decimali"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisione come numero di cifre significative secondo l'incertezza. La posizione decimale deve essere fornita viene data dal primo numero diverso da zero nell'incertezza, in questa posizione il sistema arrotonderà l'incertezza e i risultati. Per esempio, con un risultato di 5.243 e dun incertezza di 0.22, il sistema mostrerà correttamente come 5.2 +-0.2. Se non viene impostato un intervallo di incertezza per il risultato, il sistema utilizzerà un impostazione di precisione fissa."
 
@@ -3766,7 +3735,7 @@ msgstr "Notazione scientifica preferita per i reports"
 msgid "Preferred scientific notation format for results"
 msgstr "Notazione scientifica preferita per i risultati"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefisso"
 
@@ -3774,12 +3743,12 @@ msgstr "Prefisso"
 msgid "Prefixes"
 msgstr "Prefissi"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premio"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3791,17 +3760,17 @@ msgstr "Predisposto da"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Conservazione"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Categoria di conservazione"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3812,7 +3781,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Conservazioni"
 
@@ -3822,14 +3791,14 @@ msgstr "Conservazioni"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Conservatore"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Preventivo"
 
@@ -3837,34 +3806,34 @@ msgstr "Preventivo"
 msgid "Preventive maintenance procedure"
 msgstr "Procedura manutenzione preventiva"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Prezzo"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Prezzo (IVA esclusa)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Percentuale di premio di prezzo"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Prezzo IVA esclusa"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Listino prezzi"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Listini prezzi"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3879,13 +3848,13 @@ msgstr "Stampa"
 msgid "Print date:"
 msgstr "Data stampa:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Priorità"
 
@@ -3902,34 +3871,34 @@ msgstr "Reports produttività"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "Open Source Professionale LIMS/LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profilo"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Analisi del profilo"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Profilo chiave"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Parola chiave Profilo"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profili"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (Non ancora fatturata)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "ID Protocollo"
 
@@ -3937,7 +3906,7 @@ msgstr "ID Protocollo"
 msgid "Public. Lag"
 msgstr "Ritarto Public."
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Specifiche Pubblicazione"
 
@@ -3952,21 +3921,21 @@ msgstr "Preferenza di pubblicazione"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Pubblicato"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Pubblicate Richieste Analisi che non hanno fattura"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Pubblicato da"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Risultati pubblicati"
 
@@ -3979,8 +3948,8 @@ msgid "QC Analyses"
 msgstr "Analisi QC"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "ID Campione QC"
 
@@ -4001,23 +3970,23 @@ msgstr "Quantità"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Commento Intervallo"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Commento intervallo"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Intervallo massimo"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Intervallo minimo"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Specifiche intervallo"
 
@@ -4039,9 +4008,9 @@ msgstr "Ricevere"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Ricevuto"
 
@@ -4049,11 +4018,11 @@ msgstr "Ricevuto"
 msgid "Recept. Lag"
 msgstr "Rit. Ricevimento"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Destinatari"
 
@@ -4062,31 +4031,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "Fare riferimento alla documentazione <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\">Creating new report templates</a> sul Bika LIMS wiki per ottenerne di più o aggiungere i propri modelli di report.."
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Riferimento"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Analisi Riferimento"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Definizione di riferimento"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Definizioni di riferimento"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Campione di Riferimento"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Campioni di riferimento"
 
@@ -4094,16 +4063,16 @@ msgstr "Campioni di riferimento"
 msgid "Reference Supplier"
 msgstr "Fornitore di riferimento"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Tipo di riferimento"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valori di riferimento"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Analisi standard QC"
@@ -4112,7 +4081,7 @@ msgstr "Analisi standard QC"
 msgid "Reference analysis quality control graphs"
 msgstr "Grafici di controllo della qualità delle analisi standard"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Grafici analisi di controllo qualità di riferimento"
 
@@ -4120,21 +4089,21 @@ msgstr "Grafici analisi di controllo qualità di riferimento"
 msgid "Reference sample"
 msgstr "Campione di riferimento"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "I Valori di esempio di riferimento sono zero o 'vuoto'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "ReferenceAnalysesGroupID"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition rappresenta la Definizione di Riferimento o tipo campione utilizzato per la verifica del controllo qualità"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Riferimenti: ${references}"
 
@@ -4157,8 +4126,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4167,9 +4136,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Percentuale differenza relativa, ${variation_here} %, è al di fuori dell'intervallo valido (${variation} %))"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Osservazioni"
 
@@ -4177,7 +4146,7 @@ msgstr "Osservazioni"
 msgid "Remarks to take into account before calibration"
 msgstr "Considerazioni da fare prima della calibrazione"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Considerazioni da fare prima di eseguire il compito"
 
@@ -4185,7 +4154,7 @@ msgstr "Considerazioni da fare prima di eseguire il compito"
 msgid "Remarks to take into account before validation"
 msgstr "Considerazioni da fare prima della validazione"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Considerazioni da fare prima del processo di manutenzione"
 
@@ -4194,8 +4163,8 @@ msgstr "Considerazioni da fare prima del processo di manutenzione"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Aggiustare"
 
@@ -4204,7 +4173,7 @@ msgid "Repeated analyses"
 msgstr "Analisi ripetute"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Report"
 
@@ -4218,14 +4187,14 @@ msgstr "Data Report"
 msgid "Report ID"
 msgstr "ID Report"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Tipo Report"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Considerato come sostanza secca"
 
@@ -4250,7 +4219,7 @@ msgstr "Report tabelle all'interno di un periodo di tempo il numero di campioni 
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Report tabelle delle Richieste Analisi e totali presentate all'interno di un periodo di tempo"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Tipo report"
 
@@ -4258,7 +4227,7 @@ msgstr "Tipo report"
 msgid "Report upload"
 msgstr "Caricare report"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Reports"
 
@@ -4267,15 +4236,15 @@ msgstr "Reports"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Richiesta"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID richiesta"
 
@@ -4283,26 +4252,26 @@ msgstr "ID richiesta"
 msgid "Request new analyses"
 msgstr "Richiesta di nuove analisi"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Richiesto"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Richieste"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Obbligatorio"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volume richiesto"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "I campi richiesti non sono valorizzati: ${field_names}"
 
@@ -4310,13 +4279,13 @@ msgstr "I campi richiesti non sono valorizzati: ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Categorie con restrizioni"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Risultato"
 
@@ -4324,15 +4293,15 @@ msgstr "Risultato"
 msgid "Result Footer"
 msgstr "Piè di pagina Risultato"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opzioni Risultato"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valore Risultato"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4350,11 +4319,11 @@ msgstr "Risultato fuori scala"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "I valori di risultato con almeno questo numero di cifre significative è visualizzato in notazione scientifica utilizzando la lettera 'e' per indicare l'esponente. La precisione può essere configueata nei singoli Servizi Analisi."
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Interpretazione Risultati"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Interpretazione Risultati"
 
@@ -4362,7 +4331,7 @@ msgstr "Interpretazione Risultati"
 msgid "Results attachments permitted"
 msgstr "Risultati allegati permessi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "I risultati sono stati revocati"
 
@@ -4370,11 +4339,11 @@ msgstr "I risultati sono stati revocati"
 msgid "Results interpretation"
 msgstr "Interpretazione risultati"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Risultato per punto di campionamento"
@@ -4383,14 +4352,14 @@ msgstr "Risultato per punto di campionamento"
 msgid "Results per samplepoint and analysis service"
 msgstr "Risultati per punto di campionamento e servizio analisi"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Periodo di conservazione"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Riesaminato"
@@ -4409,11 +4378,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "Analisi retratta"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Report di svincolo non disponibile"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Ritrattazioni"
 
@@ -4429,12 +4398,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "Codice SWIFT."
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Formula di saluto"
 
@@ -4442,19 +4411,19 @@ msgstr "Formula di saluto"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Come sopra, ma imposta il predefinito nei servizi analisi. Questa configurazione può essere impostataper singola analisi nelle rispettiva configurazione"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Campione"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Condizione Campione"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Condizioni Campione"
 
@@ -4463,8 +4432,8 @@ msgid "Sample Due"
 msgstr "Campione dovuto"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID del campione"
 
@@ -4476,12 +4445,12 @@ msgstr "Campione ID Padding"
 msgid "Sample ID Sequence Start"
 msgstr "Inizio sequenza ID campione"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Matrici Campione"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Matrice Campione"
 
@@ -4491,52 +4460,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Partizione del Campione"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Punto campione"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Punti di campionamento"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Tipo di campione"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefisso tipo di campione"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Specifiche per Tipo Campione (Cliente)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Specifiche per Tipo Campione (Laboratorio)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Tipi di campione"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Condizioni campione"
 
@@ -4546,9 +4515,9 @@ msgstr "Condizioni campione"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Punto campionamento"
 
@@ -4576,17 +4545,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Reports campioni relativi"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Tipo di campione"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Matrice campioni"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Tipo Campione"
 
@@ -4596,30 +4565,30 @@ msgstr "Tipo Campione"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Campionatore"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Campioni"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Campioni di questo tipo dovrebbero essere trattati come pericolosi"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Campioni ricevuti vs. elaborati"
@@ -4628,62 +4597,62 @@ msgstr "Campioni ricevuti vs. elaborati"
 msgid "Samples received vs. samples reported"
 msgstr "Campioni ricevuti vs. elaborati"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Campioni: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Data di campionamento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Deviazione di Campionamento"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Deviazioni di Campionamento"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Frequenza di campionamento"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4693,9 +4662,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Salva"
 
@@ -4708,17 +4677,17 @@ msgstr "Salva osservazioni"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Attività pianificata"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Nome scientifico"
 
@@ -4726,16 +4695,16 @@ msgstr "Nome scientifico"
 msgid "Search"
 msgstr "Ricerca"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Secondi"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4747,11 +4716,11 @@ msgstr "Selezionare 'Registrare' se si vuole che le etichette vengano stampate a
 msgid "Select AR Templates to include"
 msgstr "Selezionare i Modelli RA da includere"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Selezionare l'interfaccia dati"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Selezionare una conservazione predefinita per questo servizio analisi. Se la conservazione dipende dalla combinazione con il tipo campione, specificare la conservazione per tipo campione nella tabella sotto"
 
@@ -4759,11 +4728,11 @@ msgstr "Selezionare una conservazione predefinita per questo servizio analisi. S
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Selezionare una posizione di destinazione e la RA da duplicare"
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Selezionare un responsabile tra le persone configurate disponibili sotto la voce di impostazione 'contatti laboratorio'. I responsabili di dipartimento sono indicati nei reports di risultati analisi in base al loro dipartimento."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Selezionare un campione per creare una RS secondaria"
 
@@ -4775,7 +4744,7 @@ msgstr "Selezionare tutti gli elementi"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Selezionare le analisi da includere in questo modello"
 
@@ -4787,11 +4756,11 @@ msgstr "Selezionare l'analista"
 msgid "Select existing file"
 msgstr "Seleziona un file esistente"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Selezionare se l'analisi deve essere esclusa dalla fattura"
 
@@ -4799,19 +4768,19 @@ msgstr "Selezionare se l'analisi deve essere esclusa dalla fattura"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Selezionare se è un autocertificazione della calibrazione "
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Selezionare se il calcolo da usare è il calcolo impostato come predefinito per il metodo predefinito. Se non selezionato, il calcolo può essere scelto manualmente"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Selezionare se la descrizione deve essere inclusa"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4837,7 +4806,7 @@ msgstr "Selezionare il paese che il sito mostrerà di default"
 msgid "Select the currency the site will use to display prices."
 msgstr "Selezionare la valuta che il sito utilizzerà per visualizzare i prezzi."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Selezionare il contenitore predefinito da utilizzare per questo servizio analisi. Il contenitore da usare dipende dalla combinazione tipo campione e conservazione, specificare il contenitore nella tabella tipo campione sotto"
 
@@ -4849,7 +4818,7 @@ msgstr "Selezionare la pagina predefinita di destinazione. Questa viene utilizza
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Selezionare lo strumento preferito"
 
@@ -4857,7 +4826,7 @@ msgstr "Selezionare lo strumento preferito"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4881,7 +4850,7 @@ msgstr "Selezionare questo per attivare le fasi di raccolta campione del flusso 
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Selezionare quali analisi devono essere incluse nel foglio di lavoro"
 
@@ -4897,7 +4866,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Selezionare quali etichette stampare quando è abilitata la stampa etichette automatica"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4909,7 +4878,7 @@ msgstr "Invia email"
 msgid "Separate"
 msgstr "Separato"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Contenitore Separato"
 
@@ -4917,32 +4886,28 @@ msgstr "Contenitore Separato"
 msgid "Serial No"
 msgstr "Serial Nr."
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Servizio"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "I servizi sono inclusi in ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Servizi"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Impostare l'attività di manutenzione come chiusa"
 
@@ -4950,31 +4915,31 @@ msgstr "Impostare l'attività di manutenzione come chiusa"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Selezionare il numero massimo di richieste analisi per email risultati. Troppe colonne per email sono difficili da leggere per alcuni clienti che preferiscono minori risultati per email"
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Selezionare le specifiche da utilizzare prima di pubblicare una RA."
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Impostazioni delle specifiche dei risultati dei servizi di analisi di laboratorio"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Codice Scaffale"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Descrizione Scaffale"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Titolo Scaffale"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Indirizzo di spedizione"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Titolo Breve"
 
@@ -4990,7 +4955,7 @@ msgstr "Mostra Analisi QC"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Mostra solo la categoria selezionata nella vista cliente"
 
@@ -5002,29 +4967,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Firma"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Codice Ubicazione"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Descizione Ubicazione"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Titolo Ubicazione"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Dimensioni"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Icona Piccola"
 
@@ -5032,14 +4993,14 @@ msgstr "Icona Piccola"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Alcine analisi utilizzano strumenti scaduti o non calibrati. Edizione risultati non consentita"
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Chiave Ordinamento"
 
@@ -5047,41 +5008,41 @@ msgstr "Chiave Ordinamento"
 msgid "Specification"
 msgstr "Specifica"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Specifiche"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Specificare la dimensione del Foglio di lavoro, ad esempio corrispondente alla dimensione specifica del cassetto dello strumento. Quindi selezionare un Analisi 'tipo' per posizione del Foglio di lavoro. Quando campioni QC sono selezionati, selezionare anche quale Campione di Riferimento dovrebbe essere usato. Se è selezionata un analisi duplicata, indicare a quale posizione campione dovrebbe essere duplicata"
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "Specificare i valori di incertezza per un dato intervallo, ad esempio fer i risultati in un intervallo con minimo 0 e massimo 10, quando il valore di incertezza è 0.5 - un risultato di 6.67 sarà riportato come 6.67 +- 0.5. Si può anche specificare un valore di incertezza come percentuale del valore risultato, aggiungendo un '%' al valore inserito nella colonna 'Valore Incertezza', ad esempio per risultati in un intervallo con minimo 10.01 e massimo 100, quando il valore di incertezza è 2% - un risultato di 100 sarà indicato come 100 +- 2. Prego accertarsi che gli intervalli successivi siano continui, ad esempio 0.00 - 10.00 è seguito da 10.01 - 20.00, 20.01 - 30.00 ecc."
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Data Inizio"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Stato"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Stato"
 
@@ -5089,33 +5050,33 @@ msgstr "Stato"
 msgid "Sticker templates"
 msgstr "Modelli etichette"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Posizione Magazzino"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Posizioni Magazzino"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Sotto gruppo"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Sotto gruppi"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "I sottogruppi sono ordinati con questa chiave nella vista gruppi"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Invia"
 
@@ -5123,37 +5084,34 @@ msgstr "Invia"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Indicare un valido file Open XML (.XLSX) contenente i registri di configurazione Bika per continuare."
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotale"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Fornitore"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Fornitori"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Ordine di Fornitura"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Cognome"
 
@@ -5173,11 +5131,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Compito"
 
@@ -5186,20 +5144,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Tipo compito"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descrizione tecnica e istruzioni per l'analista"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5217,35 +5175,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "La selezione di Profilo Analisi per questo modello"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "l'ID assegnata alla richiesta del cliente dal laboratorio"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "l'ID assegnata alla richiesta del cliente dal laboratorio"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "L'indirizzo web del Laboratorio"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "Il limite di rivelazione basso, LDL, è il più basso valore a cui il parametro misurato può essere determinato utilizzando la metodolodia di esame specificata. Il risultato inserito che fosse inferiore a questo valore verrà indicato come < LDL"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "Il limite di rivelazione alto, UDL, è il più alto valore a cui il parametro misurato può essere determinato utilizzando la metodolodia di esame specificata. Il risultato inserito che fosse superiore ai questo valore verrà indicato come > UDL"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "La norma di accreditamento che si applica, ad esempio ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Le analisi incluse in questo profilo, raggruppate per categoria"
 
@@ -5257,7 +5215,7 @@ msgstr "Le analisi da utilizzare per determinare la materia secca"
 msgid "The analyst or agent responsible of the calibration"
 msgstr "L'analista o l'addetto responsabile della calibrazione"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "L'analista o l'addetto responsabile della manutenzione"
 
@@ -5265,12 +5223,12 @@ msgstr "L'analista o l'addetto responsabile della manutenzione"
 msgid "The analyst responsible of the validation"
 msgstr "L'analista responsabile della convalida"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Allegati alle \"richieste di analisi\" ed analisi"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Le categoria del servizio analisi appartiene a"
 
@@ -5278,19 +5236,19 @@ msgstr "Le categoria del servizio analisi appartiene a"
 msgid "The date the instrument was installed"
 msgstr "La data di installazione dello strumento"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Il separatore decimale selezionato in Impostazioni Bika sarà usato"
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Il tipo contenitore predefinito. Nuove suddivisioni campione sono automaticamente assegnate a contenitori di questo tipo, a meno che non sia specificato in più dettagli per servizio analisi"
 
@@ -5302,7 +5260,7 @@ msgstr "Lo sconto percentuale inserito qui, è applicato ai prezzi per i clienti
 msgid "The full URL: http://URL/path:port"
 msgstr "L'URL completo: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "L'altezza o la profondita al quale il campione deve essere preso"
 
@@ -5319,24 +5277,24 @@ msgstr "Numero di modello dello strumento"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Il laboratorio non è accreditato o l'accreditamento non è stato configurato. "
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Il dipartimento di laboratorio"
@@ -5353,27 +5311,27 @@ msgstr "La quantità degli zero iniziali per ID Campioni"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "La quantità degli zero iniziali per numero RA negli ID RA"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "L'elenco dei punti di campionamento che questo tipo campione può essere raccolto. Se nessun punto di campionamento è selezionato, allora tutti i punti di campionamento sono disponibili."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "L'elenco dei tipi campione che può essere associato questo punto di campionamento. Se nessun tipo campione è selezionato, allora tutti i tipi campione sono disponibili."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "L'unità di misura per questi risultati di servizio analisi, ead esempio mg/l, ppm, dB, mV, ecc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Il minimo volume campione richiesto per analisi, ad esempio '10 ml' o '1 kg'."
 
@@ -5397,7 +5355,7 @@ msgstr "Il numero di giorni prima della scadenza della password. 0 disabilita la
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Il numero di giorni prima della scadenza campione e non potrà essere vpiù analizzato. Questa impostazione può essere ignorata per singoli tipi campioni nella impostazione dei tipi campione"
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5414,11 +5372,11 @@ msgstr "Il numero di richieste e di analisi"
 msgid "The number of requests and analyses per client"
 msgstr "Il numero di richieste e di analisi per cliente"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "La percentuale utilizzata per calcolare il prezzo per analisi effettuate in questa priorità"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Il periodo nel quale i campioni non conservati di questi tipo possono essere tenuti prima della scadenza e non può essere analizzato ulteriormente"
 
@@ -5435,19 +5393,19 @@ msgstr "La persona della ditta fornitore che ha eseguito il compito"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "La persona della ditta fornitore che ha preparato il certificato"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "Il prezzo modificato per analisi per i clienti qualificati per gli sconti grandi quantità"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "l'ID commerciale del profilo per fini contabili"
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "La chiave di profilo è usata per identificarlo univocamente nei file di importazione. Deve essere unico, e non può essere lo stesso di qualsiasi campo ID Calcolo Provvisorio"
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Il codice di riferimento rilasciato al laboratorio dall'ente di accreditamento"
 
@@ -5455,11 +5413,11 @@ msgstr "Il codice di riferimento rilasciato al laboratorio dall'ente di accredit
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "I risultati dei Servizi Analisi che utilizzano questo metodo possono essere impostati manualmente"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "I risultati o campi analisi sono acquisiti durante il campionamento nel punto di campionamento, ad esempio la temperatura di un campione di acqua del fiume dove viene campionato. Le analisi di laboratorio vengono eseguite nel laboratorio"
 
@@ -5467,7 +5425,7 @@ msgstr "I risultati o campi analisi sono acquisiti durante il campionamento nel 
 msgid "The room and location where the instrument is installed"
 msgstr "La stanza e la posizione dove lo strumento è installato"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "Gli strumenti selezionati supportano questo metodo. Utilizza la vista modifica strumento per assegnare il metodo ad uno specifico strumento"
 
@@ -5479,11 +5437,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Il numero seriale che identifica univocamente lo strumento"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "ID del protocollo analitico del servizio"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "L'ID commerciale del servizio ai fini contabili"
 
@@ -5491,19 +5449,19 @@ msgstr "L'ID commerciale del servizio ai fini contabili"
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "La configurazione predefinita a livello di sistema per indicare se gli allegati sono necessari, consentiti o meno per richiesta analisi"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Il tempo di risposta delle analisi"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "Il tempo di risposta di analisi tracciata nel tempo"
 
@@ -5515,7 +5473,7 @@ msgstr "I tempi di risposta delle analisi"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "I tempi di risposta di analisi tracciati nel tempo"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "La parola chiave univica utilizzata per identificare il servizio analisi nell'impostazine dei file di massa RA richieste e risultati da acquisizione strumentale. E 'anche usato per identificare i servizi analisi dipendenti nei risultati calcolo definiti dall'utente"
 
@@ -5527,37 +5485,37 @@ msgstr "Non ci sono risultati."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Questi risultati possono essere riportati come sostanza secca"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Questi risultati sono stati revocati e sono elencati qui per scopi tracciabilità. Si prega di seguire il collegamento per il riesame"
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "Questa analisi richiesta è stata generata automaticamente a causa del ritrattazione della richiesta analisi ${retracted_request_id}."
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Queste Richieste Analisi sono state revocate e sono elencate qui per scopi tracciabilità. Riesamina: ${retest_child_id}."
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Questo servizio di analisi non può essere selezionato perché il calcolo è inattivo."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Questo servizio di analisi non può essere disattivato perché uno o più calcoli associati as esso sono attivi."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5569,7 +5527,7 @@ msgstr "Questo servizio non richiede una suddivisione separata"
 msgid "This service requires a separate container."
 msgstr "Questo servizio richiede un contenitore separato."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5577,13 +5535,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "Questo testo viene apposto al reports risultati."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Questo valore è riportato in fondo a tutti i risultati pubblicati"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5597,63 +5551,63 @@ msgstr "Questo Foglio lavoro è stato rifiutato. Il Foglio lavoro sostitutivo è
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Consiglio. I documenti allegati non verranno caricati a meno che non sono presenti nell'istanza."
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Titolo"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Titolo posizione"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Titolo scaffale"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Titolo del luogo"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "A"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Da Conservare"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Da campionare"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Da mostrare sotto ogni sezione Categoria Analisi nei reports dei risultati."
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Da verificare"
 
@@ -5665,13 +5619,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Totale"
 
@@ -5679,22 +5633,22 @@ msgstr "Totale"
 msgid "Total Lag"
 msgstr "Ritardo Totale"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Prezzo totale"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Analisi totali"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Totale punti dati"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Prezzo totale"
 
@@ -5706,11 +5660,11 @@ msgstr "Totale:"
 msgid "Traceability"
 msgstr "Tracciabilità"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5718,61 +5672,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Abilitare se si vuole lavorare con suddivisioni campione"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Tempo risposta (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipo"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Tipo Errore"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Tipo di posizione"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Impossibile caricare il modello"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Impossibile inviare un email di alert lab ai contatti cliente che la Richiesta Analisi è stata ritratta: ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Non assegnati"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incertezza"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valore di incertezza"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Indefinito"
 
@@ -5780,13 +5728,13 @@ msgstr "Indefinito"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unità"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "IBAN nazione sconosciuta %s"
 
@@ -5811,17 +5759,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Non Pubblicato"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Formato file non riconoscibile ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Formato file non riconoscibile ${fileformat}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5833,11 +5781,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Caricare una firma digitalizzata da utilizzare sui report di analisi. Le dimensioni ideali sono di 250x150 pixel."
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "Limite di rilevazione superiore (UDL)"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "Usa Prezzo Profilo Analisi"
 
@@ -5845,7 +5793,7 @@ msgstr "Usa Prezzo Profilo Analisi"
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Usa calcolo predefinito"
 
@@ -5857,13 +5805,13 @@ msgstr "Utilizza un ID server"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Utilizzare questo campio per inviare parametri arbitrari al modulo di import/export."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Utente"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nome utente"
@@ -5876,7 +5824,7 @@ msgstr "Cronologia utente"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Cronologia utente"
@@ -5885,27 +5833,27 @@ msgstr "Cronologia utente"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Usando troppi pochi punti dati non genera significato statistico. Impostare un numero minimo accettabile di risultati prima di calcolare e tracciare statistiche QC"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Importo IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "IVA Totale"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Numero di partita IVA"
 
@@ -5913,11 +5861,11 @@ msgstr "Numero di partita IVA"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Valido dal"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Valido da"
 
@@ -5925,181 +5873,181 @@ msgstr "Valido da"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validazione"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Validazione fallita: '${keyword}': chiave duplicata"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Validazione fallita: '${title}': Questa chiave è già in uso nel calcolo '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Validazione fallita: '${title}': Questa chiave è già in uso dal servizio '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Validazione fallita: '${title}': titolo duplicato"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Validazione fallita: '${value}' non è univoco"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Convalida non riuscita: Posizione deve essere E/W"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Convalida non riuscita: Posizione deve essere N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Convalida non riuscita: Errore percentuale deve essere compreso tra 0 e 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Convalida non riuscita: Valore errore deve essere 0 o maggiore"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Convalida non riuscita: Valore errore deve essere numerico"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Convalida non riuscita: Valore atteso deve essere compreso tra Min e Max"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Convalida non riuscita: Valore atteso deve essere numerico"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Convalida non riuscita: Chiave '${keyword}' non valida"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Convalida non riuscita: i valori Max devono essere più grandi dei valori Min"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Convalida non riuscita: i valori Max devono essere numerici"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Convalida non riuscita: i valori Min devono essere numerici"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Convalida non riuscita: i valori di errore in percentuale devono essere compresi tra 0 e 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Convalida non riuscita: i valori di errore in percentuale devono essere numerici"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Convalida non riuscita: i contenitori preconservati devono avere una conservazione selezionata"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Convalida non riuscita: il risultato testo non può essere vuoto"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Convalida non riuscita: i valori del risultato devono essere numeri"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Convalida non riuscita: le selezioni richieste dalle seguenti categorie vanno indicate: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Convalida non riuscita: i valori devono essere numerici"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Convalida non riuscita: il titolo colonna '${title}' deve avere la parola chiave '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Validazione non riuscita: se i gradi sono 180 i minuti devono essere zero."
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Validazione non riuscita: se i gradi sono 180 i secondi devono essere zero."
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Validazione non riuscita: se i gradi sono 90 i minuti devono essere zero."
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Validazione non riuscita: se i gradi sono 90 i secondi devono essere zero."
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Validazione non riuscita: i gradi devono essere compresi tra 0 - 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Convalida non riuscita: i gradi devono essere compresi tra 0 - 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Convalida non riuscita: i gradi devono essere numerici"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Convalida non riuscita: la parola chiave '${keyword}' deve avere il titolo colonna '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Convalida non riuscita: la parola chiave contiene caratteri non validi"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Convalida non riuscita: la parola chiave è richiesta"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Convalida non riuscita: i minuti devono essere da 0 - 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Convalida non riuscita: i minuti devono essere numerici"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Convalida non riuscita: i valori percentuale devono essere tra 0 e 100"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Convalida non riuscita: i valori percentuali devono essere numerici"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Convalida non riuscita: i secondi devono essere 0 - 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Convalida non riuscita: i secondi devono essere numerici"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Convalida non riuscita: il titolo è richiesto"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6107,7 +6055,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "Data convalida report"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Convalidatore"
@@ -6118,12 +6066,12 @@ msgstr "Convalidatore"
 msgid "Value"
 msgstr "Valore"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "I valori possono essere inseriti qui i quali sovrasciveranno i predefiniti specificati nel Campi Provvisori di Calcolo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificato"
@@ -6134,7 +6082,7 @@ msgstr "Verificato"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versione"
 
@@ -6144,11 +6092,11 @@ msgstr "Versione"
 msgid "Volume"
 msgstr "Volume"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Indirizzo Web per l'ente di accreditamento"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Sito Web."
 
@@ -6156,24 +6104,24 @@ msgstr "Sito Web."
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Settimane alla scadenza"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "Quando è impostato, il sistema utilizza il prezzo del profilo analisi nel preventivo e l'IVA di sistema viene sovrascritta dall'IVA specifica del profilo analisi"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Quando i risultati di analisi duplicate nei fogli di lavoro, effettuate sullo stesso campione, differiscono di più di questa percentuale, viene elevato un alert"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "Metacaratteri per provvisori non sono permessi: ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Lavoro Eseguito"
@@ -6184,25 +6132,25 @@ msgstr "Flusso di lavoro"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Foglio di lavoro"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Layout del foglio di lavoro"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Modelli dei foglio di lavoro"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Fogli di lavoro"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Errata lunghezza IBAN da %s: %sshort da %i"
 
@@ -6210,9 +6158,9 @@ msgstr "Errata lunghezza IBAN da %s: %sshort da %i"
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Si"
 
@@ -6224,7 +6172,7 @@ msgstr "Non hai sufficienti privilegi per gestire il foglio di lavoro"
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "Non si possiedono sufficienti privilegi per vedere il piano di lavoro ${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "E' necessario assegnare questa richiesta ad un cliente"
 
@@ -6232,11 +6180,11 @@ msgstr "E' necessario assegnare questa richiesta ad un cliente"
 msgid "You must select an instrument"
 msgstr "È necessario selezionare uno strumento"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "Si dovrebbe introdurre una chiave risultati predefinita."
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "azione"
 
@@ -6252,15 +6200,15 @@ msgstr "analisi"
 msgid "analysis requests selected"
 msgstr "analisi richieste selezionate"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "ed altri"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6283,7 +6231,7 @@ msgstr "bika-frontpage-description"
 msgid "bika-frontpage-title"
 msgstr "bika-frontpage-title"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "commento"
 
@@ -6291,37 +6239,9 @@ msgstr "commento"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "datalines"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6332,7 +6252,7 @@ msgstr "disattivare"
 msgid "heading_arpriority"
 msgstr "heading_arpriority"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6381,19 +6301,19 @@ msgstr "new_version_available_description"
 msgid "new_version_available_title"
 msgstr "new_version_available_title"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6401,19 +6321,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "ripetendo ogni"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "periodo ripetizione"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6432,19 +6352,8 @@ msgstr "summary_content_listing"
 msgid "text_default_site_title"
 msgstr "text_default_site_title"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6456,7 +6365,7 @@ msgstr "title_required"
 msgid "to"
 msgstr "a"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6464,7 +6373,7 @@ msgstr ""
 msgid "type"
 msgstr "tipo"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "fino a"
 
@@ -6490,7 +6399,7 @@ msgstr "valore"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6502,6 +6411,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ja/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ja/LC_MESSAGES/bika.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/bikalabs/bika-lims/language/ja/)\n"
@@ -25,49 +25,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -97,15 +97,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -117,15 +117,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -138,7 +138,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -147,32 +147,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -183,16 +177,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -204,7 +198,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -212,17 +206,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -230,54 +224,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "アカウント名"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "アカウントナンバー"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "アカウントタイプ"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -291,21 +285,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -325,11 +319,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -337,16 +327,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -359,26 +349,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -390,7 +380,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -398,15 +388,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -414,11 +404,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -426,48 +416,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -481,7 +471,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -494,27 +484,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -522,52 +512,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -575,65 +565,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -642,46 +632,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -689,12 +679,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -710,17 +700,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -729,7 +719,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -741,7 +731,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -759,15 +749,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -785,27 +775,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -815,25 +805,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -845,7 +835,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -862,27 +852,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -891,31 +881,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -923,7 +913,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -931,7 +921,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -939,63 +929,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1003,8 +997,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1017,11 +1011,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1033,12 +1027,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1052,9 +1046,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1070,18 +1064,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1090,7 +1084,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1098,17 +1092,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1121,31 +1115,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1153,7 +1147,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1169,19 +1163,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1189,19 +1183,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1209,59 +1203,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1270,39 +1264,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1310,21 +1304,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1333,13 +1327,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1348,8 +1342,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1358,48 +1352,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1415,12 +1409,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1433,18 +1427,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1452,7 +1446,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1460,8 +1454,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1469,12 +1463,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1487,7 +1481,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1501,88 +1495,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1598,7 +1592,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1616,7 +1610,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1625,11 +1619,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1641,17 +1635,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1659,49 +1653,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1710,11 +1704,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1738,11 +1732,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1750,7 +1744,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1758,11 +1752,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1770,16 +1764,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1787,9 +1781,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1802,13 +1796,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1816,7 +1810,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1824,19 +1818,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1844,7 +1838,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1852,16 +1846,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1873,7 +1867,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1882,8 +1876,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1892,54 +1886,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1952,20 +1946,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1974,20 +1968,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1999,35 +1993,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2035,7 +2029,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2055,14 +2049,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2074,16 +2068,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2091,15 +2085,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2107,7 +2101,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2115,45 +2109,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2162,19 +2156,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2182,44 +2176,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2227,19 +2217,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2259,16 +2249,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2278,18 +2268,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2299,7 +2289,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2311,37 +2301,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2350,8 +2340,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2359,31 +2349,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2395,7 +2385,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2403,27 +2393,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2431,7 +2421,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2444,7 +2434,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2453,7 +2443,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2462,8 +2452,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2472,7 +2462,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2480,7 +2470,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2488,30 +2478,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2535,7 +2522,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2548,17 +2535,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2571,16 +2558,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2588,19 +2575,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2644,9 +2631,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2670,7 +2657,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2686,24 +2673,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2711,43 +2695,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2757,7 +2741,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2765,12 +2749,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2779,47 +2763,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2839,13 +2823,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2855,7 +2839,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2877,11 +2861,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2893,7 +2877,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2905,41 +2889,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2964,35 +2948,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -3000,16 +2984,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3017,31 +3001,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3050,14 +3028,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3065,30 +3043,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3097,22 +3075,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3124,9 +3102,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3134,17 +3112,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3156,8 +3134,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3165,27 +3143,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3199,7 +3177,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3211,13 +3189,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3226,17 +3204,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3252,18 +3230,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3275,23 +3253,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3299,7 +3277,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3311,17 +3289,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3329,7 +3307,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3339,16 +3317,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3366,25 +3344,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3404,19 +3379,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3424,30 +3399,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3455,15 +3430,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3472,31 +3447,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3504,15 +3479,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3525,26 +3497,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3552,7 +3524,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3564,8 +3536,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3577,16 +3549,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3607,8 +3576,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3633,31 +3602,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3670,8 +3639,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3679,7 +3648,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3687,19 +3656,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3708,13 +3677,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3722,16 +3691,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3759,7 +3728,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3767,12 +3736,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3784,17 +3753,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3805,7 +3774,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3815,14 +3784,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3830,34 +3799,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3872,13 +3841,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3895,34 +3864,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3930,7 +3899,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3945,21 +3914,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3972,8 +3941,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3994,23 +3963,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4032,9 +4001,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4042,11 +4011,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4055,31 +4024,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4087,16 +4056,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4105,7 +4074,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4113,21 +4082,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4150,8 +4119,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4160,9 +4129,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4170,7 +4139,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4178,7 +4147,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4187,8 +4156,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4197,7 +4166,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4211,14 +4180,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4243,7 +4212,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4251,7 +4220,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4260,15 +4229,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4276,26 +4245,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4303,13 +4272,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4317,15 +4286,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4343,11 +4312,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4355,7 +4324,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4363,11 +4332,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4376,14 +4345,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4402,11 +4371,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4422,12 +4391,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4435,19 +4404,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4456,8 +4425,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4469,12 +4438,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4484,52 +4453,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4539,9 +4508,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4569,17 +4538,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4589,30 +4558,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4621,62 +4590,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4686,9 +4655,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4701,17 +4670,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4719,16 +4688,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4740,11 +4709,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4752,11 +4721,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4768,7 +4737,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4780,11 +4749,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4792,19 +4761,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4830,7 +4799,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4842,7 +4811,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4850,7 +4819,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4874,7 +4843,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4890,7 +4859,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4902,7 +4871,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4910,32 +4879,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4943,31 +4908,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4983,7 +4948,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4995,29 +4960,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5025,14 +4986,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5040,41 +5001,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5082,33 +5043,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5116,37 +5077,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5166,11 +5124,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5179,20 +5137,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5210,35 +5168,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5250,7 +5208,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5258,12 +5216,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5271,19 +5229,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5295,7 +5253,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5312,24 +5270,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5346,27 +5304,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5390,7 +5348,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5407,11 +5365,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5428,19 +5386,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5448,11 +5406,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5460,7 +5418,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5472,11 +5430,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5484,19 +5442,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5508,7 +5466,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5520,37 +5478,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5562,7 +5520,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5570,12 +5528,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5590,63 +5544,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5658,13 +5612,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5672,22 +5626,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5699,11 +5653,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5711,61 +5665,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5773,13 +5721,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5804,17 +5752,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5826,11 +5774,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5838,7 +5786,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5850,13 +5798,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5869,7 +5817,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5878,27 +5826,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5906,11 +5854,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5918,181 +5866,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6100,7 +6048,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6111,12 +6059,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6127,7 +6075,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6137,11 +6085,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6149,24 +6097,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6177,25 +6125,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6203,9 +6151,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6217,7 +6165,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6225,11 +6173,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6245,15 +6193,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6274,7 +6222,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6282,36 +6230,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6323,7 +6243,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6371,19 +6291,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6391,19 +6311,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6422,19 +6342,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6446,7 +6355,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6454,7 +6363,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6479,7 +6388,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6491,6 +6400,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ka_GE/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ka_GE/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Georgian (Georgia) (http://www.transifex.com/bikalabs/bika-lims/language/ka_GE/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -136,7 +136,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -210,17 +204,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -323,11 +317,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -388,7 +378,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -479,7 +469,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -520,52 +510,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -640,46 +630,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -813,25 +803,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1096,17 +1090,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1207,59 +1201,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1268,39 +1262,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1346,8 +1340,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1356,48 +1350,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1785,9 +1779,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2033,7 +2027,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2225,19 +2215,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2276,18 +2266,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2348,8 +2338,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2460,8 +2450,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2486,30 +2476,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2763,12 +2747,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2777,47 +2761,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2853,7 +2837,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2998,16 +2982,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3015,31 +2999,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3063,30 +3041,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4040,11 +4009,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4085,16 +4054,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4168,7 +4137,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4274,26 +4243,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4315,15 +4284,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5670,22 +5624,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5904,11 +5852,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6125,7 +6073,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6135,11 +6083,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/kn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/kn/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Kannada (http://www.transifex.com/bikalabs/bika-lims/language/kn/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/lt/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/lt/LC_MESSAGES/bika.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/bikalabs/bika-lims/language/lt/)\n"
@@ -28,49 +28,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} gali prisijungti prie LIMS naudodamas ${contact_username} vartotojo vardą. Naudotojas privalo pasikeisti slaptažodį. Jeigu pamiršote slaptažodį, jį galima pakeisti prisijungimo lange."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} laukia išsaugojimo."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} laukia kol bus atsiųstas."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} atmesta."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} sėkmingai sukurtos."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: dalys laukiamos kol bus gautos."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} laukiama išsaugojimo."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} laukiama kols bus atsiųsta."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} sėkmingai sukurtas."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} laukiama kols bus atsiųsta."
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "Paklaida %"
 
@@ -100,15 +100,15 @@ msgstr "% Įvykdytas"
 msgid "% Published"
 msgstr "% Paskelbtas"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -120,15 +120,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Tuščias)"
@@ -141,7 +141,7 @@ msgstr "(Valdymas)"
 msgid "(Duplicate)"
 msgstr "(Dubliuoti)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Pavojingas)"
 
@@ -150,32 +150,26 @@ msgid "(Required)"
 msgstr "(Privalomas)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "16x16 taškų ikonėlė panaudota pirmumui eilėje nurodyti."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "32x32 taškų ikonėlė panaudota pirmumui eilėje nurodyti."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -186,16 +180,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -207,7 +201,7 @@ msgstr "Tyrimo Užužsakymo prisegtuko nuostatos"
 msgid "AR ID Padding"
 msgstr "Papildomas Tyrimo Užužsakymo ID"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Tyrimo Užužsakymo įvestis"
 
@@ -215,17 +209,17 @@ msgstr "Tyrimo Užužsakymo įvestis"
 msgid "AR Import options"
 msgstr "Tyrimo Užužsakymo įvesties nustatos"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "TU Šablonas"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "TU pakartotinai ištirti rezultatus"
 
@@ -233,54 +227,54 @@ msgstr "TU pakartotinai ištirti rezultatus"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "TU' ai: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Naudotojo vardas"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Naudotojo numeris"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Naudotojo tipas"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akreditacija"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akreditacijos įstaigos santrumpa"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akreditacijos įstaigos URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akreditacijos ženkliukas"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akreditacijos pagrindas"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akredituotas"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -294,21 +288,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktyvus"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Šiuo atveju."
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Pridėti"
 
@@ -328,11 +322,7 @@ msgstr "Pridėti valdymo nuorodą"
 msgid "Add Duplicate"
 msgstr "Pridėti kopiją"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -340,16 +330,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -362,26 +352,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Visa"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Visi tyrimai priskirti"
 
@@ -393,7 +383,7 @@ msgstr "Visi tyrimai pagal tipą"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -401,15 +391,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -417,11 +407,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -429,48 +419,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Tyrimai"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Tyrimai netenkinantys matavimo ribų"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Tyrimai pagal mėginio tipą"
@@ -484,7 +474,7 @@ msgstr "Tyrimai pagal paslaugas"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -497,27 +487,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Pakartotini tyrimai"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Tyrimai"
 
@@ -525,52 +515,52 @@ msgstr "Tyrimai"
 msgid "Analysis Attachment Option"
 msgstr "Tyrimo prisegtuko nuostatos"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Tyrimų kategorijos"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Tyrimų kategorija"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Tyrimų raktinis žodis"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Tyrimo profilis"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Tyrimo užsakymo (TU) ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Tyrimo užsakymo įkėlimas"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -578,65 +568,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Tyrimo užsakymas"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Tyrimų paslauga"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Tyrimų paslaugos"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Tyrimų specifikacijos"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tyrimų tipas"
@@ -645,46 +635,46 @@ msgstr "Tyrimų tipas"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Tyrimų užsakymai ir tyrimai"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Tyrimų užsakymai ir tyrimai pagal klientus"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Tyrimų užsakymai be sąskaitos"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -692,12 +682,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -713,17 +703,17 @@ msgstr "Tyrimų eigos laikas"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Tyrėjas"
 
@@ -732,7 +722,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Bet koks"
 
@@ -744,7 +734,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Pritaikyti šabloną"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -762,15 +752,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Užregistruotas"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -788,27 +778,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Priskirti"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Prisegtukas"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Prisegtuko raktas"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Prisegtuko nuostatos"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Prisegtuko tipas"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Prisegtuko tipai"
 
@@ -818,25 +808,25 @@ msgstr "Prisegtuko tipai"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Prisegtukai draudžiami"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Privaloma pateikti prisegtuką"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Prisegtuko tipas"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Prisegtukai"
 
@@ -848,7 +838,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Automatins duomenų užpildymas"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Automatinis duomenų importas"
 
@@ -865,27 +855,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Banko skyrius"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Banko vardas"
 
@@ -894,31 +884,31 @@ msgid "Basis"
 msgstr "Pagrindas"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Grupė, partija"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Grupės ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Grupės etiketė"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Grupės"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Azimutas"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Prieš  ${start_date}"
 
@@ -926,7 +916,7 @@ msgstr "Prieš  ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Didelė piktograma"
 
@@ -934,7 +924,7 @@ msgstr "Didelė piktograma"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS nustatymai"
 
@@ -942,63 +932,67 @@ msgstr "Bika LIMS nustatymai"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Sąskaitos pateikimo adresas"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Tuščias"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Šaka"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Viso užsakymo nuolaida"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Užsakymo kaina (be PVM)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Darbo telefonas"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Prie"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC e-paštas"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Skaičiavimas"
 
@@ -1006,8 +1000,8 @@ msgstr "Skaičiavimas"
 msgid "Calculation Formula"
 msgstr "Skaičiavimų išraiška"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Skaičiavimo tarpinė sritis"
@@ -1020,11 +1014,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Skaičiavimai"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Kalibravimas"
 
@@ -1036,12 +1030,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1055,9 +1049,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Anuliuoti"
 
@@ -1073,18 +1067,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1093,7 +1087,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Sąrašo numeris"
 
@@ -1101,17 +1095,17 @@ msgstr "Sąrašo numeris"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategorija"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Kategorija negali būti išjungta, nes ji turi veikiančią tyrimų tarnybą"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1124,31 +1118,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1156,7 +1150,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1172,19 +1166,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klasikinis"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1192,19 +1186,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Užsakovas"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Užsakovo ID"
 
@@ -1212,59 +1206,59 @@ msgstr "Užsakovo ID"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Užsakovo vardas"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Užsakymas"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Užsakovo nuoroda"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Užsakovo nuoroda"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Užsakovo SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Užsakovo kontakto duomenys privalo egzistuoti prieš atliekant užsakymą"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Užsakovai"
 
@@ -1273,39 +1267,39 @@ msgstr "Užsakovai"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1313,21 +1307,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Mišrus"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Pasikliautinas intervalas %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1336,13 +1330,13 @@ msgid "Confirm password"
 msgstr "Patvirtinti slaptažodį"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontaktiniai duomenys"
@@ -1351,8 +1345,8 @@ msgstr "Kontaktiniai duomenys"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontaktas"
@@ -1361,48 +1355,48 @@ msgstr "Kontaktas"
 msgid "Contacts to CC"
 msgstr "Kontakto CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Talpa"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Turinio tipas"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrolė"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1418,12 +1412,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1436,18 +1430,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1455,7 +1449,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1463,8 +1457,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1472,12 +1466,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Einamasis"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1490,7 +1484,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1504,88 +1498,88 @@ msgstr "Duomenų sąsaja"
 msgid "Data Interface Options"
 msgstr "Duomenų sąsajos nustatymai"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Išsiuntimo data"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Atlikimo data"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Galiojimo iki data"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Įvesties data"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Užkrovimo data"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Pradžios data"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Paskelbimo data"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Gavimo data"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Užklausos data"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Tyrimo data"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1601,7 +1595,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1619,7 +1613,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1628,11 +1622,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dienos"
 
@@ -1644,17 +1638,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Numatyta"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1662,49 +1656,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1713,11 +1707,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1741,11 +1735,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Numatytoji reikšmė"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1753,7 +1747,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1761,11 +1755,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1773,16 +1767,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Laipsnis"
 
@@ -1790,9 +1784,9 @@ msgstr "Laipsnis"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1805,13 +1799,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1819,7 +1813,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1827,19 +1821,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1847,7 +1841,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1855,16 +1849,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1876,7 +1870,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1885,8 +1879,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1895,54 +1889,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1955,20 +1949,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1977,20 +1971,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -2002,35 +1996,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2038,7 +2032,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2058,14 +2052,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2077,16 +2071,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2094,15 +2088,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2110,7 +2104,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2118,45 +2112,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2165,19 +2159,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2185,44 +2179,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2230,19 +2220,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2262,16 +2252,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2281,18 +2271,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2302,7 +2292,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2314,37 +2304,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2353,8 +2343,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2362,31 +2352,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2398,7 +2388,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2406,27 +2396,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2434,7 +2424,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2447,7 +2437,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2456,7 +2446,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2465,8 +2455,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2475,7 +2465,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2483,7 +2473,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2491,30 +2481,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2538,7 +2525,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2551,17 +2538,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2574,16 +2561,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2591,19 +2578,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2647,9 +2634,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2673,7 +2660,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2689,24 +2676,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2714,43 +2698,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2760,7 +2744,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2768,12 +2752,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2782,47 +2766,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2842,13 +2826,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2858,7 +2842,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2880,11 +2864,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2896,7 +2880,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2908,41 +2892,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2967,35 +2951,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -3003,16 +2987,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3020,31 +3004,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3053,14 +3031,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3068,30 +3046,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3100,22 +3078,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3127,9 +3105,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3137,17 +3115,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3159,8 +3137,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3168,27 +3146,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3202,7 +3180,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3214,13 +3192,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3229,17 +3207,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3255,18 +3233,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3278,23 +3256,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3302,7 +3280,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3314,17 +3292,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3332,7 +3310,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3342,16 +3320,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3369,25 +3347,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3407,19 +3382,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3427,30 +3402,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3458,15 +3433,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3475,31 +3450,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3507,15 +3482,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3528,26 +3500,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3555,7 +3527,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3567,8 +3539,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3580,16 +3552,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3610,8 +3579,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3636,31 +3605,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3673,8 +3642,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3682,7 +3651,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3690,19 +3659,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3711,13 +3680,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3725,16 +3694,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3762,7 +3731,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3770,12 +3739,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3787,17 +3756,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3808,7 +3777,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3818,14 +3787,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3833,34 +3802,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3875,13 +3844,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3898,34 +3867,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3933,7 +3902,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3948,21 +3917,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3975,8 +3944,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3997,23 +3966,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4035,9 +4004,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4045,11 +4014,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4058,31 +4027,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4090,16 +4059,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4108,7 +4077,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4116,21 +4085,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4153,8 +4122,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4163,9 +4132,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4173,7 +4142,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4181,7 +4150,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4190,8 +4159,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4200,7 +4169,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4214,14 +4183,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4246,7 +4215,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4254,7 +4223,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4263,15 +4232,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4279,26 +4248,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4306,13 +4275,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4320,15 +4289,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4346,11 +4315,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4358,7 +4327,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4366,11 +4335,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4379,14 +4348,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4405,11 +4374,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4425,12 +4394,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4438,19 +4407,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4459,8 +4428,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4472,12 +4441,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4487,52 +4456,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4542,9 +4511,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4572,17 +4541,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4592,30 +4561,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4624,62 +4593,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4689,9 +4658,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4704,17 +4673,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4722,16 +4691,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4743,11 +4712,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4755,11 +4724,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4771,7 +4740,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4783,11 +4752,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4795,19 +4764,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4833,7 +4802,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4845,7 +4814,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4853,7 +4822,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4877,7 +4846,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4893,7 +4862,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4905,7 +4874,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4913,32 +4882,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4946,31 +4911,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4986,7 +4951,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4998,29 +4963,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5028,14 +4989,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5043,41 +5004,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5085,33 +5046,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5119,37 +5080,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5169,11 +5127,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5182,20 +5140,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5213,35 +5171,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5253,7 +5211,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5261,12 +5219,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5274,19 +5232,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5298,7 +5256,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5315,24 +5273,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5349,27 +5307,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5393,7 +5351,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5410,11 +5368,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5431,19 +5389,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5451,11 +5409,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5463,7 +5421,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5475,11 +5433,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5487,19 +5445,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5511,7 +5469,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5523,37 +5481,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5565,7 +5523,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5573,12 +5531,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5593,63 +5547,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5661,13 +5615,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5675,22 +5629,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5702,11 +5656,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5714,61 +5668,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5776,13 +5724,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5807,17 +5755,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5829,11 +5777,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5841,7 +5789,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5853,13 +5801,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5872,7 +5820,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5881,27 +5829,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5909,11 +5857,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5921,181 +5869,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6103,7 +6051,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6114,12 +6062,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6130,7 +6078,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6140,11 +6088,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6152,24 +6100,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6180,25 +6128,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Darbo kortelių šablonai"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6206,9 +6154,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6220,7 +6168,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6228,11 +6176,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6248,15 +6196,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6277,7 +6225,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6285,36 +6233,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6326,7 +6246,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6374,19 +6294,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6394,19 +6314,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6425,19 +6345,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6449,7 +6358,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6457,7 +6366,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6482,7 +6391,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6494,6 +6403,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/mn/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/mn/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Mongolian (http://www.transifex.com/bikalabs/bika-lims/language/mn/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Error"
 
@@ -96,15 +96,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -116,15 +116,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -137,7 +137,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -211,17 +205,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -229,54 +223,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -324,11 +318,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -336,16 +326,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -358,26 +348,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -389,7 +379,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -480,7 +470,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -493,27 +483,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -521,52 +511,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -641,46 +631,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -688,12 +678,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -709,17 +699,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -740,7 +730,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -814,25 +804,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -922,7 +912,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -930,7 +920,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -938,63 +928,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1002,8 +996,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1016,11 +1010,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1032,12 +1026,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1069,18 +1063,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1097,17 +1091,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1208,59 +1202,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1269,39 +1263,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1309,21 +1303,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1347,8 +1341,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1357,48 +1351,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1432,18 +1426,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1451,7 +1445,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1468,12 +1462,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1786,9 +1780,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1815,7 +1809,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1851,16 +1845,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1881,8 +1875,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1891,54 +1885,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2034,7 +2028,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2161,19 +2155,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2226,19 +2216,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2277,18 +2267,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2452,7 +2442,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2461,8 +2451,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2487,30 +2477,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2764,12 +2748,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2778,47 +2762,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3016,31 +3000,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3164,27 +3142,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3225,17 +3203,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3678,7 +3647,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3721,16 +3690,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3814,14 +3783,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4041,11 +4010,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4169,7 +4138,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4259,15 +4228,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4779,11 +4748,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4849,7 +4818,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5447,11 +5405,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,12 +5527,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5671,22 +5625,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5698,11 +5652,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5868,7 +5816,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5877,27 +5825,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5905,11 +5853,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5917,181 +5865,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6126,7 +6074,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6136,11 +6084,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6281,36 +6229,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/nl/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/nl/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/bikalabs/bika-lims/language/nl/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Fout"
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Blank)"
@@ -136,7 +136,7 @@ msgstr "(Controle)"
 msgid "(Duplicate)"
 msgstr "(Duplicate)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr "(Vereist)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr "AA Attachment optie"
 msgid "AR ID Padding"
 msgstr "AA ID opvulling"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "AA importeren"
 
@@ -210,17 +204,17 @@ msgstr "AA importeren"
 msgid "AR Import options"
 msgstr "AA importopties"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Rekeningnaam"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Rekeningnummer"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Rekeningtype"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Accreditatie"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Accreditatie-instelling afkorting"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Accreditatie-instelling URL"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Accreditatie referentie"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Geaccrediteerd"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Actieve"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Toevoegen"
 
@@ -323,11 +317,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Alle"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Alle analyses toegewezen"
 
@@ -388,7 +378,7 @@ msgstr "Alle analyses van type"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analyses"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analyses out of range"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analyses per monster type"
@@ -479,7 +469,7 @@ msgstr "Analyses per dienst"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Analyses herhaald"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analyse"
 
@@ -520,52 +510,52 @@ msgstr "Analyse"
 msgid "Analysis Attachment Option"
 msgstr "Analyse Attachment optie"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Analyse Categorieën"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Analyse categorie"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Analyse aanvraag-ID"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Analyse verzoek invoer"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Analyse Aanvragen"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Analyse specificaties"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Soort analyse"
@@ -640,46 +630,46 @@ msgstr "Soort analyse"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr "Analyse doorlooptijd"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analist"
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Elke"
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Sjabloon toepassen"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Toegewezen"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Hechten aan"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Bijlage"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Bijlage sleutelwoorde"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Bijlage optie"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Type bijlage"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Bijlagentypen"
 
@@ -813,25 +803,25 @@ msgstr "Bijlagentypen"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Bijlagen"
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr "Berekeningsformule"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Berekeningvelden Interim"
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Berekeningen"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Geannuleerd"
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Catalogusnummer"
 
@@ -1096,17 +1090,17 @@ msgstr "Catalogusnummer"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Classic"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Client"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Client-ID"
 
@@ -1207,59 +1201,59 @@ msgstr "Client-ID"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Clientnaam"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Client Ref"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referentie voor client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Client MID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Client Monster-ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Klanten"
 
@@ -1268,39 +1262,39 @@ msgstr "Klanten"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composiet"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr "Bevestig wachtwoord"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contact"
@@ -1346,8 +1340,8 @@ msgstr "Contact"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contactpersonen"
@@ -1356,48 +1350,48 @@ msgstr "Contactpersonen"
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1785,9 +1779,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr "Droge"
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Verschuldigd"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Duur"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Vroegheid"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Hoogte"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "E-mail"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "E-mailadres"
 
@@ -2033,7 +2027,7 @@ msgstr "E-mailadres"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Onderwerpregel"
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Uitsluiten van factuur"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Verwachte resultaat"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Verlopen"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Vervaldatum"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Vrouw"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Veld"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Veld Analyses"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Veld Titel"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Bestand"
 
@@ -2225,19 +2215,19 @@ msgstr "Bestand"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Bestandsnaam"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Voornaam"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formule"
 
@@ -2276,18 +2266,18 @@ msgstr "Formule"
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Volledige naam"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Uur"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2348,8 +2338,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2460,8 +2450,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2486,30 +2476,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2763,12 +2747,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2777,47 +2761,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Lab Analyses"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Lab contacten"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Lab afdelingen"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Lab producten"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Lab URL"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorium"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Geaccrediteerd laboratorium"
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Laatst bewerkt"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Laat"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Late Analyses"
@@ -2853,7 +2837,7 @@ msgstr "Late Analyses"
 msgid "Late Analysis"
 msgstr "Late Analyse"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Gekoppelde monster"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Log"
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Lengtegraad"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Lotnummer"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Mailing adres"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Mannetje"
 
@@ -2998,16 +2982,16 @@ msgstr "Mannetje"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Manager"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "E-mail manager"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Manager telefoon"
 
@@ -3015,31 +2999,25 @@ msgstr "Manager telefoon"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabrikant"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Max tijd"
 
@@ -3063,30 +3041,30 @@ msgstr "Max tijd"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maximale turn-around tijd"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Lid korting %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Lid korting geldt"
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Methode"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Methode Document"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Methode instructies"
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4040,11 +4009,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4085,16 +4054,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4168,7 +4137,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4274,26 +4243,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4315,15 +4284,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5670,22 +5624,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5904,11 +5852,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6125,7 +6073,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6135,11 +6083,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/pl/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pl/LC_MESSAGES/bika.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Polish (http://www.transifex.com/bikalabs/bika-lims/language/pl/)\n"
@@ -29,49 +29,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} może się zalogować do LIMS używając jako nazwy użytkownika ${contact_username}. Wymagana jest zmiana hasła. W przypadku zapomnienia można wystąpić o nowe używając formularza logowania."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${item} brak daty utrwalenia lub osoby odpowiedzialnej"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} oczekują na utrwalenie."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} oczekują na przyjęcie."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} unieważnione"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} zostały pomyślnie utworzone."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: części czekają na przyjęcie"
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} brak Utrwalającego lub daty utrwalenia"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} oczekuje na utrwalenie."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} oczekuje na przyjęcie."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} został pomyślnie utworzony."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} oczekuje na przyjęcie."
 
@@ -87,7 +87,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Błąd"
 
@@ -101,15 +101,15 @@ msgstr "% wykonanych"
 msgid "% Published"
 msgstr "% opublikowanych"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s nie ma '%s' kolumny."
 
@@ -121,15 +121,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Klasyczny' oznacza konieczność odniesienia każdej próbki do kodu zlecenia i usługi analitycznej. W przypadku 'Profil', użycie słowa kluczowego analizy połączy wiele usług analitycznych dla danego zbioru próbek"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Ślepa)"
@@ -142,7 +142,7 @@ msgstr "(Kontrolna)"
 msgid "(Duplicate)"
 msgstr "(Duplikat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Niebezpieczna)"
 
@@ -151,32 +151,26 @@ msgid "(Required)"
 msgstr "(Wymagane)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Ikona 16x16 pikseli użyta do zanaczenia tego priorytetu na listach "
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Ikona 32x32 piksele używana do zaznaczenia tego priorytetu w widokach obiektu"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -187,16 +181,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "Zastaw Analiz ${ar_number}"
 
@@ -208,7 +202,7 @@ msgstr "Opcje załączników dotyczących Zestawów Analiz"
 msgid "AR ID Padding"
 msgstr "Ilość cyfr w kodzie zestawu analiz"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Importowanie AR"
 
@@ -216,17 +210,17 @@ msgstr "Importowanie AR"
 msgid "AR Import options"
 msgstr "Opcje importowania AR"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Szablony zestawów analiz -AR-"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Zlecenia Analiz dla wyników powtarzanych"
 
@@ -234,54 +228,54 @@ msgstr "Zlecenia Analiz dla wyników powtarzanych"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "Zestawy analiz: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nazwa konta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Numer konta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Typ konta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akredytacja"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Skrót nazwy jednostki akredytującej"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Adres URL jednostki akredytującej"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logo akredytacji"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Numer akredytacji"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Nagłówek strony akredytacji"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akredytowane"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -295,21 +289,21 @@ msgstr "Operacje wykonywane przez użytkowników (lub określonego użytkownika)
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Aktywne"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Doraźne"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Dodaj"
 
@@ -329,11 +323,7 @@ msgstr "Dodaj próbkę kontrolną"
 msgid "Add Duplicate"
 msgstr "Dodaj próbkę zdublowaną"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Dodaj szablon"
 
@@ -341,16 +331,16 @@ msgstr "Dodaj szablon"
 msgid "Add a remarks field to all analyses"
 msgstr "Dadaj pole komentarza do wszystkich analiz"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Dodaj nowe"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Dodatkowe uwagi:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adres"
@@ -363,26 +353,26 @@ msgstr "Dodaje dwucyfrowy rok po prefiksie ID"
 msgid "Administrative Reports"
 msgstr "Raporty administracyjne"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Po ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Laboratorium wzorcujące"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Wszystkie"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Poniżej wymieniono wszystkie akredytowane metody badań"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Wszystkie analizy przypisane"
 
@@ -394,7 +384,7 @@ msgstr "Wszystkie analizy typu"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Zezwól Kierownikowi laboratorium na utworzenia konta klienta i jego edycję"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Zezwól na ręczne wprowadzanie granicy oznaczalności"
 
@@ -402,15 +392,15 @@ msgstr "Zezwól na ręczne wprowadzanie granicy oznaczalności"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Zezwól na dostęp do kart pracy tylko upoważnionym analitykom"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Zezwól na ręczne wprowadzanie wartości niepewności"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -418,11 +408,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Zewól analitykowi na zmianę wdomyślnego Limitu Detekcji (LDL i UDL) w widocznym zbiorze wyników"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Zezwól analitykowi na ręczną zmianę domyślnej wartości niepewności."
 
@@ -430,48 +420,48 @@ msgstr "Zezwól analitykowi na ręczną zmianę domyślnej wartości niepewnośc
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Alternatywne obliczenia"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Zawsze rozwijaj wybrane kategorie w widokach klienta"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Ilość"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analizy"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Analizy w zakresie dopuszczalnego błędu"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Analizy poza zakresem"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Analizy według usług"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Analizy według typu próbki"
@@ -485,7 +475,7 @@ msgstr "Analizy według metod badań"
 msgid "Analyses performed and published as % of total"
 msgstr "Analizy przeprowadzone i opublikowane jako % ogółu"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Analizy przeprowadzone jako % ogółu"
 
@@ -498,27 +488,27 @@ msgstr "Raporty dotyczące analiz"
 msgid "Analyses repeated"
 msgstr "Analizy powtarzane"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Wynik poza wyspecyfikowaną wartością"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Analizy wykonane ponownie"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Podsumowanie analiz według działów"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Analizy, które zostały ponownie wykonane"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analiza"
 
@@ -526,52 +516,52 @@ msgstr "Analiza"
 msgid "Analysis Attachment Option"
 msgstr "Opcja załącznika do analizy"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Kategorie analiz"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Kategoria analiz"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Analiza - słowo kluczowe"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Profil analizy"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Profile analiz"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Zestaw analiz"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID Zestawu analiz -AR-"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Import Zestawu Analiz"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Priorytet Zestawu Analiz"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Specyfikacja Zestawu Analiz"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -579,65 +569,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Zestawy analiz"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Metoda badań"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Metody badań"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Specyfikacja analizy"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Specyfikacja analizy"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Status analizy"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Typ analizy"
@@ -646,46 +636,46 @@ msgstr "Typ analizy"
 msgid "Analysis category"
 msgstr "Kategoria analizy"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Zestaw analiz ${AR} został pomyślnie utworzony."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Zestawy analiz ${ARs} zostały pomyślnie utworzone."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Zestawy analiz i analizy"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Zestawy analiz i analizy według klienta"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Zestawy analiz, dla których nie wygenerowano faktur"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Wynik analizy w zakresie błedu"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Wyniki analiz"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Wyniki analiz dla ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Wyniki badań na punkt pobierania i metodę badań"
 
@@ -693,12 +683,12 @@ msgstr "Wyniki badań na punkt pobierania i metodę badań"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Wyniki analiz poza zakresem określonym przez laboratorium lub klienta. Wyszukiwanie może potrwać kilka minut."
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Metoda badań"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Przywrócono wartości domyślne dla Specyfikacji analizy"
 
@@ -714,17 +704,17 @@ msgstr "Czas realizacji analizy"
 msgid "Analysis turnaround time over time"
 msgstr "Czas realizacji analizy w okresie"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Czas realizacji analizy"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Czas realizacji analiz w okresie"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analityk"
 
@@ -733,7 +723,7 @@ msgid "Analyst must be specified."
 msgstr "Analityk musi być wskazany"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Wszystkie"
 
@@ -745,7 +735,7 @@ msgstr "Zastosuj"
 msgid "Apply template"
 msgstr "Zastosuj szablon"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Zastosuj wielokrotnie"
 
@@ -763,15 +753,15 @@ msgstr "Numer ewidencyjny"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Przydzielony"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Przypisane do karty pracy"
 
@@ -789,27 +779,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Dołącz do"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Załącznik"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Słowa kluczowe dla załącznika"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opcje załączników"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Typ załącznika"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Typy załączników"
 
@@ -819,25 +809,25 @@ msgstr "Typy załączników"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Załącznik niedozwolony"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Wymagany jest załącznik"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Typ załącznika"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Załączniki"
 
@@ -849,7 +839,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Automatyczne wypełnianie"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Automatyczne importowanie"
 
@@ -866,27 +856,27 @@ msgstr "Automatyczne drukowanie etykiet"
 msgid "Available templates"
 msgstr "Dostępne szablony"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Średni czas wykonania"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Średnie wyprzedzenie"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Średnie opóźnienie"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Stan źle sformułowany: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Oddział banku"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nazwa banku"
 
@@ -895,31 +885,31 @@ msgid "Basis"
 msgstr "Jednomianowa"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Seria próbek"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Kod serii próbek"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etykiety serii próbek"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Serie próbek"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Azymut"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Przed ${start_date}"
 
@@ -927,7 +917,7 @@ msgstr "Przed ${start_date}"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Duża Ikona"
 
@@ -935,7 +925,7 @@ msgstr "Duża Ikona"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Konfiguracja Bika LIMS"
 
@@ -943,63 +933,67 @@ msgstr "Konfiguracja Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Adres fakturowania"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Ślepa"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Kontrolna analiza ślepej próby QC"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marka"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Obowiązuje zniżka hurtowa"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Cena hurtowa (bez VAT)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Telefon służbowy"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "przez"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC Kontakty"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Obliczenie Precyzji z Niepewności"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Obliczanie"
 
@@ -1007,8 +1001,8 @@ msgstr "Obliczanie"
 msgid "Calculation Formula"
 msgstr "Formuła obliczania"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Tymczasowe pola obliczeniowe"
@@ -1021,11 +1015,11 @@ msgstr "Reguła obliczania: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Reguła obliczania: Brak"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Formuły obliczeniowe"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Kalibracja"
 
@@ -1037,12 +1031,12 @@ msgstr "Świadectwa wzorcowania"
 msgid "Calibration report date"
 msgstr "Data raportu kalibracji"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Kalibrator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1056,9 +1050,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Anulowane"
 
@@ -1074,18 +1068,18 @@ msgstr "Nie można wyłączyć obliczeń, ponieważ są używne przez następuj�
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Nie można zweryfikować: Wysłsne przez bieżącego użytkownika"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Pojemność"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Data wprowadzenia"
 
@@ -1094,7 +1088,7 @@ msgid "Cardinal"
 msgstr "Wielomianowa"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Numer katalogowy"
 
@@ -1102,17 +1096,17 @@ msgstr "Numer katalogowy"
 msgid "Categorise analysis services"
 msgstr "Klasyfikowane metody analityczne"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Kategoria nie może być wyłączona, ponieważ zawiera Metody badań"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Numer świdectwa"
 
@@ -1125,31 +1119,31 @@ msgstr "Kod świadectwa"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Sprawdź czy metoda była akredytowana"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Zaznacz to pole wyboru, jeśli metoda badań jest objęta zakresem akredytacji laboratorium"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Zaznacz tą opcję, jeżeli pobrana z tego miejsca próbka jest 'złożona' i składa się z więcej niż jednej części, np. kilka próbek wody z powierzchni zbiornika zmieszanych dla uzyskania reprezentatywności. Domyślnie pole to nie jest zaznaczone"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Zaznacz to pole, jeśli pojemnik jest już utrwalony. Zaznaczenie to spowoduje przerwanie procedury utrwalania próbek w nim  przechowywanych."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Zaznacz tę opcję, jeżeli jest to priorytet domyślny"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Zaznacz to pole, jeśli twoje laboratorium jest akredytowane"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Zaznacz to pole jeżeli dla tej metody badań wymagane jest pobranie próbki do osobnego pojemnika"
 
@@ -1157,7 +1151,7 @@ msgstr "Zaznacz to pole jeżeli dla tej metody badań wymagane jest pobranie pr�
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Zaznacz, jeżeli chcesz używać zewnętrzego serwera identyfikatorów ID. Prefiksy można definiować oddzielnie dla każdej strony Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Wybierz wartości domyślne dla specyfikacji  zestawu analiz AR"
 
@@ -1173,19 +1167,19 @@ msgstr ""
 msgid "City"
 msgstr "Miasto"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klasyczny"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Kliknij na Kategorie Analiz AC (zacienione tło) dla wyświetlenia wszystkich kategorii Usług Analitycznych AS. Dla określenia dopuszczalnego zakresu wyników, wprowadź minimalną i maksymalną wartość. Każdy wynik spoza tego zakresu będzie generował alarm. Alternatywnym sposobem ewaluacji może być wykorzystanie pola % Error, gdzie wpisana wartość blędu w % będzie użyta do sprawdzenia poprawności wyniku. Wartość przekraczjąca minimum lub maksimum ale mieszcząca się w zakresie błędu zdefiniwanego procentowo wygeneruje ostrzeżenie."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Kliknij na Kategorie Analiz AC (zacienione tło) dla wyświetlenia wszystkich kategorii Usług Analitycznych AS. Dla określenia dopuszczalnego zakresu wyników, wprowadź wartość minimalną i maksymalną . Każdy wynik spoza tego zakresu będzie generował alarm. Alternatywnym sposobem ewaluacji może być wykorzystanie pola Dopuszczalny błąd, gdzie wpisana wartość w % będzie użyta do sprawdzenia poprawności wyniku. Wartość przekraczjąca minimum lub maksimum ale mieszcząca się w zakresie błędu zdefiniwanego procentowo wygeneruje ostrzeżenie."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Kliknij na Kategorie Analiz AC (zacienione tło) dla wyświetlenia wszystkich kategorii Usług Analitycznych AS. Dla określenia dopuszczalnego zakresu wyników, wprowadź minimalną i maksymalną wartość. Każdy wynik spoza tego zakresu będzie generował alarm. Alternatywnym sposobem ewaluacji może być wykorzystanie pola % Error, gdzie wpisana wartość blędu w % będzie użyta do sprawdzenia poprawności wyniku. Wartość przekraczjąca minimum lub maksimum ale mieszcząca się w zakresie błędu zdefiniwanego procentowo wygeneruje ostrzeżenie. Jeżeli wynik ma wartość poniżej 'Min', będzie wyświetlony jako '<[min]'. To samo dotyczy wartości powyżej 'Max'"
 
@@ -1193,19 +1187,19 @@ msgstr "Kliknij na Kategorie Analiz AC (zacienione tło) dla wyświetlenia wszys
 msgid "Click to download"
 msgstr "Kliknij, aby pobrać"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Klient"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "Kod serii próbek nadany przez klienta"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID klienta"
 
@@ -1213,59 +1207,59 @@ msgstr "ID klienta"
 msgid "Client Landing Page"
 msgstr "Strona docelowa klienta"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nazwa klienta"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Zlecenie klienta"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Numer Zamówienia Klienta"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Odniesienie do klienta"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Odniesienie do klienta"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Kod próbki nadany przez klienta"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Kod próbki klienta"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Wymagane jest podanie kontaktu do klienta zanim możliwe będzie dodawanie danych"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Klienci"
 
@@ -1274,39 +1268,39 @@ msgstr "Klienci"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Zamknięte"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Kod lokalizacji"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Kod miejsca"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Kod półki"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Przecinek(,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Komentarze"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Komentarz lub interpretacja wyników"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "Komercyjny ID"
 
@@ -1314,21 +1308,21 @@ msgstr "Komercyjny ID"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Złożona"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Poziom ufności %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Konfiguracja szablonu dla próbek wieloczęściowych i utrwalania. W zakładce Analizy każdej części przypisz odpowiednią analizę."
 
@@ -1337,13 +1331,13 @@ msgid "Confirm password"
 msgstr "Potwierdź hasło"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Uwarunkowania"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Kontakt"
@@ -1352,8 +1346,8 @@ msgstr "Kontakt"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Kontakty"
@@ -1362,48 +1356,48 @@ msgstr "Kontakty"
 msgid "Contacts to CC"
 msgstr "Kontakty Do wiadomości"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Pojemnik"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Typ pojemnika"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Typy pojemników"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Pojemniki na próbki"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Typ zawartości"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Typ zawartości"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrola"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Analiza kontrolna QC"
 
@@ -1419,12 +1413,12 @@ msgstr "Kopiuj metodę badań"
 msgid "Copy from"
 msgstr "Kopiuj z"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Kopiuj jako nowy"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Policz"
 
@@ -1437,18 +1431,18 @@ msgstr "Kraj"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Utwórz nową próbkę tego typu"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Utworzony"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Utworzone przez"
 
@@ -1456,7 +1450,7 @@ msgstr "Utworzone przez"
 msgid "Created by:"
 msgstr "Utworzone przez:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1464,8 +1458,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Twórca"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Kryteria"
 
@@ -1473,12 +1467,12 @@ msgstr "Kryteria"
 msgid "Currency"
 msgstr "Waluta"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Bieżące"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Defininiowany separator miejsca dziesiętnego"
 
@@ -1491,7 +1485,7 @@ msgstr "Lista Dystrybucyjna"
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1505,88 +1499,88 @@ msgstr "Interfejs danych"
 msgid "Data Interface Options"
 msgstr "Opcje interfejsu danych"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Przyjęte zamówienia"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Data utworzenia"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Data wysyłki"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Data usunięcia"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Data przydatności"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Data importowania"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Data wczytania"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Data otwarcia"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Data utrwalenia"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Data opublikowania"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Data dostarczenia"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Data zgłoszenia"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Data pobrania"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1602,7 +1596,7 @@ msgstr "Data, od której potwierdzenie kalibracji jest ważne"
 msgid "Date from which the instrument is under calibration"
 msgstr "Data, od której instrument jest wykalibrowany"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Data, od której instrument jest w konserwacji"
 
@@ -1620,7 +1614,7 @@ msgid "Date until the certificate is valid"
 msgstr "Data do kiedy certyfikat jest ważny"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Data, do której przyrząd będzie niedostępny"
@@ -1629,11 +1623,11 @@ msgstr "Data, do której przyrząd będzie niedostępny"
 msgid "Date when the calibration certificate was granted"
 msgstr "Data uzyskania świadectwa kalibracji"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dni"
 
@@ -1645,17 +1639,17 @@ msgstr "Nieaktywny do następnego testu kalibracji"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Separator dziesiętny do zastosowania w raportach tego Klienta"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Domyślne"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Domyślny typ  zestawu analiz AR"
 
@@ -1663,49 +1657,49 @@ msgstr "Domyślny typ  zestawu analiz AR"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Domyślna reguła obliczania"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Domyślny pojemnik"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Domyślny rodzaj pojemnika"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Domyślny przyrząd"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Domyślna metoda"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Domyślne utrwalanie"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Domyślny priorytet"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Zastosowanie  domyślnej reguły obliczeniwej z domyślnej metody, która zostanie przypisana podczas edycji."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Kategorie domyślne"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Domyślny pojemnik dla nowej próbki częściwej."
 
@@ -1714,11 +1708,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Domyślne pojemniki: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Domyślny separator dziesiętny"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1742,11 +1736,11 @@ msgstr "Domyślny format notacji naukowej dla raportów"
 msgid "Default scientific notation format for results"
 msgstr "Domyślny format notacji naukowej dla wyników"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Wartość domyślna"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "Wybierz opcję"
 
@@ -1754,7 +1748,7 @@ msgstr "Wybierz opcję"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Zdefiniuj kod identyfikacyjny dla metody, który musi być unikalny."
 
@@ -1762,11 +1756,11 @@ msgstr "Zdefiniuj kod identyfikacyjny dla metody, który musi być unikalny."
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Definicja ilości miejsc dziesiętnych dla tego wyniku"
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Definicja precyzji podczas konwersji wartości do notacji wykładniczej. Domyślnie 7."
 
@@ -1774,16 +1768,16 @@ msgstr "Definicja precyzji podczas konwersji wartości do notacji wykładniczej.
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Zdefiniuj prefiksy dla nadawanych przez system unikalnym sekwencyjnym identyfikatorom ID obiektów. W polu 'Padding' wskaż ile pozycji wypełnionych wstępnie zerami ma mieć mumer. Np. prefiks KP dla karty pracy z wartością 'Padding' 4 będzie widoczny w zakresie KP-0001 do KP-9999. Start sekwencji wskazuje na numer od którego ma się zacząć numeracja. Zostanie użyty, jeżeli jest większy od już istniejącego identyfikatora. Powstełego w ten sposób odstępu w numeracji nie można wykorzystać. Uwaga: nazwy dla próbek i zestawów analiz porzedzone zostają skrótem typu próbki i nie są definiowane w tej tabeli - ilość pozycji dla nich można ustawić w odpowiednich polach poniżej."
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Stopnie"
 
@@ -1791,9 +1785,9 @@ msgstr "Stopnie"
 msgid "Delete attachment"
 msgstr "Usuń załącznik"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Dział"
 
@@ -1806,13 +1800,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analizy zależne"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Opis metody zrozumiały dla laika. Informacje te są udostępniane klientom laboratorium"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Opis"
 
@@ -1820,7 +1814,7 @@ msgstr "Opis"
 msgid "Description of the actions made during the calibration"
 msgstr "Opis czynności podejmowanych podczas kalibracji"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Opis czynności podejmowanych podczas konserwacji"
 
@@ -1828,19 +1822,19 @@ msgstr "Opis czynności podejmowanych podczas konserwacji"
 msgid "Description of the actions made during the validation"
 msgstr "Opis czynności podejmowanych podczas walidacji"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Opis lokalizacji"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Opis półki"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Opis miejsca"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1848,7 +1842,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Rabat %"
 
@@ -1856,16 +1850,16 @@ msgstr "Rabat %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Wysłane"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Wyświetlana wartość"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Wyświetl wskaźnik Limit Detekcji"
 
@@ -1877,7 +1871,7 @@ msgstr "Wyświetl powiadomienie o nowym wydaniu Bika LIMS"
 msgid "Display individual sample partitions "
 msgstr "Wyświetl poszczególne częsci próbki"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Termin usunięcia"
 
@@ -1886,8 +1880,8 @@ msgstr "Termin usunięcia"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Usunięte"
@@ -1896,54 +1890,54 @@ msgstr "Usunięte"
 msgid "District"
 msgstr "Powiat"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Dzielenie przez zero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Dokument"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Ukryte"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Kropka (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Skąd"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Aż do"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Pobierz"
 
@@ -1956,20 +1950,20 @@ msgstr "Suchy"
 msgid "Dry matter analysis"
 msgstr "Analiza suchej masy"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Planowana"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Data planowana"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Zmienność Duplikatu"
 
@@ -1978,20 +1972,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplikat"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplikat"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Kontrolna analiza próby powtórzonej QC"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Zmienność dla próbek podwójnych %"
 
@@ -2003,35 +1997,35 @@ msgstr "Kontrolna analiza próby powtórzonej QC"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Wykresy kontroli jakości dla analiz podwójnych"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Czas trwania"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Np. PCA itp."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Earliness"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Wczesny"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Wysokość - głębokość"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "E-mail"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Adres E-mail"
 
@@ -2039,7 +2033,7 @@ msgstr "Adres E-mail"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Wiersz tematu wiadomości e-mail"
 
@@ -2059,14 +2053,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Data Końcowa"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Rozszerzenie"
 
@@ -2078,16 +2072,16 @@ msgstr "Wprowadź nazwę użytkownika, np.: 'jkowalski'. Nazwa nie może zawiera
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Wprowadź adres e-mail. Jest on konieczny w przypadku zgubienia hasła. Szanujemy Twoją prywatność i nie będziemy podawać adresu osobom trzecim lub publikować go gdziekolwiek."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Wprowadź wartość procentową rabatu"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Wprowadź wartość procentową, np. 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Wprowadź wartość procentową np. 23.0. Zostanie ona zastosowana tylko dla Profilu Analizy, zastępując sytemową stawkę podatku VAT"
 
@@ -2095,15 +2089,15 @@ msgstr "Wprowadź wartość procentową np. 23.0. Zostanie ona zastosowana tylko
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Wprowadź wartość procentową, np. 14.0. Ma ona zasięg globalny ale może zostać zmieniona w razie potrzeby. "
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Wprowadź wartość procentową, np. 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Wprowadź szerokość geograficzną punktu pobierania próbki wyrażoną w stopniach 0-90, minutach 0-59, sekundach 0-59 oraz N/S  "
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Wprowadź długość geograficzną punktu pobierania próbki wyrażoną w stopniach 0-180, minutach 0-59, sekundach 0-59 oraz E/W  "
 
@@ -2111,7 +2105,7 @@ msgstr "Wprowadź długość geograficzną punktu pobierania próbki wyrażoną 
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Wprowadź szczegółowe informacje  dla każdej usługi analitycznej, którą chcesz skopiować"
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Wprowadź szczegółowe informacje dotyczące akredytacji laboratorium. Dostępne są natępujące pola:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
 
@@ -2119,45 +2113,45 @@ msgstr "Wprowadź szczegółowe informacje dotyczące akredytacji laboratorium. 
 msgid "Entity"
 msgstr "Jednostka"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Błędny wynik publikacji z ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Wyłączenie z faktury"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Oczekiwany wynik"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Oczekiwane wartości"
 
@@ -2166,19 +2160,19 @@ msgstr "Oczekiwane wartości"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Przedawnione"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Data przedawnienia"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Precyzja formatu wykładniczego"
 
@@ -2186,44 +2180,40 @@ msgstr "Precyzja formatu wykładniczego"
 msgid "Exponential format threshold"
 msgstr "Wartość graniczna dla notacji wykładniczej"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Faks"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Faks (praca)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Żeński"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Teren"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Analizy w terenie"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Utrwalanie w terenie"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Tytuł pola"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Plik"
 
@@ -2231,19 +2221,19 @@ msgstr "Plik"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Zaznaczenie opcji umożliwi dodanie załczników np. zdjęcia mikroskopowe do wników wysyłanych emailem"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nazwa pliku"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2263,16 +2253,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Imię"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formuła"
 
@@ -2282,18 +2272,18 @@ msgstr "Formuła"
 msgid "From"
 msgstr "Od"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "Od ${start_date} do ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Imię i nazwisko"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Próbka do pobrania w przyszłości"
 
@@ -2303,7 +2293,7 @@ msgstr "Próbka do pobrania w przyszłości"
 msgid "Generate report"
 msgstr "Generuj raport"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Tytuł np. Pan, Pani, Dr"
 
@@ -2315,37 +2305,37 @@ msgstr "Grupuj metody badań według kategorii, pomocne jeśli lista jest długa
 msgid "Group by"
 msgstr "Grupuj według"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "okres grupowania"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Niebezpieczna"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Ukryty"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Pole ukryte"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Godziny"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "Podstawowe stałe"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2354,8 +2344,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID serwera URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID serwera niedostępny"
 
@@ -2363,31 +2353,31 @@ msgstr "ID serwera niedostępny"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "WAŻNE: Nie używaj zarezerwowanej nazwy \"Bika\" lub \"BIKA\". Może to powodować błędy np. \"Site Error\" wypisze \"AttributeError: adapters\""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Jeżeli zaznaczona jest opcja 'Zezwolenie na wprowadzanie danych z instrumentu', będzie użyta jego metoda domyślna. W innym przypadku zostanie wyświetlona metoda wybrana powyżej."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Jeżeli z tego punktu pobiera sie próbki okresowo, wpisz częstotliwość, np. raz w tygodniu"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "Jeżeli zaznaczone, obok pola wyniku analizy wyświetlona zostanie lista wyboru, której użycie umożliwi analitykowi zastąpienie wyniku wartością Limitu Detekcji (LDL lub UDL)"
 
@@ -2399,7 +2389,7 @@ msgstr "Jeżeli zaznaczone, instrument będzie niedostępny do czasu wykonania w
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2407,27 +2397,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Jeżeli włączone, nazwa analizy będzie zapisana kursywą."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "Jeżeli włączone, ta analiza i powiązane z nią wyniki nie będą wyświetlane w raportach. Ustawienie to może być nadpisane w Profilu Analizy i/lub Zastawieniu Analiz"
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "Jeżeli nie wprowadzono treści Tytułu, zostanie użyty Identyfikaor Zestawu ID"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Jeżeli wymagane, wybierz formułę obliczeniową dla Usługi analitycznej przypisaną do tej metody. Formuła obliczeniowa może być zdefiniowana w konfiguracji LIMS "
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Jeśli to konieczne, wybierz obliczenia dla tej analizy. Obliczenia mogą być konfigurowane w ustawieniach LIMS"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Tekst tu wprowadzony zostanie użyty zamiast tytułu nagłówka kolumny wyświetlającej usługi. Dozwolone jast formatowanie HTML."
 
@@ -2435,7 +2425,7 @@ msgstr "Tekst tu wprowadzony zostanie użyty zamiast tytułu nagłówka kolumny 
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "Jeżeli istnieją poprzednie wyniki dla usługi z tego samego zestawu analiz AR, zostaną dołączone do sprawozdania."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Jeśli ten pojemnik jest wstępnie przygotowany dla utrwalenia próbek, wówczas metoda utrwalania może być zaznaczona tutaj."
 
@@ -2448,7 +2438,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Jeżeli nie zaznaczone, analityk będzie miał dostęp do wszystkich kart pracy."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Import"
@@ -2457,7 +2447,7 @@ msgstr "Import"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Zaimportowane"
@@ -2466,8 +2456,8 @@ msgstr "Zaimportowane"
 msgid "In-lab calibration procedure"
 msgstr "Wewnętrzna procedura kalibracyjna"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Nieaktywne"
@@ -2476,7 +2466,7 @@ msgstr "Nieaktywne"
 msgid "Include Previous Results From Batch"
 msgstr "Dołącz Wyniki z Poprzedniego Zestawu"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Wprowadź wszystkie zlecenia analiz przypisane do wybranych obiektów."
 
@@ -2484,7 +2474,7 @@ msgstr "Wprowadź wszystkie zlecenia analiz przypisane do wybranych obiektów."
 msgid "Include and display pricing information"
 msgstr "Zawiera i wyświetla informacje cenowe."
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Zawiera opisy"
 
@@ -2492,30 +2482,27 @@ msgstr "Zawiera opisy"
 msgid "Include year in ID prefix"
 msgstr "Dodaje rok do ID prefiksu"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "Niewłaściwy numer IBAN: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "Niwłaściwy numer NIB: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Wyniki nie oznaczone"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Wskazuje, czy dla tej analizy wymagane są pliki załączników np. zdjęcia mikroskopowe i czy na ekranie pobierania danych dostępna będzie funkcja pobierania plików "
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Dziedziczy z"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Wersja początkowa"
 
@@ -2539,7 +2526,7 @@ msgstr "Pobranie certyfikatu instalacji"
 msgid "InstallationDate"
 msgstr "Data Instalacji"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instrukcje"
@@ -2552,17 +2539,17 @@ msgstr "Instrukcja okresowej wewnętrznej procedury kalibracji przeznaczonej dla
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instrukcja okresowej procedury przeglądu i konserwacji przeznaczonej dla analityka"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Przyrząd"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Kalibracj Przyrządu"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2575,16 +2562,16 @@ msgstr "Import danych z przyrządu"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Przegląd techniczny"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Zaplanowane zadania"
 
@@ -2592,19 +2579,19 @@ msgstr "Zaplanowane zadania"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Typy przyrządów"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Walidacje Przyrządu"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2648,9 +2635,9 @@ msgstr "Typ przyrządu"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Przyrządy"
 
@@ -2674,7 +2661,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Wewnętrzne Testy Kalibracji"
 
@@ -2690,24 +2677,21 @@ msgstr "Interpolacja"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Nieprawidłowe"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "Nieprawidłowy Zetaw Analiz wykonany ponownie"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Znaleziono nieważne wieloznaczności: ${wildcards}"
 
@@ -2715,43 +2699,43 @@ msgstr "Znaleziono nieważne wieloznaczności: ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Faktura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Data faktury"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Wykluczenie z faktury"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Numer faktury"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "Zestawienie faktur nie ma daty końcowej"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "Zestawienie faktur nie ma daty początkowej"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "Zestawienie faktur nie ma Nazwy"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Element jest nieaktywny."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Elementy, które mają zostać użyte jako tytuł w e-mailu"
 
@@ -2761,7 +2745,7 @@ msgstr "Elementy, które mają zostać użyte jako tytuł w e-mailu"
 msgid "Job Title"
 msgstr "Stanowisko"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Stanowisko"
 
@@ -2769,12 +2753,12 @@ msgstr "Stanowisko"
 msgid "Key"
 msgstr "Klucz"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Błędny Klucz"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Słowo kluczowe"
@@ -2783,47 +2767,47 @@ msgstr "Słowo kluczowe"
 msgid "Keywords"
 msgstr "Słowa kluczowe"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Lab"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Analizy laboratoryjne"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Kontakty do Laboratorium"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Działy Laboratorium"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Utrwalenie w laboratorium"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Produkty Laboratorium"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Adres URL Laboratorium"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etykieta"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratorium"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratorium akredytowane"
 
@@ -2843,13 +2827,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Ostatnia modyfikacja"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Spóźnione"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Analizy spóźnione"
@@ -2859,7 +2843,7 @@ msgstr "Analizy spóźnione"
 msgid "Late Analysis"
 msgstr "Analiza spóźniona"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Szerokość"
 
@@ -2881,11 +2865,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Połączone próbki"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2897,7 +2881,7 @@ msgstr "Lista próbek przyjętych w danym okresie"
 msgid "Load Setup Data"
 msgstr "Wczytaj zapisane ustawienia"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Wczytaj dokumenty opisujące metodę"
 
@@ -2909,41 +2893,41 @@ msgstr "Załaduj z pliku"
 msgid "Load the certificate document here"
 msgstr "Pobierz plik świadectwa"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Załadowane"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Kod miejsca"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Opis miejsca"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Tytuł miejsca"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Typ miejsca"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Miejsce, w którym przechowywana jest próbka"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Miejsce, z którego pobrana była próbka"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Log"
@@ -2968,35 +2952,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Numer partii"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Dolny Limit Detekcji (LDL)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Adres korespondencyjny"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Wykonujący obsługę"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Typ przeglądu"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Męski"
 
@@ -3004,16 +2988,16 @@ msgstr "Męski"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Kierownik"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "E-mail do Kierownika"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telefon do Kierownika"
 
@@ -3021,31 +3005,25 @@ msgstr "Telefon do Kierownika"
 msgid "Manual"
 msgstr "Ręczny"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Rączne wprowadzanie"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Ręczne wprowadzanie wyników"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Producent"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Producenci"
 
@@ -3054,14 +3032,14 @@ msgstr "Producenci"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Maksymalny czas"
 
@@ -3069,30 +3047,30 @@ msgstr "Maksymalny czas"
 msgid "Maximum columns per results email"
 msgstr "Maksymalna ilość kolumn wysyłana e-mailem"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Maksymalny możliwy rozmiar lub objętość próbek."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Maksymalny termin zakończenia analizy. Po upływie tego czasu wyświetlane jest ostrzeżenie o opóźnieniu analiz"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maksymalny czas wykonania"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Zniżki użytkowanika %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Obowiązuje zniżka członkowska"
 
@@ -3101,22 +3079,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Metoda"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Dokument opisujący metodę"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "ID metody"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instrukcje dot. metody"
 
@@ -3128,9 +3106,9 @@ msgstr "Metoda: ${method_name}"
 msgid "Method: None"
 msgstr "Metoda: brak"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Metody"
 
@@ -3138,17 +3116,17 @@ msgstr "Metody"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Metody akredytowane w ${accreditation_body} zamieszczone w Zakresie Akredytacji laboratorium. Uwagi do analiz nie są akredytowane."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Inicjały"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Drugie imię"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3160,8 +3138,8 @@ msgstr "Moje"
 msgid "Minimum 5 characters."
 msgstr "Minimum 5 znaków."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Objętość minimalna"
 
@@ -3169,27 +3147,27 @@ msgstr "Objętość minimalna"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Minimalna liczba wyników wymagana do obliczania statystyki QC"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minuty"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Telefon komórkowy"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Data modyfikacji"
 
@@ -3203,7 +3181,7 @@ msgstr ""
 msgid "More"
 msgstr "Więcej"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3215,13 +3193,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nazwa"
 
@@ -3230,17 +3208,17 @@ msgstr "Nazwa"
 msgid "New"
 msgstr "Nowy"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Nie"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Nie znaleziono żadnych zestawów analiz dla zadanych warunków"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3256,18 +3234,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Dla użytkownika ${user} nie znaleziono żadnych działań"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Żadne analizy nie zostały zaznaczone"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Żadna analiza nie pasuje do zapytania"
 
@@ -3279,23 +3257,23 @@ msgstr "Żadne analizy nie zostały dodane"
 msgid "No analyses were added to this worksheet."
 msgstr "Żadne analizy nie zostały dodane do karty pracy"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Nie wybrano analizy"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Nie wybrano usługi analitycznej"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Żadna metoda badań nie została zaznaczona"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Brak zmian."
 
@@ -3303,7 +3281,7 @@ msgstr "Brak zmian."
 msgid "No control type specified"
 msgstr "Nie określono rodzaju kontroli"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3315,17 +3293,17 @@ msgstr "Żadne domyślne pojemniki nie zostały określone dla tej analizy"
 msgid "No default preservations specified for this service"
 msgstr "Żadne domyślne utrwalanie próbki nie zostało określone dla tej analizy"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Nie wybrano pliku"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Żadne poprzednie działania nie pasują do zapytania"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Żaden element nie został zaznaczony"
 
@@ -3333,7 +3311,7 @@ msgstr "Żaden element nie został zaznaczony"
 msgid "No items selected"
 msgstr "Nie zaznaczono żadnego elementu"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Żaden nowy element nie został utworzony."
 
@@ -3343,16 +3321,16 @@ msgstr "Żaden nowy element nie został utworzony."
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Żaden materiał odniesienia nie został zaznaczony."
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Nie znaleziona żadnego raportu w zapytaniu"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Nie znaleziono żadnych próbek dla zadanych warunków"
 
@@ -3370,25 +3348,22 @@ msgstr "Użykownik ${contact_fullname} nie ma możliwości logowania. W celu utw
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Żaden"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Niedozwolone"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Niedostępny"
 
@@ -3408,19 +3383,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "Ilość kolumn"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Ilość Analiz"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Liczba analiz i zestawów analiz"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Liczba analiz i zestawów analiz wg klienta"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3428,30 +3403,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Liczba analiz"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Liczba analiz poza zakresem dla zadanego okresu"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Liczba zestawów analiz na metody badań"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Liczba zestawów analiz w zależności od typu próbki"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Liczba analiz ponownie badanych dla zadanego okresu"
 
@@ -3459,15 +3434,15 @@ msgstr "Liczba analiz ponownie badanych dla zadanego okresu"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Ilość zgłoszonych i opublikowanych analiz na departament wyrażona jako procent wszystkich wykonanych."
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Liczba zapytań"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3476,31 +3451,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Liczba próbek"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Wartość liczbowa wskazująca sposób sortowania obiektów według tak zdefiniowanego priorytetu"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "Ibentyfikator obiektu ID"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Okres w którym po utrwaleniu, próbka musi zostać rozdysponowana. Jeżeli nie podany, użyty zostanie czas przechowywania stosowany dla danego typu próbki "
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3508,15 +3483,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Tylko kierownik laboratorium może utworzyć i modyfikować Kartę pracy"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Tylko dla pól o zerowej wartości lub pustych"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Otwarte"
@@ -3529,26 +3501,26 @@ msgstr ""
 msgid "Order"
 msgstr "Zamówienie"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Data zamówienia"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID zamówienia"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Numer zamówienia"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Zamówienia"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Zamówienia: ${orders}"
 
@@ -3556,7 +3528,7 @@ msgstr "Zamówienia: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Instytucja uprawniona do wydawania świadectw kalibracji"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3568,8 +3540,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "Inne raporty wydajności"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Nieaktualne"
 
@@ -3581,16 +3553,13 @@ msgstr "Format wyjściowy"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Część próbki"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3611,8 +3580,8 @@ msgstr "Hasło"
 msgid "Password lifetime"
 msgstr "Czas trwania hasła"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Oczekiwane"
@@ -3637,31 +3606,31 @@ msgstr "Wykonane przez"
 msgid "Period"
 msgstr "Okres"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Dozwolone"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Dopuszczalny błąd %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefon (praca)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefon (dom)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefon (komórkowy)"
 
@@ -3674,8 +3643,8 @@ msgid "Photo of the instrument"
 msgstr "Zdjęcie przyrządu"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Adres"
 
@@ -3683,7 +3652,7 @@ msgstr "Adres"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Jeżeli wynik należy wyrazić wartością opisową, np. 'Dodatni', 'Ujemny' lub 'Nieoznaczony', tworzymy listę na której 'Wartości wyniku' przypisany jest opis. Wartość wyniku musi być liczbą."
 
@@ -3691,19 +3660,19 @@ msgstr "Jeżeli wynik należy wyrazić wartością opisową, np. 'Dodatni', 'Uje
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Jeżeli sposób utrwalenia próbek jest inny niż domyślnie zdefiniowany w usłudze analitycznej, proszę określić go tutaj."
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Wyślij logo akredytacji, które będzie używane na stronie www oraz  wraz z publikowanymi wynikami. Maksymalny rozmiar: 175 x 175 pikseli."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Miejsce uzyskania wyników"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3712,13 +3681,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Pozycja"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Adres pocztowy"
 
@@ -3726,16 +3695,16 @@ msgstr "Adres pocztowy"
 msgid "Postal code"
 msgstr "Kod pocztowy"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Wstępnie utrwalone"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Liczba miejsc po przecinku"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precyzja jako ilość cyfr znaczących stosownie do niepewności pomiaru. Miejsce dziesiętne będzie określone jako pozycja pierwszej cyfry różnej od zera w niepewności i system zaokrągli do tej wartości wynik pomiaru i niepewność. Na przykład, dla wyniku 5.243 i niepewności 0.22, wyświetlona zostanie wartość 5.2+-0.2. Jeżeli nie określono niepewności wyników, system użyje ustalonej precyzji."
 
@@ -3763,7 +3732,7 @@ msgstr "Notacja naukowa preferowana w raportach "
 msgid "Preferred scientific notation format for results"
 msgstr "Preferowana dla wyników notacja naukowa"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefiks"
 
@@ -3771,12 +3740,12 @@ msgstr "Prefiks"
 msgid "Prefixes"
 msgstr "Prefiksy"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premia"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3788,17 +3757,17 @@ msgstr "Przygotowane przez"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Utrwalenie"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Kategoria utrwalania"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3809,7 +3778,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Próbka utrwalona"
 
@@ -3819,14 +3788,14 @@ msgstr "Próbka utrwalona"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Utrwalający"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Zapobiegawczy"
 
@@ -3834,34 +3803,34 @@ msgstr "Zapobiegawczy"
 msgid "Preventive maintenance procedure"
 msgstr "Procedura przeglądu okresowego"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Cena"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Cena (bez VAT)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Wartość premii w procentach"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Cena bez VAT"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Cennik dla"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Cenniki"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3876,13 +3845,13 @@ msgstr "Drukuj"
 msgid "Print date:"
 msgstr "Wydrukowano dnia:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Priorytet"
 
@@ -3899,34 +3868,34 @@ msgstr "Raporty wydajności"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "Profesjonalny  otwarty LIMS/LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Profil analiz"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Klucz profilu"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Słowo kluczowe profilu"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profile"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (niezafakturowane)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "ID protokołu"
 
@@ -3934,7 +3903,7 @@ msgstr "ID protokołu"
 msgid "Public. Lag"
 msgstr "Opóźnienie publikacji"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Specyfikacja Publikacji"
 
@@ -3949,21 +3918,21 @@ msgstr "Preferencje publikacji"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Opublikowane"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Opublikowane Zestawy Analiz -AR-, dla których nie wygenerowano faktur"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Opublikowane przez"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Opublikowane wyniki"
 
@@ -3976,8 +3945,8 @@ msgid "QC Analyses"
 msgstr "Kontrola jakości analiz"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "Identyfikator próbki kontrolnej QC ID"
 
@@ -3998,23 +3967,23 @@ msgstr "Ilość"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Opis Zakresu"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Opis Zakresu"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Zakres max"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Zakres min"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Specyfikacja zakresu"
 
@@ -4036,9 +4005,9 @@ msgstr "Odbiór"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Dostarczone"
 
@@ -4046,11 +4015,11 @@ msgstr "Dostarczone"
 msgid "Recept. Lag"
 msgstr "Opóźnione przyjęcie"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Odbiorcy"
 
@@ -4059,31 +4028,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "W odnośniku  <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\">Tworzenie nowych szbalonów raportów</a>więcej informacji w dokumentacji Bika LIMS wiki lub dodaj własny szablon raportu."
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Materiał Referencyjny"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Analizy Referencyje"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Opis materiału odniesienia"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Opisy materiałów odniesienia"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Materiał odniesienia"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Materiały odniesienia"
 
@@ -4091,16 +4060,16 @@ msgstr "Materiały odniesienia"
 msgid "Reference Supplier"
 msgstr "Dostawca materiału odniesienia"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Typ materiału odniesienia"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Wartości odniesienia"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Materiały odniesienia QC"
@@ -4109,7 +4078,7 @@ msgstr "Materiały odniesienia QC"
 msgid "Reference analysis quality control graphs"
 msgstr "Wykresy kontroli jakości dla materiałów odniesienia"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Wykresy kontroli jakości dla materiałów odniesienia"
 
@@ -4117,21 +4086,21 @@ msgstr "Wykresy kontroli jakości dla materiałów odniesienia"
 msgid "Reference sample"
 msgstr "Materiał odniesienia"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Wartość odniesienia wynosi zero lub jest to \"próbka ślepa\""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "IDGrupyReferencyjnychAnaliz"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "Opis typów próbek używanych do kontroli jakości pomiarów"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Referencje: ${references}"
 
@@ -4154,8 +4123,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4164,9 +4133,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Błąd względny procentowy, ${variation_here} %, jest poza zakresem (${variation} %))"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Uwagi"
 
@@ -4174,7 +4143,7 @@ msgstr "Uwagi"
 msgid "Remarks to take into account before calibration"
 msgstr "Uwagi do uwzględnienia przed kalibracją"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Uwagi do uwzględnienia przed wykonaniem zadania"
 
@@ -4182,7 +4151,7 @@ msgstr "Uwagi do uwzględnienia przed wykonaniem zadania"
 msgid "Remarks to take into account before validation"
 msgstr "Uwagi do uwzględnienia przed walidacją"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Uwagi do uwzględnienia w procesie konserwacji"
 
@@ -4191,8 +4160,8 @@ msgstr "Uwagi do uwzględnienia w procesie konserwacji"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Naprawa"
 
@@ -4201,7 +4170,7 @@ msgid "Repeated analyses"
 msgstr "Analizy powtarzane"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Raport"
 
@@ -4215,14 +4184,14 @@ msgstr "Data Raportu"
 msgid "Report ID"
 msgstr "Identyfikator Raportu"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Typ raportu"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Wynik jako sucha masa"
 
@@ -4247,7 +4216,7 @@ msgstr "Zestawienie ilości przyjętych próbek w stosunku do raportowanych w da
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Tabela Zestawów Analiz AR rozliczonych i wysłanych w danym przedziale czasu"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Typ raportu"
 
@@ -4255,7 +4224,7 @@ msgstr "Typ raportu"
 msgid "Report upload"
 msgstr "Pobieranie raportu"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Raporty"
 
@@ -4264,15 +4233,15 @@ msgstr "Raporty"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Zestaw analiz"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "Kod zestawu analiz"
 
@@ -4280,26 +4249,26 @@ msgstr "Kod zestawu analiz"
 msgid "Request new analyses"
 msgstr "Nowy zestaw analiz"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Zamówione"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Zamówienia"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Wymagane"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Wymagana objętość"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "Wymagane pola nie mają wartości: ${field_names}"
 
@@ -4307,13 +4276,13 @@ msgstr "Wymagane pola nie mają wartości: ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Ograniczenie kategorii"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Wynik"
 
@@ -4321,15 +4290,15 @@ msgstr "Wynik"
 msgid "Result Footer"
 msgstr "Stopka sprawozdania"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opcje wyników"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Wartość wyniku"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4347,11 +4316,11 @@ msgstr "Wynik poza zakresem"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Ilość cyfr znaczących, powyżej której wyniki wyświetlane będą w notacji naukowej z  literą 'e' jako znacznikiem wykładnika. Precyzja wyników może zostać zdefiniowana w każdej Usłudze Analitycznej AR niezależnie."
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Interpretacja wyników"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Interpretacja wyników"
 
@@ -4359,7 +4328,7 @@ msgstr "Interpretacja wyników"
 msgid "Results attachments permitted"
 msgstr "Dozwolone załączniki do wyników"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Wyniki zostały unieważnione"
 
@@ -4367,11 +4336,11 @@ msgstr "Wyniki zostały unieważnione"
 msgid "Results interpretation"
 msgstr "Interpretacja wyników"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Wyniki dla punktu pobierania"
@@ -4380,14 +4349,14 @@ msgstr "Wyniki dla punktu pobierania"
 msgid "Results per samplepoint and analysis service"
 msgstr "Wyniki na punkt pobieranie próbki i metodę badań"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Okres przechowywania"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Ponownie przebadane"
@@ -4406,11 +4375,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "Analizy zawrócone"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Raport próbek zawróconych niedostępny"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Zawrócenia"
 
@@ -4426,12 +4395,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "Kod SWIFT"
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Zwrot grzecznościowy"
 
@@ -4439,19 +4408,19 @@ msgstr "Zwrot grzecznościowy"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "Tak jak wyżej, ale z wartościami domyślnymi w usłudze analitycznej. Ustawienia te mogą być zmienione dla każej analizy w jej konfiguracji"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Próbka"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Stan próbki"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Stany próbki"
 
@@ -4460,8 +4429,8 @@ msgid "Sample Due"
 msgstr "Próbka planowana"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "Kod próbki"
 
@@ -4473,12 +4442,12 @@ msgstr "Ilość cyfr w kodzie próbki"
 msgid "Sample ID Sequence Start"
 msgstr "Start sekwencji identyfikatorów próbek ID"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Matryce próbki"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Matryca próbki"
 
@@ -4488,52 +4457,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Części próbki"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Punkt pobierania próbki"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Punkty pobierania próbek"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Rodzaj próbki"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefiks dla rodzaju próbki"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Specyfikacja wg typów próbek (Klient)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Specyfikacja wg typów próbek (Laboratorium)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Rodzaje próbek"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Stan próbki"
 
@@ -4543,9 +4512,9 @@ msgstr "Stan próbki"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Punkt pobierania"
 
@@ -4573,17 +4542,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "Raporty dotyczące próbek"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Typ próbki"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Matryca Próbki"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Typ próbki"
 
@@ -4593,30 +4562,30 @@ msgstr "Typ próbki"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Próbobiorca"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Próbki"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Próbki tego typu powinny być traktowane jako niebezpieczne"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Próbki przyjęte względem raportowanych"
@@ -4625,62 +4594,62 @@ msgstr "Próbki przyjęte względem raportowanych"
 msgid "Samples received vs. samples reported"
 msgstr "Próbki przyjęte względem raportowanych"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Próbki: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Data pobrania próbki"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Zmienność próbek"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Uwagi dot. pobierania próbek"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Częstotliwość pobierania próbek"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4690,9 +4659,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Zapisz"
 
@@ -4705,17 +4674,17 @@ msgstr "Zapisz uwagi"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Zaplanowane zadanie"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Nazwa naukowa"
 
@@ -4723,16 +4692,16 @@ msgstr "Nazwa naukowa"
 msgid "Search"
 msgstr "Wyszukiwanie"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Sekundy"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4744,11 +4713,11 @@ msgstr "Zaznacz 'Rejestracja' jeżeli naklejki mają być drukowane automatyczni
 msgid "Select AR Templates to include"
 msgstr "Zaznacz AR Szablony by dołączyć"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Wybierz interfejs danych"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Zaznacz domyślne utrwalanie dla tej usługi analitycznej. W tabeli poniżej przypisz sposób utrwalania dla każdego rodzaju próbek zgodnie z wymaganiami "
 
@@ -4756,11 +4725,11 @@ msgstr "Zaznacz domyślne utrwalanie dla tej usługi analitycznej. W tabeli poni
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Wybierz pozycję docelową i próbkę dla duplikatu."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Wybierz kierownika z personelu, który jest dostępny w zakładce 'kontakty laboratorium'. Kierownicy działów autoryzują wyniki analiz realizowanych w ich dziale."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Zaznacz próbkę aby utworzyć kolejny zestaw analiz"
 
@@ -4772,7 +4741,7 @@ msgstr "Zaznacz wszystkie pozycje"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Zaznacz analizy do uwzględnienia w szablonie"
 
@@ -4784,11 +4753,11 @@ msgstr "Wybierz analityka"
 msgid "Select existing file"
 msgstr "Wybierz istniejący plik"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Zaznacz, jeśli analiza ma być wyłączona z faktury"
 
@@ -4796,19 +4765,19 @@ msgstr "Zaznacz, jeśli analiza ma być wyłączona z faktury"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Zaznacz, jeżeli jest wewnętrzne świadectwo kalibracji"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Zaznacz, jeżeli zostanie użyta formuła obliczeniowa zdefiniowana jak domyślna w domyślnej metodzie. Jeżeli nie zanaczone, formuła może zostać wybrana ręcznie"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Zaznacz, jeśli powinny zostać zawarte opisy"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4834,7 +4803,7 @@ msgstr "Zaznacz kraj wyświetlany domyślnie na witrynie"
 msgid "Select the currency the site will use to display prices."
 msgstr "Wybierz walutę, którą witryna będzie używała do wyświetlania cen."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Zaznacz domyślny pojemnik dla tej usługi analitycznej. W tabeli poniżej wskaż typ pojemnika jeżeli jego użycie zależy od typu próbki lub sposobu utrwalania"
 
@@ -4846,7 +4815,7 @@ msgstr "Wybierz domyślną stronę docelową przeznaczoną dla klienta logujące
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Wybierz preferowany przyrząd"
 
@@ -4854,7 +4823,7 @@ msgstr "Wybierz preferowany przyrząd"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4878,7 +4847,7 @@ msgstr "Zaznacz dla aktywacji instrukcji opisującej proces pobierania próbek."
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Zaznacz, które analizy powinny być uwzględniane w karcie pracy"
 
@@ -4894,7 +4863,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Wybierz która naklejka ma być drukowana w trybie automatycznym."
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4906,7 +4875,7 @@ msgstr "Wyślij e-mail"
 msgid "Separate"
 msgstr "Oddzielnie"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Oddzielny pojemnik"
 
@@ -4914,32 +4883,28 @@ msgstr "Oddzielny pojemnik"
 msgid "Serial No"
 msgstr "Nr seryjny"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Usługa"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "Metoda badań znajduje się w ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Usługi"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Ustaw wskażnik przeglądu technicznego jako zakończony"
 
@@ -4947,31 +4912,31 @@ msgstr "Ustaw wskażnik przeglądu technicznego jako zakończony"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Ustaw maksymalną liczbę wyników zestawów analiz 'AR' wysyłanych na e-mail. Zbyt wiele kolumn wysyłanych e-mailem może być trudne do odczytania dla niektórych klientów."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Przed opublikowaniem Zestawu Analiz AR, wybierz odpowiednią specyfikację"
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Zdefiniuj zakresy wartości dla wyników analiz"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Kod półki"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Opis półki"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Tytuł półki"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Adres dostawy"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Krótki tytuł"
 
@@ -4987,7 +4952,7 @@ msgstr "Pokaż Analizy kontroli Jakości QC"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Pokaż tylko wybrane kategorie w widokach klienta"
 
@@ -4999,29 +4964,25 @@ msgstr ""
 msgid "Signature"
 msgstr "Podpis"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Kod miejsca"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Opis miejsca"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Nazwa miejsca"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Rozmiar"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Mała ikona"
 
@@ -5029,14 +4990,14 @@ msgstr "Mała ikona"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Niektóre analizy używają przeterminowanych lub niekalibrowanych przyrządów. Niedozwolona edycja wyników"
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Klucz sortowania"
 
@@ -5044,41 +5005,41 @@ msgstr "Klucz sortowania"
 msgid "Specification"
 msgstr "Specyfikacja"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Specyfikacje"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Wybierz rozmiar Karty Pracy, np. stosownie do ilości próbek lub podajnika próbek w przyrządzie. Następnie  wybierz 'typ' analizy dla każdej pozycji Karty pracy.  Wskaż, które Próbki Referencyjne powinny być użyte dla pomiarów kontrolnych QC. Dla Duplikatów, wskaż do kórych próbek będą się odnosić."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "Określ wartość niepewności dla danego zakresu, np. dla wyników w zakreesie 0 - 10, gdzie wartość niepewności jest 0.5 - wynik 6.67 będzie przedstawiony jako 6.67+-0.5. Można też zdefiniować niepewność w procentach wartości zmierzonej, dodając '%' do liczby wpisanej do kolumny 'Wartości niepewności', np. dla wyniku w zakresie 10.01 - 100, gdzie niepewność zdefiniowano jako 2% - wynik 100 będzie przedstawiony jako 100+-2. Warto zwrócić uwagę na granice sąsiednich przedziałów, gdzie np. po 0.00-10.00 następuje 10.01-20.00, 20.01-30.00 itd."
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Data początkowa"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Status"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Status"
 
@@ -5086,33 +5047,33 @@ msgstr "Status"
 msgid "Sticker templates"
 msgstr "Szablony naklejek"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Miejsce przechowywania"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Miejsca przechowywania"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Podgrupa"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Podgrupy"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Sortowanie podgrup według tego klucza w widokach grup"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Prześlij"
 
@@ -5120,37 +5081,34 @@ msgstr "Prześlij"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Aby kontynuować, wyślij plik w formacie Open XML (.XLSX) zawierający konfigurację Bika"
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Suma częściowa"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Dostawca"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Dostawcy"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Zamówienie dostawy"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Nazwisko"
 
@@ -5170,11 +5128,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Zadanie"
 
@@ -5183,20 +5141,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Typ zadania"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Opis techniczny i instrukcje przeznaczone dla analityków"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5214,35 +5172,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "Wybierz Profil Analizy dla tego szablonu"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "Przypisany przez laboratorium identyfikator ID zamówienia klienta"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "Przypisany przez laboratorium identyfikator ID próbki klienta"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Adres internetowy laboratorium"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "Dolny Limit Detekcji zdefiniowano jako najniższą wartość, którą można zmierzyć daną metodą analityczną. Uzyskany wynik o mniejszej wartości będzie zapisany jako < DLD"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "Górny Limit Detekcji zdefiniowano jako najwyższą wartość, którą można zmierzyć daną metodą analityczną. Uzyskany wynik o większej wartości będzie zapisany jako > GLD"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Norma, wg której akredytowane jest laboratorium, np. ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Analizy zawarte w tym profilu, pogrupowane według kategorii"
 
@@ -5254,7 +5212,7 @@ msgstr "Analiza używana dla określenia suchej masy."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Osoba odpowiedzialna za kalibrację"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Osoba odpowiedzialna za przeglądy"
 
@@ -5262,12 +5220,12 @@ msgstr "Osoba odpowiedzialna za przeglądy"
 msgid "The analyst responsible of the validation"
 msgstr "Analityk odpowiedzialny za walidację"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Załączniki powiązane z zestawami analiz -AR- i analizami"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Kategoria metod badań należy do"
 
@@ -5275,19 +5233,19 @@ msgstr "Kategoria metod badań należy do"
 msgid "The date the instrument was installed"
 msgstr "Data instalacji przyrządu"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "Użyty zostanie separetor dziesiętny zdefiniowany w Konfiguracji Bika"
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "Domyślny typ pojemnika. Zostanie automatycznie przydzielony dla nowej próbki wieloczęściowej, chyba że będzie zdefiniowany odrębnie dla każdej usługi analitycznej."
 
@@ -5299,7 +5257,7 @@ msgstr "Wprowadzona tu wartość procentowa rabatu ma zastosowanie do cen dla kl
 msgid "The full URL: http://URL/path:port"
 msgstr "Pełny adres URL: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Wysokości lub głębokości, na której próbka powinna zostać pobrana"
 
@@ -5316,24 +5274,24 @@ msgstr "Numer modelu przyrządu"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Laboratorium nie jest akredytowane lub akredytacja nie została skonfigurowana."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Dział laboratorium"
@@ -5350,27 +5308,27 @@ msgstr "Ilość cyfr (łącznie z zerami) w kodzie próbki"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Ilość cyfr w kodzie zestawu analiz -AR-"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "Wykaz punktów pomiarowych, z których tego typu próbki mogą być pobierane. Jeśli żaden z punktów pomiarowych nie jest zaznaczony, wszystkie punkty pobierania próbek będą dostępne."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "Lista typów próbek, które mogą być pobierane w tym punkcie pobierania. Jeżeli żaden typ próbki nie jest zaznaczony dostępne są wszystkie typy próbek."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Jednostki miary dla tej metody badań, np. mg/l, ppm, itp."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "Minimalna ilość próbki wymagana do analizy np. 10 ml lub 1 kg"
 
@@ -5394,7 +5352,7 @@ msgstr "Liczba dni, po których hasło wygasa. 0 wyłącza opcję wygaśnięcia 
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Liczba dni, po których  próbka traci ważność i nie może być więcej analizowana. To ustawienie może być nadpisane dla pojedynczego rodzaju próbki w ustawieniach typów próbek"
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5411,11 +5369,11 @@ msgstr "Ilość zleceń i analiz"
 msgid "The number of requests and analyses per client"
 msgstr "Liczba zapytań i analiz według klienta"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "Wartość procentowa używana do obliczenia ceny analizy wykonanej zgodnie z tym priorytetem"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "Okres, w którym niezakonserwowane próbki tego typu mogą być przechowywane przed ich przedawnieniem i nie mogą być później badane"
 
@@ -5432,19 +5390,19 @@ msgstr "Osoba, która wykonała zadanie"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "Osoba, która przygotowała certyfikat"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "Cena za analizę dla klientów, którym przysługuje rabat za 'hurtowe' zamówienia"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "Komercyjny Identyfikator profilu do celów księgowych."
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "Słowo kluczowe profilu, jest niezbędne dla jego dentyfikacji w importowanych plikach, musi być unikalne i różne od identyfikatorów ID pól tymczasowych w Formułach obliczeniowych, "
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Numer akredytacji przypisany laboratorium przez organ akredytacyjny"
 
@@ -5452,11 +5410,11 @@ msgstr "Numer akredytacji przypisany laboratorium przez organ akredytacyjny"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "Metoda umożliwi ręcznie wpisywanie wyników do Usługi Analtycznej AS"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Wyniki analiz terenowych uzyskiwane są podczas pobierania próbek w punkcie pobierania, np. temperatura próbki wody w rzece, gdzie próbka jest pobierana. Analizy laboratoryjne są wykonywane w laboratorium."
 
@@ -5464,7 +5422,7 @@ msgstr "Wyniki analiz terenowych uzyskiwane są podczas pobierania próbek w pun
 msgid "The room and location where the instrument is installed"
 msgstr "Pomieszczenie i położenie zainstalowanego przyrządu"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "Przyrządy, które mogą być zastosowanie w tej metodzie. Dla przypisania odpowiedniego przyrządu do metody należ użyć edycji Intrumentu"
 
@@ -5476,11 +5434,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Numer seryjny, który unikatowo identyfikuje przyrząd"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "Identyfikator protokołu analitycznego danej usługi"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "Komercyjny Identyfikator usługi do celów księgowych."
 
@@ -5488,19 +5446,19 @@ msgstr "Komercyjny Identyfikator usługi do celów księgowych."
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "Domyślne globalne ustawienie wskazujące czy dla zamówienia pliki załączników są wymagane, dozwolone lub nie."
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Czas realizacji analiz"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "Pracochłonność analizy wykreślona na osi czasu"
 
@@ -5512,7 +5470,7 @@ msgstr "Czas realizacji analiz"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "Pracochłonność analizy wykreślona na osi czasu"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "Unikalne słowo kluczowe używane w celu identyfikacji metody badań w importowanych plikach oraz wyników importowanych z przyrządów. Jest ono również stosowane do identyfikacji powiązanych usług analitycznych w zdefiniowanych przez użytkownika formułach obliczniowych"
 
@@ -5524,37 +5482,37 @@ msgstr "Nie ma żadnych wyników."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Wynik ten może być wyrażony jako sucha masa"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Wyniki te zostały unieważnione i wyświetlone tu dla diagnostyki problemu. Proszę wykorzystać link dla powtórzenia analiz."
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "To Zamówienie Analliz AR zostało wygenerowane automatycznie jako wynik zawróconego Zamówienia Analiz  ${retracted_request_id}."
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Wyniki te zostały unieważnione i wyświetlone tu dla diagnostyki problemu. Proszę wykorzystać link dla powtórzenia analiz. Retest: ${retest_child_id}."
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Ta metoda badań nie może być aktywowana ponieważ wymagana reguła obliczeń jest nieaktywna"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Ta metoda badań nie może być wyłączona, ponieważ jedna lub więcej aktywnych reguł obliczeń jest od niej zależna"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5566,7 +5524,7 @@ msgstr "Ta analiza nie wymaga osobnej części próbki"
 msgid "This service requires a separate container."
 msgstr "Ta analiza wymaga oddzielnego pojemnika na próbki"
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5574,13 +5532,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "Ten tekst będzie dołączany do wyników - raportu."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Ta wartość przedstawiana jest w dolnej części wszystkich opublikowanych wyników"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5594,63 +5548,63 @@ msgstr "Ten arkusz został odrzucony. Jego zamiennikiem jest  ${ws_id}"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Wskazówka. Załączone dokumenty nie zostaną załadowane, chyba że są one obecne w instancji."
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Tytuł"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Opis lokalizacji"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Opis półki"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Nazwa miejsca"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Do"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Do utrwalenia"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Do pobrania"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "Będzie wyświetlony na sprawozdaniu wyników  poniżej  każdej sekcji Kategorii Analiz "
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Do sprawdzenia"
 
@@ -5662,13 +5616,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Ogółem"
 
@@ -5676,22 +5630,22 @@ msgstr "Ogółem"
 msgid "Total Lag"
 msgstr "Opóźnienie całkowite"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Cena Całkowita"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Wszystkie analizy"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Wszystkie źródła danych"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Cena całkowita"
 
@@ -5703,11 +5657,11 @@ msgstr "Ogółem:"
 msgid "Traceability"
 msgstr "Spójność pomiarowa"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5715,61 +5669,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Włącz, jeżeli zamierzasz analizować próbki wieloczęściowe"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Czas realizacji (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Typ"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Błąd typu"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Typ lokalizacji"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Nie można załadować szablonu"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Nie można wysłać informacji dla klienta laboratorium, że Zlecenie Analizy AR zostało zwrócone: ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Nieprzypisane"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Niepewność"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Wartość niepewności"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Nieokreślone"
 
@@ -5777,13 +5725,13 @@ msgstr "Nieokreślone"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Jednostka"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "Nieznany IBAN kraju %s"
 
@@ -5808,17 +5756,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Nieopublikowane"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Nieznany format pliku ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Nieznany format pliku ${fileformat}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5830,11 +5778,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Wczytaj zeskanowany podpis, który będzie używany w drukowanym sprawozdaniu z badań. Idealny rozmiar wynosi 250 pikseli szerokości oraz 150 wysoki"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "Górny Limit Detekcji (GLD)"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "Użyj Ceny Profilu Analtycznego"
 
@@ -5842,7 +5790,7 @@ msgstr "Użyj Ceny Profilu Analtycznego"
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Użyj domyślnej formuły obliczeniowej"
 
@@ -5854,13 +5802,13 @@ msgstr "Użyj zewnętrznego serwera ID"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Pole to służy do przekazywania dowolnych parametrów dla modułów eksportu/importu."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Użytkownik"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nazwa użytkownika"
@@ -5873,7 +5821,7 @@ msgstr "Historia użytkownika"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Historia użytkowników"
@@ -5882,27 +5830,27 @@ msgstr "Historia użytkowników"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Używanie zbyt małej ilości danych nie ma statystycznego sensu. Ustaw minimalną akceptowalną liczbę wyników, zanim statystyki QC będą obliczane i wykreślane"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "VAT"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "VAT %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Kwota podatku VAT"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "VAT Ogółem"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "NIP"
 
@@ -5910,11 +5858,11 @@ msgstr "NIP"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Ważne od"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Ważne do"
 
@@ -5922,181 +5870,181 @@ msgstr "Ważne do"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Walidacja"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Sprawdzenie poprawności zakończyło się niepowodzeniem: '${keyword}': słowo kluczowe się powtarza"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Sprawdzenie poprawności zakończyło się niepowodzeniem: '${title}': To słowo kluczowe jest już używane przez formułę obliczeniową '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Sprawdzenie poprawności nie powiodło się: '${title}': To słowo kluczowe jest już używane przez metodę badań: '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Sprawdzenie poprawności nie powiodło się: '${title}': tytuł się powtarza"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Sprawdzenie poprawności nie powiodło się: '${value}' nie jest unikalny"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Weryfikacja nie powiodła się: Azymut musi być E/W"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Weryfikacja nie powiodła się: Azymut musi być N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Weryfikacja nie powiodła się: Błąd wyrażony w procentach musi zawierać się w przedziale od 0 do 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Weryfikacja nie powiodła się: Błąd musi być większy lub rówy zero"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Weryfikacja nie powiodła się: Błąd musi być wartością liczbową"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Weryfikacja nie powiodła się: Oczekiwane wartości muszą być między wartością minimalną i maksymalną"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Weryfikacja nie powiodła się: Oczekiwane wartości muszą być wartościami liczbowymi"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Sprawdzenie poprawności nie powiodło się: Słowo kluczowe '${keyword}' jest niewłaściwe"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Weryfikacja nie powiodła się: Wartości maksymalne muszą być większe niż wartości minimalne"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Weryfikacja nie powiodła się: Wartości maksymalne muszą być wartościami liczbowymi"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Weryfikacja nie powiodła się: Wartości minimalne muszą być wartościami liczbowymi"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Weryfikacja nie powiodła się: Procent błędu musi zawierać się w przedziale od 0 do 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Weryfikacja nie powiodła się: Procent błędu musi być wartością liczbową"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Weryfikacja nie powiodła się: Pojemniki do utrwalania muszą mieć zaznaczoną opcje utrwalania"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Weryfikacja nie powiodła się: Pole Result Text nie może być puste"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Weryfikacja nie powiodła się: Wartości muszą być liczbami"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Sprawdzenie poprawności zakończyło się niepowodzeniem: Wybór to wymaga zaznaczenia następujących kategorii: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Weryfikacja nie powiodła się: Wartości muszą być liczbami"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Sprawdzenie poprawności zakończyło się niepowodzeniem: tytuł kolumny '${title}' musi być słowem kluczowym '${keyword}' "
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Weryfikacja nie powiodła się: stopnie wynoszą 180; minuty muszą być równe zeru"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Weryfikacja nie powiodła się: stopnie wynoszą 180; sekundy muszą być równe zeru"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Weryfikacja nie powiodła się: stopnie wynoszą 90; minuty muszą być równe zeru"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Weryfikacja nie powiodła się: stopnie wynoszą 90; sekundy muszą być równe zeru"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Weryfikacja nie powiodła stopnie muszą być w zakresie 0 - 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Weryfikacja nie powiodła się: stopnie muszą być w zakresie 0 - 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Weryfikacja nie powiodła się: stopnie muszą być liczbami"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Sprawdzenie poprawności zakończyło się niepowodzeniem: słowo kluczowe '${keyword}' musi być tytułem kolumny '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Weryfikacja nie powiodła się: słowo kluczowe zawiera niedozwolone znaki"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Sprawdzenie poprawności nie powiodło się: słowo kluczowe jest wymagane"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Weryfikacja nie powiodła się: minuty muszą być w zakresie 0 - 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Weryfikacja nie powiodła się: minuty muszą być liczbami"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Weryfikacja nie powiodła się: Procent błędu musi zawierać się w przedziale od 0 do 100"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Weryfikacja nie powiodła się: Procent błędu musi być wartością liczbową"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Weryfikacja nie powiodła się: sekundy muszą być w zakresie 0 - 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Weryfikacja nie powiodła się: sekundy muszą być liczbami"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Sprawdzenie poprawności nie powiodło się: tytuł jest wymagany"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6104,7 +6052,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "Data raportu walidacji"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Sprawdzający"
@@ -6115,12 +6063,12 @@ msgstr "Sprawdzający"
 msgid "Value"
 msgstr "Wartość"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Wpisana tu wartość zastąpi domyślną zdefiniowaną w konfiguracji Pól Tymczasowych Formuł Obliczeniowych"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Sprawdzone"
@@ -6131,7 +6079,7 @@ msgstr "Sprawdzone"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Wersja"
 
@@ -6141,11 +6089,11 @@ msgstr "Wersja"
 msgid "Volume"
 msgstr "Objętość"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Adres internetowy jednostki akredytacyjnej"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Strona internetowa"
 
@@ -6153,24 +6101,24 @@ msgstr "Strona internetowa"
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Tygodni do wygaśnięcia"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "Jeśli ustawiono odrębną stawkę VAT dla ceny profilu analiz (AP), system wykorzysta ją, nadpisując domyślnie ustawioną stawkę."
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Jeżeli różnica wyników pomiaru próbki i jej duplikatu w karcie pracy przekracza zdefiniowaną w procentach wartość, zostanie to zasygnalizowane."
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "Wartości wieloznaczne nie są dozwolone dla pól tymczasowych: ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Wykonana Praca"
@@ -6181,25 +6129,25 @@ msgstr "Obieg"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Karta pracy"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Układ karty pracy"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Szablony kart pracy"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Karty pracy"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Nieprawidłowa długość numeru IBAN %s: %sshort by %i"
 
@@ -6207,9 +6155,9 @@ msgstr "Nieprawidłowa długość numeru IBAN %s: %sshort by %i"
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Tak"
 
@@ -6221,7 +6169,7 @@ msgstr "Nie masz wystarczających uprawnień do modyfikowania tego arkusza"
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "Nie masz wystarczających uprawnień do otwarcia arkusza ${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "Musicz przypisać to zlecenie do klienta"
 
@@ -6229,11 +6177,11 @@ msgstr "Musicz przypisać to zlecenie do klienta"
 msgid "You must select an instrument"
 msgstr "Musisz wybrać przyrząd"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "Należy wprowadzić domyślny klucz wyniku"
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "akcja"
 
@@ -6249,15 +6197,15 @@ msgstr "analiza"
 msgid "analysis requests selected"
 msgstr "wybrane zlecenia analiz"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "i inne"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6280,7 +6228,7 @@ msgstr "opis_strony_tytułowej"
 msgid "bika-frontpage-title"
 msgstr "tytuł_strony_tytułowej"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "komentarz"
 
@@ -6288,37 +6236,9 @@ msgstr "komentarz"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "wiersze danych"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6329,7 +6249,7 @@ msgstr "ukryj"
 msgid "heading_arpriority"
 msgstr "priorytet_ar"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6378,19 +6298,19 @@ msgstr "opis_dostępnej_nowej_wersji"
 msgid "new_version_available_title"
 msgstr "tytuł_dostępnej_nowej_wersji"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6398,19 +6318,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "powtarzać co każde"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "okres powtarzania"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6429,19 +6349,8 @@ msgstr "Lista zawartości"
 msgid "text_default_site_title"
 msgstr "tekst_domyślny_tytuł_strony"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6453,7 +6362,7 @@ msgstr "tytuł_wymagany"
 msgid "to"
 msgstr "do"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6461,7 +6370,7 @@ msgstr ""
 msgid "type"
 msgstr "typ"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "do"
 
@@ -6487,7 +6396,7 @@ msgstr "wartość"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6499,6 +6408,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/pt/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pt/LC_MESSAGES/bika.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/bikalabs/bika-lims/language/pt/)\n"
@@ -29,49 +29,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -87,7 +87,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "Erro"
 
@@ -101,15 +101,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Vazio)"
@@ -142,7 +142,7 @@ msgstr "(Controlo)"
 msgid "(Duplicate)"
 msgstr "(Duplicado)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -151,32 +151,26 @@ msgid "(Required)"
 msgstr "(Requerimentos)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -187,16 +181,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -208,7 +202,7 @@ msgstr "PA Opção de Anexo"
 msgid "AR ID Padding"
 msgstr "PA ID Estofo"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "PA Importação"
 
@@ -216,17 +210,17 @@ msgstr "PA Importação"
 msgid "AR Import options"
 msgstr "PA Opções Importação"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -234,54 +228,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nome da Conta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número da Conta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo da Conta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Credenciamento"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviação da Entidade Credenciadora"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL da Entidade Credenciadora"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referência de Credenciamento"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Credenciado"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -295,21 +289,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Ativo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Adicionar"
 
@@ -329,11 +323,7 @@ msgstr "Adicionar Controle de Referência"
 msgid "Add Duplicate"
 msgstr "Adicionar Cópia"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Adicionar Tema"
 
@@ -341,16 +331,16 @@ msgstr "Adicionar Tema"
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -363,26 +353,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "All"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Todas as amostras assinadas"
 
@@ -394,7 +384,7 @@ msgstr "Todas os tipos de análises"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -402,15 +392,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -418,11 +408,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -430,48 +420,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Análises"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Análises fora de série"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Procurar por serviço de análise"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Análise por tipo de amostra"
@@ -485,7 +475,7 @@ msgstr "Análise por serviço"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -498,27 +488,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Repetir Análise"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Análise"
 
@@ -526,52 +516,52 @@ msgstr "Análise"
 msgid "Analysis Attachment Option"
 msgstr "Opção de Anexo de Análise"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Analisar Categorias"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Analisar Categoria"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Identificador de Análise"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Análise de perfil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Código do pedido"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importes de Pedidos de Análises"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -579,65 +569,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Pedidos de análise"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Serviços de Análise"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Serviço de Análise"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificações de Análise"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo de Análise"
@@ -646,46 +636,46 @@ msgstr "Tipo de Análise"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Pedidos de Análises e Análises"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Pedidos de Análises e Análises por cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Pedidos de Análises não facturados"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -693,12 +683,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -714,17 +704,17 @@ msgstr "Tempo de devolução de análise"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -733,7 +723,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Qualquer"
 
@@ -745,7 +735,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Aplicar Template"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -763,15 +753,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Incluída"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -789,27 +779,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Anexado a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Anexo"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Chaves de Anexos"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opção de Anexo"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipo de Anexo"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipos de Anexos"
 
@@ -819,25 +809,25 @@ msgstr "Tipos de Anexos"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Anexos"
 
@@ -849,7 +839,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -866,27 +856,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Sucursal bancária"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nome do banco"
 
@@ -895,31 +885,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Rumo"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -927,7 +917,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -935,7 +925,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -943,63 +933,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Endereço de facturação"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Branco"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Contacto Profissional"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC Emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Calculo"
 
@@ -1007,8 +1001,8 @@ msgstr "Calculo"
 msgid "Calculation Formula"
 msgstr "Fórmula de Cálculo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1021,11 +1015,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Cálculos"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1037,12 +1031,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1056,9 +1050,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -1074,18 +1068,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1094,7 +1088,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número de Catálogo"
 
@@ -1102,17 +1096,17 @@ msgstr "Número de Catálogo"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Categoria não pode ser desativada porque contém Serviços de Análises"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1125,31 +1119,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1157,7 +1151,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1173,19 +1167,19 @@ msgstr ""
 msgid "City"
 msgstr "Cidade"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clássico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1193,19 +1187,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "Click para Baixar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID do Cliente"
 
@@ -1213,59 +1207,59 @@ msgstr "ID do Cliente"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nome do Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Pedido de Cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. do Cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referência do Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID do Cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Contacto do cliente é necessário antes do pedido ser submetido"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clientes"
 
@@ -1274,39 +1268,39 @@ msgstr "Clientes"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1314,21 +1308,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Compósito"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Nível de Confiança %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1337,13 +1331,13 @@ msgid "Confirm password"
 msgstr "Confirme a senha"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contato"
@@ -1352,8 +1346,8 @@ msgstr "Contato"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contatos"
@@ -1362,48 +1356,48 @@ msgstr "Contatos"
 msgid "Contacts to CC"
 msgstr "Contatos para CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Recipiente"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo de Conteúdo"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Controle"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1419,12 +1413,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiar de"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1437,18 +1431,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1456,7 +1450,7 @@ msgstr ""
 msgid "Created by:"
 msgstr "Criado por:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1464,8 +1458,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1473,12 +1467,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Currente"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1491,7 +1485,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1505,88 +1499,88 @@ msgstr "Interface de Dados"
 msgid "Data Interface Options"
 msgstr "Opções da Interface de Dados"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Data de envio"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Data de recepção"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Data do pedido"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1602,7 +1596,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1620,7 +1614,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1629,11 +1623,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dias"
 
@@ -1645,17 +1639,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Padrão"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1663,49 +1657,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categorias Padrão"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1714,11 +1708,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1742,11 +1736,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valores Padrão"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1754,7 +1748,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1762,11 +1756,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1774,16 +1768,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1791,9 +1785,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1806,13 +1800,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descrição"
 
@@ -1820,7 +1814,7 @@ msgstr "Descrição"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1828,19 +1822,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1848,7 +1842,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1856,16 +1850,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Despachado"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Mostrar Valor"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1877,7 +1871,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1886,8 +1880,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1896,54 +1890,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1956,20 +1950,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1978,20 +1972,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -2003,35 +1997,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Endereço de e-mail"
 
@@ -2039,7 +2033,7 @@ msgstr "Endereço de e-mail"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2059,14 +2053,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2078,16 +2072,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2095,15 +2089,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2111,7 +2105,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2119,45 +2113,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2166,19 +2160,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2186,44 +2180,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Feminino"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2231,19 +2221,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nome do arquivo"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2263,16 +2253,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Sobrenome do arquivo"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2282,18 +2272,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nome Completo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2303,7 +2293,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2315,37 +2305,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Horas"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2354,8 +2344,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2363,31 +2353,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2399,7 +2389,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2407,27 +2397,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2435,7 +2425,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2448,7 +2438,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importar"
@@ -2457,7 +2447,7 @@ msgstr "Importar"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2466,8 +2456,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2476,7 +2466,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2484,7 +2474,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2492,30 +2482,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Resultado Indeterminado"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisão Inicial"
 
@@ -2539,7 +2526,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2552,17 +2539,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Instrumento"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2575,16 +2562,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2592,19 +2579,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2648,9 +2635,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2674,7 +2661,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2690,24 +2677,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2715,43 +2699,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2761,7 +2745,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2769,12 +2753,12 @@ msgstr ""
 msgid "Key"
 msgstr "Chave"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2783,47 +2767,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratório"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Lab Análises"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Lab Contatos"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Lab Departamentos"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Lab Produtos"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL de laboratório"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratório"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2843,13 +2827,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2859,7 +2843,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -2881,11 +2865,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2897,7 +2881,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2909,41 +2893,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Registo"
@@ -2968,35 +2952,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Meridiano"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Masculino"
 
@@ -3004,16 +2988,16 @@ msgstr "Masculino"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Gerente"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Email do Gerente"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telefone do Gerente"
 
@@ -3021,31 +3005,25 @@ msgstr "Telefone do Gerente"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3054,14 +3032,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Max Tempo"
 
@@ -3069,30 +3047,30 @@ msgstr "Max Tempo"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3101,22 +3079,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Método"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3128,9 +3106,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Métodos"
 
@@ -3138,17 +3116,17 @@ msgstr "Métodos"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3160,8 +3138,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr "Mínimo 5 carácteres"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3169,27 +3147,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutos"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Telefone Móvel"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modelo"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3203,7 +3181,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3215,13 +3193,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nome"
 
@@ -3230,17 +3208,17 @@ msgstr "Nome"
 msgid "New"
 msgstr "Novo"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Não"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3256,18 +3234,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3279,23 +3257,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3303,7 +3281,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr "Tipo de controle não especificado"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3315,17 +3293,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3333,7 +3311,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3343,16 +3321,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3370,25 +3348,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3408,19 +3383,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3428,30 +3403,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3459,15 +3434,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3476,31 +3451,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3508,15 +3483,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Abrir"
@@ -3529,26 +3501,26 @@ msgstr ""
 msgid "Order"
 msgstr "Encomenda"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3556,7 +3528,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3568,8 +3540,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3581,16 +3553,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3611,8 +3580,8 @@ msgstr "Senha"
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pendente"
@@ -3637,31 +3606,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefone"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefone(Trabalho)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefone(Casa)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefone(Móvel)"
 
@@ -3674,8 +3643,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3683,7 +3652,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3691,19 +3660,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3712,13 +3681,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3726,16 +3695,16 @@ msgstr ""
 msgid "Postal code"
 msgstr "Código Postal"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3763,7 +3732,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3771,12 +3740,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3788,17 +3757,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3809,7 +3778,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3819,14 +3788,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3834,34 +3803,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3876,13 +3845,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3899,34 +3868,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Perfil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Análise de Perfil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Chave de Perfil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3934,7 +3903,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3949,21 +3918,21 @@ msgstr "Preferências de publicação"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publicado"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3976,8 +3945,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3998,23 +3967,23 @@ msgstr "Quantidade"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4036,9 +4005,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4046,11 +4015,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4059,31 +4028,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4091,16 +4060,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4109,7 +4078,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4117,21 +4086,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4154,8 +4123,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4164,9 +4133,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Notas"
 
@@ -4174,7 +4143,7 @@ msgstr "Notas"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4182,7 +4151,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4191,8 +4160,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4201,7 +4170,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Relatório"
 
@@ -4215,14 +4184,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4247,7 +4216,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4255,7 +4224,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4264,15 +4233,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4280,26 +4249,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volume requerido"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4307,13 +4276,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Categoria Restrita"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultado"
 
@@ -4321,15 +4290,15 @@ msgstr "Resultado"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opção de Resultado"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valor Resultado"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4347,11 +4316,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4359,7 +4328,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4367,11 +4336,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4380,14 +4349,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4406,11 +4375,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4426,12 +4395,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4439,19 +4408,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4460,8 +4429,8 @@ msgid "Sample Due"
 msgstr "Amostras a caminho"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4473,12 +4442,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4488,52 +4457,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4543,9 +4512,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4573,17 +4542,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4593,30 +4562,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4625,62 +4594,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4690,9 +4659,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Salvar"
 
@@ -4705,17 +4674,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4723,16 +4692,16 @@ msgstr ""
 msgid "Search"
 msgstr "Busca"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4744,11 +4713,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4756,11 +4725,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4772,7 +4741,7 @@ msgstr "Selecionar todos os itens"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4784,11 +4753,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4796,19 +4765,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4834,7 +4803,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4846,7 +4815,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4854,7 +4823,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4878,7 +4847,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4894,7 +4863,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4906,7 +4875,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4914,32 +4883,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "Número de serie"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Serviço"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Serviços"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4947,31 +4912,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4987,7 +4952,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4999,29 +4964,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Tamanho"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5029,14 +4990,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5044,41 +5005,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Estado"
 
@@ -5086,33 +5047,33 @@ msgstr "Estado"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Submeter"
 
@@ -5120,37 +5081,34 @@ msgstr "Submeter"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Gerir resultados"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5170,11 +5128,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5183,20 +5141,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5214,35 +5172,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5254,7 +5212,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5262,12 +5220,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5275,19 +5233,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5299,7 +5257,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5316,24 +5274,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5350,27 +5308,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5394,7 +5352,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5411,11 +5369,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5432,19 +5390,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5452,11 +5410,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5464,7 +5422,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5476,11 +5434,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5488,19 +5446,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5512,7 +5470,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5524,37 +5482,37 @@ msgstr "Sem resultado"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5566,7 +5524,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5574,12 +5532,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5594,63 +5548,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Título"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "A verificar"
 
@@ -5662,13 +5616,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5676,22 +5630,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Preço Total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Preço total"
 
@@ -5703,11 +5657,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5715,61 +5669,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipo"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sem Assinatura"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5777,13 +5725,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5808,17 +5756,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5830,11 +5778,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5842,7 +5790,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5854,13 +5802,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Usuário"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nome do usuário"
@@ -5873,7 +5821,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5882,27 +5830,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% DE IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Valor do IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5910,11 +5858,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5922,181 +5870,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6104,7 +6052,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6115,12 +6063,12 @@ msgstr ""
 msgid "Value"
 msgstr "Valor"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificado"
@@ -6131,7 +6079,7 @@ msgstr "Verificado"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versão"
 
@@ -6141,11 +6089,11 @@ msgstr "Versão"
 msgid "Volume"
 msgstr "Volume"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6153,24 +6101,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6181,25 +6129,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Ficha de trabalho"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Layout da Ficha de Trabalho"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Tema da Ficha de Trabalho"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Fichas de trabalho"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6207,9 +6155,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Sim"
 
@@ -6221,7 +6169,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6229,11 +6177,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6249,15 +6197,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6278,7 +6226,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6286,36 +6234,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6327,7 +6247,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6375,19 +6295,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6395,19 +6315,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6426,19 +6346,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6450,7 +6359,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6458,7 +6367,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6483,7 +6392,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6495,6 +6404,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/pt_BR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/pt_BR/LC_MESSAGES/bika.po
@@ -24,7 +24,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/bikalabs/bika-lims/language/pt_BR/)\n"
@@ -42,49 +42,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "${contact_fullname} pode entrar no sistema LIMS usando ${contact_username} como nome de usuário. Os contatos devem trocar as suas próprias senhas. Caso uma senha seja esquecida, o contato pode solicitar uma nova através do formulário de login."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} está faltando Preservação ou Data de Preservação"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} estão aguardando para serem preservados."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} estão aguardando seu recebimento."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} invalidados."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} foram criados com sucesso."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: partições estão aguardando recebimento."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} está faltando Preservação ou Data de Preservação."
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} está aguardando para ser preservado."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} está aguardando para ser recebido."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} foi criado com sucesso."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} está aguardando recebimento."
 
@@ -100,7 +100,7 @@ msgstr "${nr_items} Itens"
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Erro"
 
@@ -114,15 +114,15 @@ msgstr "%Realizado"
 msgid "% Published"
 msgstr "% Publicado"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr "%s não pode ser transferido."
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s foi rejeitada"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s não possui coluna '%s'"
 
@@ -134,15 +134,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Clássico' indica a importação de requisições de análise através da seleção de amostra e serviço de análise. Com 'Perfis', palavras-chave de perfis de análise são usadas para selecionar múltiplos serviços de análises conjuntamente."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr "´Data de amostragem´e ´Definir o Amostrador para a amostragem programada´ deve ser preenchida e salva para poder agendar uma amostragem."
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr "´Data de amostragem´e ´Definir o Amostrador para a amostragem programada´ deve ser preenchida e salva para poder agendar uma amostragem. Elemento: %s"
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Branco)"
@@ -155,7 +155,7 @@ msgstr "(Controle)"
 msgid "(Duplicate)"
 msgstr "(Duplicata)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Perigoso)"
 
@@ -164,33 +164,27 @@ msgid "(Required)"
 msgstr "(Requerido)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Ícone de 16x16 pixels usado para esta prioridade em listagens."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Ícone de 32x32 pixels usado para esta prioridade em visualizações de objeto."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< mín."
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
 msgstr "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Outro"
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr "<p>${service} requer que os seguintes serviços sejam selecionados:</p><br/><p>${deps}</p><br/><p> Deseja aplicar essas seleções agora? </p>"
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
-msgstr "<p>Os seguintes serviços dependem de ${service} e não serão selecionados se você continuar:</p><br/><p>${deps}</p><br/><p> Para remover essas seleções agora?</P>"
 
 #: bika/lims/content/calculation.py:84
 msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
@@ -200,16 +194,16 @@ msgstr "<p>A fórmula que você digitar aqui será calculada dinamicamente quand
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr "<span>x</span> <span class=\"formHelp\">x</span>"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> máx."
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr "Um nome curto que descreve a Rodada para que ela seja facilmente identificada em formulários e menus drop-down"
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "RA ${ar_number}"
 
@@ -221,7 +215,7 @@ msgstr "RA - Opção de Anexo"
 msgid "AR ID Padding"
 msgstr "Lacunas para o ID da RA"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "RA - Importar"
 
@@ -229,17 +223,17 @@ msgstr "RA - Importar"
 msgid "AR Import options"
 msgstr "RA - Opções de importação"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr "Titulo de Modelos de RA"
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "Modelos de RA"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "RA para resultados retestados"
 
@@ -247,54 +241,54 @@ msgstr "RA para resultados retestados"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "RAs: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nome da Conta"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Número da Conta"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tipo da Conta"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Credenciamento"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Abreviação da Entidade Credenciadora"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL da Entidade Credenciadora"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Logotipo da Certificação"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Referência de Credenciamento"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Cabeçalho pagina de acreditação"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Credenciado"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -308,21 +302,21 @@ msgstr "Ações executadas por usuários (ou usuário especifico) entre um perí
 msgid "Activate"
 msgstr "Ativar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Ativo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Adicionar"
 
@@ -342,11 +336,7 @@ msgstr "Adicionar Referência de Controle"
 msgid "Add Duplicate"
 msgstr "Adicionar Duplicata"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Adicionar Observação"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Adicionar Padrão"
 
@@ -354,16 +344,16 @@ msgstr "Adicionar Padrão"
 msgid "Add a remarks field to all analyses"
 msgstr "Adiciona campo de observação para todas as análises"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Adicionar novo"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Observações adicionais:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Endereço"
@@ -376,26 +366,26 @@ msgstr "Adiciona os dois últimos dígitos do ano ao prefixo do ID"
 msgid "Administrative Reports"
 msgstr "Relatórios Administrativos"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "Após ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agência"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Todas"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Todos os serviços de análises Certificadas estão listados aqui."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Todas as amostras designadas"
 
@@ -407,7 +397,7 @@ msgstr "Todas as análises do tipo"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Permitir que balconistas criem e editem clientes"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Permitir entrada manual de Limite de Detecção "
 
@@ -415,15 +405,15 @@ msgstr "Permitir entrada manual de Limite de Detecção "
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Permitir acesso a planilhas de trabalho apenas para analistas designados"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "Permitir entrada manual de valor de incerteza "
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr "Permitir que o mesmo usuário verifique várias vezes"
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr "Permitir que o mesmo usuário verifique várias vezes, mas não consecutivamente"
 
@@ -431,11 +421,11 @@ msgstr "Permitir que o mesmo usuário verifique várias vezes, mas não consecut
 msgid "Allow self-verification of results"
 msgstr "Permitir auto-verificação de resultados"
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "Permitir que o analista possa substituir manualmente os Limites de Detecção padrão (LDL e HDL) na visualização da entrada de resultados"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "Permitir que o analista possa substituir manualmente o valor de incerteza padrão"
 
@@ -443,48 +433,48 @@ msgstr "Permitir que o analista possa substituir manualmente o valor de incertez
 msgid "Allow users to filter datas by department."
 msgstr "Permitir que os usuários filtrem dados por departamento."
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Cálculo alternativo"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Sempre expandir as categorias selecionadas nas visualizações do cliente"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr "Condições Ambientais"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Quantia"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Análises"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Análises no limite da margem de erro"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Análises fora do intervalo"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr "Análises pendentes"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Análises por serviço de análise"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Análises por tipo de amostra"
@@ -498,7 +488,7 @@ msgstr "Análises por serviço"
 msgid "Analyses performed and published as % of total"
 msgstr "Análises feitas e publicadas como % do total"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Análises feitas como % do total"
 
@@ -511,27 +501,27 @@ msgstr "Laudos de Análises relacionadas"
 msgid "Analyses repeated"
 msgstr "Análises repetidas"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Resultados de Análises fora dos intervalos especificados"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Análises retestadas"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Índice de Análises por departamento"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Análises que foram retestadas"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Análises"
 
@@ -539,52 +529,52 @@ msgstr "Análises"
 msgid "Analysis Attachment Option"
 msgstr "Opção de Anexo da Análise"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorias de análise"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categoria de análise"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Palavra-chave de análise"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Perfil de análise"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Perfis de Análises"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Pedido de Análise"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Código do Pedido de Análise"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Importação de Pedidos de Análise"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Prioridades de Requisição de Análise"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Especificações de Requisição de Análise"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr "Modelos de Requisição de Análise"
 
@@ -592,65 +582,65 @@ msgstr "Modelos de Requisição de Análise"
 msgid "Analysis Request rejection reporting form"
 msgstr "Formulário de relatório de rejeição de requisição de análise"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Pedidos de Análise"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr "Requisição de Análise  a ser preservada"
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr "Requisição de Análise  a ser publicada"
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr "Requisição de Análise  a ser recebida"
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr "Requisição de Análise  a ser amostrada"
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr "Requisição de Análise  para ser verificada"
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Requisição de Análise  com resultados pendentes"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr "Requisição de Análise  com amostragem programada"
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Serviço de Análise"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Serviços de Análises"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Especificação de Análise"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Especificações de Análises"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Estado da Análise"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tipo de Análise"
@@ -659,46 +649,46 @@ msgstr "Tipo de Análise"
 msgid "Analysis category"
 msgstr "Categoria de análise"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Requisição de Análise ${AR} criada com sucesso."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr "Modelos de solicitação de análise a serem incluídos no modelo de amostragem da rodada"
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Requisições de Análises ${ARs} criadas com sucesso."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Pedidos de Análise e Análises"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Pedidos de Análise e Análises por cliente"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Pedidos de Análise não faturados"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Resultados da análise dentro da margem de erro"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Resultados de análise"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "Resultados de análise para ${subject_parts}"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Resultados de análises por local de amostragem e serviço de análise"
 
@@ -706,12 +696,12 @@ msgstr "Resultados de análises por local de amostragem e serviço de análise"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Resultados da análise estão fora da margem especificada pelo cliente ou pelo laboratório. Observação: isto pode demorar vários minutos"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Serviço de análise"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "As especificações de análises foram configuradas para os padrões do laboratório"
 
@@ -727,17 +717,17 @@ msgstr "Tempo de retorno de análises"
 msgid "Analysis turnaround time over time"
 msgstr "Tempo de processamento de análise excedido"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Tempos de processamento das análises"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Tempos de processamento das análises excedidos"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analista"
 
@@ -746,7 +736,7 @@ msgid "Analyst must be specified."
 msgstr "Análise deve ser especificada."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Qualquer"
 
@@ -758,7 +748,7 @@ msgstr "Submeter"
 msgid "Apply template"
 msgstr "Aplicar modelo"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Aplicar largura"
 
@@ -776,15 +766,15 @@ msgstr "Número de ativos"
 msgid "Assign"
 msgstr "Designar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Designada"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Designado para planilha"
 
@@ -802,27 +792,27 @@ msgstr "Anexar"
 msgid "Attach to"
 msgstr "Anexar a"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Anexo"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Chaves do Anexo"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opção de Anexo"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tipo de Anexo"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipos de Anexo"
 
@@ -832,25 +822,25 @@ msgstr "Tipos de Anexo"
 msgid "Attachment due"
 msgstr "Anexo concluido"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Anexo não permitido"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Anexo requerido"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tipo de anexo"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Anexos"
 
@@ -862,7 +852,7 @@ msgstr "Autorizado por"
 msgid "Autofill"
 msgstr "Autopreenchimento"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Autoimportação"
 
@@ -879,27 +869,27 @@ msgstr "Impressão automática de etiquetas"
 msgid "Available templates"
 msgstr "Modelos disponiveis"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Tempo médio de Processamento"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Média adiantada"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Média atrasada"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Má formação de estado: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Agência Bancária"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Nome do Banco"
 
@@ -908,31 +898,31 @@ msgid "Basis"
 msgstr "Principio básico"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lote"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID do Lote"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Rotulação em Lote"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Lotes"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Direção"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "Antes de ${start_date}"
 
@@ -940,7 +930,7 @@ msgstr "Antes de ${start_date}"
 msgid "Biannual"
 msgstr "Bianual"
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Ícone grande"
 
@@ -948,7 +938,7 @@ msgstr "Ícone grande"
 msgid "Bika LIMS"
 msgstr "Bika LIMS"
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Configuração Bika LIMS"
 
@@ -956,63 +946,67 @@ msgstr "Configuração Bika LIMS"
 msgid "Bika LIMS front-page"
 msgstr "Página inicial Bika LIMS"
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Endereço de cobrança"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Branco"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Análises para CQ de branco"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marca"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr "Desconto para volumes"
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Descontos por volume são aplicáveis"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Preço de atacado (sem impostos)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Telefone Comercial"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "Por"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "Contatos CC"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "Emails em CC"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Calculo de precisão da incerteza"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Cálculo"
 
@@ -1020,8 +1014,8 @@ msgstr "Cálculo"
 msgid "Calculation Formula"
 msgstr "Fórmula de Cálculo"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Campos de Cálculo Intermediário"
@@ -1034,11 +1028,11 @@ msgstr "Cálculo: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Cálculo: Nenhum"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Cálculos"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibração"
 
@@ -1050,12 +1044,12 @@ msgstr "Certificados de calibração"
 msgid "Calibration report date"
 msgstr "Data de calibração do relatório"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibrador"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1069,9 +1063,9 @@ msgstr "Pode verificar, mas enviado pelo usuário atual"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -1087,18 +1081,18 @@ msgstr "Impossível desativar o cálculo pois ele está em uso pelos seguintes s
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr "Verificação não é possivel, submeter ou verificar pelo usuário atual antes"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "Verificação não é possível: Submetido pelo usuário atual"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacidade"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturado"
 
@@ -1107,7 +1101,7 @@ msgid "Cardinal"
 msgstr "Cardinal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Número do Catálogo"
 
@@ -1115,17 +1109,17 @@ msgstr "Número do Catálogo"
 msgid "Categorise analysis services"
 msgstr "Categorizar serviços de análise"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categoria"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "A categoria não pode ser desativada pois contém Serviços de Análises"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "Cert. n."
 
@@ -1138,31 +1132,31 @@ msgstr "Código de certificado"
 msgid "Changes saved."
 msgstr "Modificações salvas."
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Verifique se o método foi acreditado"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Selecione aqui se o serviço de análise está incluso no cronograma do laboratório para análises certificadas"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Selecione aqui se as amostras obtidas destes locais são 'compostas' e combinadas a partir de mais de uma sub amostra, por exemplo, várias amostras de superfície de um reservatório misturadas para constituir uma amostra representativa de todo o reservatório. O padrão, não selecionado, indica 'obtenha' amostras"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Selecione aqui se o recipiente já está preservado. Esta seleção irá reduzir o processo de preservação para partições de amostra armazenadas neste recipiente."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "Marque essa caixa se esta é a prioridade padrão"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Selecione aqui se seu laboratório é certificado."
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Selecione esta caixa para garantir que um recipiente separado para a amostra será usado neste serviço de análise"
 
@@ -1170,7 +1164,7 @@ msgstr "Selecione esta caixa para garantir que um recipiente separado para a amo
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Selecione aqui caso você deseje usar um servidor de ID diferente. Os prefixos são configuráveis separadamente em cada site Bika"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "Escolha os valores de especificação padrões da RA"
 
@@ -1186,19 +1180,19 @@ msgstr "Escolha o tipo de verificação múltipla para o mesmo usuário. Esta co
 msgid "City"
 msgstr "Cidade"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clássico"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Clique em Categorias de Análises (sobre o fundo sombreado) para ver os Serviços de Análise em cada categoria. Digite um valor mínimo e máximo para indicar a margem válida de resultados. Qualquer resultado fora desta margem irá gerar um alerta. O campo % Erro permite uma % de incerteza a ser considerada quando os resultados são avaliados contra valores mínimo e máximo. Um resultado fora da margem, mas ainda dentro da % de erro será levado em consideração, gerando um alerta menos severo."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Clique em Categorias de Análises (sobre o fundo sombreado) para ver os Serviços de Análise em cada categoria. Digite um valor mínimo e máximo para indicar a margem válida de resultados. Qualquer resultado fora desta margem irá gerar um alerta. O campo % Erro permite uma % de incerteza a ser considerada quando os resultados são avaliados contra valores mínimo e máximo. Um resultado fora da margem, mas ainda dentro da % de erro será levado em consideração, gerando um alerta menos severo."
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "Clique em Categorias de Análises (sobre o fundo sombreado) para ver os Serviços de Análise em cada categoria. Digite um valor mínimo e máximo para indicar a margem válida de resultados. Qualquer resultado fora desta margem irá gerar um alerta. O campo % Erro permite uma % de incerteza a ser considerada quando os resultados são avaliados contra valores mínimo e máximo. Um resultado fora da margem, mas ainda dentro da % de erro será levado em consideração, gerando um alerta menos severo. Se o resultado estiver abaixo de '< mín.', o resultado será exibido como '< [min]'. O mesmo se aplica para resultados acima de '> máx.'"
 
@@ -1206,19 +1200,19 @@ msgstr "Clique em Categorias de Análises (sobre o fundo sombreado) para ver os 
 msgid "Click to download"
 msgstr "Clique para baixar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Cliente"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID Cliente em lote"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID do Cliente"
 
@@ -1226,59 +1220,59 @@ msgstr "ID do Cliente"
 msgid "Client Landing Page"
 msgstr "Pagina inicial do Cliente"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nome do Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Pedido de Cliente"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Número de ordem do cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Referência de Cliente"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referência de Cliente"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID do Cliente"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "ID da Amostra do Cliente"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr "Rondada de amostragem de clientes"
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr "Contato do cliente responsável no momento da amostragem"
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "É necessário o contato com o cliente antes que o pedido possa ser processado"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr "Contato do cliente que coordena com o laboratório"
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clientes"
 
@@ -1287,39 +1281,39 @@ msgstr "Clientes"
 msgid "Close"
 msgstr "Fechar"
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Fechado"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Código para o local"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "Código para o sítio"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Código para a prateleira"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Virgula (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentários"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "Comentários ou interpretação de resultados"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "ID do comercio"
 
@@ -1327,21 +1321,21 @@ msgstr "ID do comercio"
 msgid "Complete"
 msgstr "Completar"
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Composto"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr "Composta S/N"
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "% Nível de certeza"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "Configure as partições de amostra e preservações para este modelo. Designe análises para as diferentes partições na aba de Análises do modelo."
 
@@ -1350,13 +1344,13 @@ msgid "Confirm password"
 msgstr "Confirme a senha"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Considerações"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contato"
@@ -1365,8 +1359,8 @@ msgstr "Contato"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr "Contato está desativado. O usuário não pode ser desvinculado."
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contatos"
@@ -1375,48 +1369,48 @@ msgstr "Contatos"
 msgid "Contacts to CC"
 msgstr "Contatos para CC"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Recipiente"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr "Nome do recipiente"
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tipo de Recipiente"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipos de Recipientes"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr "Volume do recipiente"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Recipientes"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tipo de Conteúdo"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tipo de conteúdo"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Controle"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "Análises para CQ de controle"
 
@@ -1432,12 +1426,12 @@ msgstr "Copiar serviços de análise"
 msgid "Copy from"
 msgstr "Copiar de"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Copiar para um novo"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Conta"
 
@@ -1450,18 +1444,18 @@ msgstr "País"
 msgid "Create a new User"
 msgstr "Criar um novo Usuário"
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Criar uma nova amostra deste tipo"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Criado"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Criado por"
 
@@ -1469,7 +1463,7 @@ msgstr "Criado por"
 msgid "Created by:"
 msgstr "Criado por:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr "Criando e inicializando objetos"
 
@@ -1477,8 +1471,8 @@ msgstr "Criando e inicializando objetos"
 msgid "Creator"
 msgstr "Criar"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Critério"
 
@@ -1486,12 +1480,12 @@ msgstr "Critério"
 msgid "Currency"
 msgstr "Moeda"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Atual"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "Marca decimal padrão"
 
@@ -1504,7 +1498,7 @@ msgstr "DL"
 msgid "Daily"
 msgstr "Diáriamente"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1518,88 +1512,88 @@ msgstr "Interface de Dados"
 msgid "Data Interface Options"
 msgstr "Opções da Interface de Dados"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Entrada de dados no diário"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Data"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Data de Criação"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Data de Remessa"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Data de descarte"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Data de Expiração"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Data de Importação"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Data de Carregamento"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Data de Abertura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Data da Preservação"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Data de Publicação"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Data de Recebimento"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Data do Pedido"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Data da Amostra"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr "Data Validada"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr "Data Verificada"
 
@@ -1615,7 +1609,7 @@ msgstr "Data a partir da qual o certificado de calibração é válido"
 msgid "Date from which the instrument is under calibration"
 msgstr "Data a partir do instrumento sob calibração"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Data a partir do instrumento sob manutenção"
 
@@ -1633,7 +1627,7 @@ msgid "Date until the certificate is valid"
 msgstr "Data até a qual o certificado é válido"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Data até que o instrumento não estará disponível"
@@ -1642,11 +1636,11 @@ msgstr "Data até que o instrumento não estará disponível"
 msgid "Date when the calibration certificate was granted"
 msgstr "Data de quando o certificado de calibração foi concedido"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr "Data/Hora da Amostragem"
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Dias"
 
@@ -1658,17 +1652,17 @@ msgstr "Desativar até a próxima calibração"
 msgid "Deactivate"
 msgstr "Desativar"
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "Marca decimal para uso nos Laudos deste cliente."
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Padrão"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Especificações de RA padrões"
 
@@ -1676,49 +1670,49 @@ msgstr "Especificações de RA padrões"
 msgid "Default ARReport Template"
 msgstr "Modelo ARReport padrão"
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Cálculo padrão"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Recipiente Padrão"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tipo Padrão de Recipiente"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr "Emails padrão para CC todos os ARs publicados para este cliente"
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Instrumento padrão"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Método padrão"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Preservação Padrão"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Prioridade padrão?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "Cálculo padrão a ser usado a partir do Método padrão selecionado. O Cálculo para um método pode ser designado na visualização Edição de método."
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categorias padrão"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "Recepiente padrão para novas partições de amostras"
 
@@ -1727,11 +1721,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Recipientes padrão: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "Marca decimal padrão"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr "O instrumento padrão %s não é válido"
 
@@ -1755,11 +1749,11 @@ msgstr "Formato de notação científica padrão para laudos"
 msgid "Default scientific notation format for results"
 msgstr "Formato de notação científica padrão para resultados"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valor Padrão"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "EspecPadrRA_descricao"
 
@@ -1767,7 +1761,7 @@ msgstr "EspecPadrRA_descricao"
 msgid "Define a date range"
 msgstr "Definir um intervalo de datas"
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "Definir um código identificador para o método. Ele deve ser exclusivo."
 
@@ -1775,11 +1769,11 @@ msgstr "Definir um código identificador para o método. Ele deve ser exclusivo.
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr "Defina campos interinos como massa do vasso, fatores de diluição, caso seu cálculo os exija. O título de campo especificado aqui será usado como cabeçalhos de colunas e descritores de campo onde os campos intermediários são exibidos. Se \"Aplicar ampla\" estiver ativado, o campo será exibido em uma caixa de seleção na parte superior da planilha, permitindo aplicar um valor específico a todos os campos correspondentes na planilha."
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "Defina o numero de decimais para ser usado neste resultado."
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "Defina a precisão quando convertendo valores para notação exponencial. O padrão é 7"
 
@@ -1787,16 +1781,16 @@ msgstr "Defina a precisão quando convertendo valores para notação exponencial
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr "Definir os prefixos para as identificações sequenciais exclusivos, os problemas de sistema para objetos. No campo 'Preenchimento', indicam com quantos zeros à esquerda os números devem ser preenchidos. Por exemplo. um prefixo de WS para planilhas com estofamento de 4, vai vê-los numeradas de WS-0001 e WS-9999. Sequência de início indica o número a partir do qual o próximo ID deve começar. Isso é definido somente se for maior do que os números de identificação existentes. Note-se que o fosso criado por IDs de salto não pode ser recarregado. NB: Note-se que as amostras e os pedidos de análise são prefixados com o tipo de amostra abreviaturas e não estão configurados no presente quadro - seu preenchimento pode ser definido nos campos especificados abaixo"
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr "Definir o coletor que deve amostrar na data programada"
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr "Definir quando o coletor tem que coletar as amostras"
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Graus"
 
@@ -1804,9 +1798,9 @@ msgstr "Graus"
 msgid "Delete attachment"
 msgstr "Apagar anexo"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Departamento"
 
@@ -1819,13 +1813,13 @@ msgstr "Departamentos"
 msgid "Dependent Analyses"
 msgstr "Análise Dependente"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Descreve o método em termos leigos. Esta informação pode ser exibida aos clientes do laboratório."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descrição"
 
@@ -1833,7 +1827,7 @@ msgstr "Descrição"
 msgid "Description of the actions made during the calibration"
 msgstr "Descrição das ações realizadas durante a calibração"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "Descrição das ações realizadas durante o processo de manutenção"
 
@@ -1841,19 +1835,19 @@ msgstr "Descrição das ações realizadas durante o processo de manutenção"
 msgid "Description of the actions made during the validation"
 msgstr "Descrição das ações feitas durante a validação"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "Descrição do local"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "Descrição da prateleira"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "Descrição do sítio"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr "Desabilitar multi-verificação para o mesmo usuário"
 
@@ -1861,7 +1855,7 @@ msgstr "Desabilitar multi-verificação para o mesmo usuário"
 msgid "Disable the filtering by date"
 msgstr "Desativar a filtragem por data"
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "Desconto %"
 
@@ -1869,16 +1863,16 @@ msgstr "Desconto %"
 msgid "Dispatch"
 msgstr "Despachar"
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Enviado"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Mostrar Valor"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "Mostrar seletor de limite de detecção"
 
@@ -1890,7 +1884,7 @@ msgstr "Mostrar um alerta em novas versões do Bika LIMS"
 msgid "Display individual sample partitions "
 msgstr "Exibir partições individuais de amostra"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "Data do Descarte"
 
@@ -1899,8 +1893,8 @@ msgstr "Data do Descarte"
 msgid "Dispose"
 msgstr "Descartar"
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Descarte"
@@ -1909,54 +1903,54 @@ msgstr "Descarte"
 msgid "District"
 msgstr "Distrito"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "Divisão por zero"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "Documento"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr "ID do documento"
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr "Localização do Documento"
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr "Tipo do Documento"
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr "Versão do Documento"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Inativo"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Ponto (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Copiar de"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Copiar para"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "Download"
 
@@ -1969,20 +1963,20 @@ msgstr "Seco"
 msgid "Dry matter analysis"
 msgstr "Análise de matéria seca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Entrega"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Data de Entrega"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Variável Duplicada"
 
@@ -1991,20 +1985,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Duplicada"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Duplicado De"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "Análises de CQ duplicadas"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Variação da Duplicação %"
 
@@ -2016,35 +2010,35 @@ msgstr "CQ de análise duplicada"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Gráficos de controle de qualidade de análise duplicada"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Duração"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Por exemplo, SANAS, APLAC, etc."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Precocidade"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Adiantado"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Elevação"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Endereço de Email"
 
@@ -2052,7 +2046,7 @@ msgstr "Endereço de Email"
 msgid "Email notification on rejection"
 msgstr "Notificação por e-mail de rejeição"
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Linha de assunto do email"
 
@@ -2072,14 +2066,14 @@ msgstr "Ativar o Agendamento da Funcionalidade de Amostragem"
 msgid "Enable the rejection workflow"
 msgstr "Ativar o processo de rejeição"
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Data final"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "Aprimorar"
 
@@ -2091,16 +2085,16 @@ msgstr "Digite um nome de usuário, tipicamente algo como 'jsmith', sem espaços
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Digite um endereço de email. Isto é necessário para a eventualidade de recuperação da sua senha. Nós respeitamos sua privacidade e não forneceremos seu endereço a terceiros e não o tornaremos público de nenhuma maneira."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Digite o percentual de desconto"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Digite um valor percentual, exemplo: 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "Digite um valor percentual , ex:14,0. Este percentual é aplicado somente ao perfil de analises, sobrepondo o VAT do sistema"
 
@@ -2108,15 +2102,15 @@ msgstr "Digite um valor percentual , ex:14,0. Este percentual é aplicado soment
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Digite um valor percentual, exemplo: 14.0. Este percentual é aplicado a todo o sistema, mas pode ser sobreposto em itens individuais"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Digite um valor percentual, exemplo: 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Entre a latitude do Local de Amostragem em graus 0-90, minutos 0-59, segundos 0-59 e o indicador N/S"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Entre a longitude do Local de Amostragem em graus 0-90, minutos 0-59, segundos 0-59 e o indicador E/W"
 
@@ -2124,7 +2118,7 @@ msgstr "Entre a longitude do Local de Amostragem em graus 0-90, minutos 0-59, se
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "Insira os detalhes de cada um dos serviços de análise que deseja copiar."
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "Entre detalhes do serviço de acreditação do seu laboratório aqui. Os seguintes campos estão disponíveis: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
@@ -2132,45 +2126,45 @@ msgstr "Entre detalhes do serviço de acreditação do seu laboratório aqui. Os
 msgid "Entity"
 msgstr "Entidade"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr "Condições Climaticas"
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr "Condições Climaticas"
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "Publicação de resultado errôneo para ${request_id}"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr "Erros"
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr "Andamento das Análises"
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr "Andamento das Requisições de Análises"
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr "Andamento das Requisições de Análises"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Excluir da fatura"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Resultado Esperado"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Valores Esperados"
 
@@ -2179,19 +2173,19 @@ msgstr "Valores Esperados"
 msgid "Expire"
 msgstr "Vence"
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Vencido"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Data de Vencimento"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "Precisão do formato exponencial"
 
@@ -2199,44 +2193,40 @@ msgstr "Precisão do formato exponencial"
 msgid "Exponential format threshold"
 msgstr "Limite do formato exponencial"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr "Perfil da extensão do Bika LIMS"
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Fax"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Fax comercial"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Feminino"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Campo"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Análises de Campo"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Preservação de Campo"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Título do Campo"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Arquivo"
 
@@ -2244,19 +2234,19 @@ msgstr "Arquivo"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "Arquivos anexos para resultados, ex.: fotos de microscópio, serão incluídas nos e-mails para destinatários se essa opção for ativada"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr "Carregar arquivo"
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Nome do arquivo"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr "Arquivos"
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr "Filtrar"
 
@@ -2276,16 +2266,16 @@ msgstr "Filtrar de:"
 msgid "Filter template analyses by client"
 msgstr "Filtrar modelo de análise por cliente"
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Primeiro Nome"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr "Valor de flutuação de 0,0 - 1000,0 indicando a ordem de classificação. Os valores duplicados são ordenados alfabeticamente."
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Fórmula"
 
@@ -2295,18 +2285,18 @@ msgstr "Fórmula"
 msgid "From"
 msgstr "De"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "De ${start_date} até ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Nome Completo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "Amostra datada no futuro"
 
@@ -2316,7 +2306,7 @@ msgstr "Amostra datada no futuro"
 msgid "Generate report"
 msgstr "Emitir Laudo"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Título de saudação, como Sr, Sra, Srta, Dr"
 
@@ -2328,37 +2318,37 @@ msgstr "Agrupar serviços de análise por categoria nas tabelas de LIMS, útil q
 msgid "Group by"
 msgstr "Agrupar por"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Período de agrupamento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Perigoso"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Oculto"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Campo Oculto"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Horas"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2367,8 +2357,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "URL do Servidor de ID"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "Servidor de ID indisponível"
 
@@ -2376,31 +2366,31 @@ msgstr "Servidor de ID indisponível"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "IMPORTANTE: Não use \"Bika\" ou \"BIKA\" como um nome de instância, este nome esta reservado. Se você receber \"Site Error\" citando \"AttributeError: adapters\", esta é a causa mais provável."
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr "Identificador"
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr "Tipo de Identificador"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr "Tipos de Identificadores"
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr "Identificadores para este objeto"
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "Se \"Permitir entrada instrumental de resultados\" estiver selecionado, o método padrão a ser usado será o método definido no Instrumento padrão. Caso contrário, apenas os métodos acima selecionados serão exibidos."
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "Se a amostra é coletada periodicamente neste local de amostragem, insira a frequência aqui, por exemplo: semanal"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "Se marcada, uma lista de seleção será exibida ao lado do campo resultado de análise, na entrada de resultados. Ao utilizar este seletor, o analista será capaz de definir o valor como um limite de detecção (LDL, HDL), em vez de um resultado normal"
 
@@ -2412,7 +2402,7 @@ msgstr "Se selecionado, o instrumento estará indisponível até a próxima cali
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr "Se ativado, um campo de texto livre será exibido perto de cada análise na exibição de entrada de resultados"
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr "Se ativado, um usuário que enviou um resultado para essa análise também poderá confirmá-lo. Esta configuração tem efeito para os usuários com uma função atribuída que lhes permite verificar resultados (por padrão, gerentes, gerentes de laboratório e verificadores). A opção definida aqui tem prioridade sobre a opção definida no Bika Setup"
 
@@ -2420,27 +2410,27 @@ msgstr "Se ativado, um usuário que enviou um resultado para essa análise tamb�
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr "Se ativado, um usuário que enviou um resultado também poderá confirmá-lo. Essa configuração só terá efeito para os usuários com uma função atribuída que lhes permita verificar resultados (por padrão, gerentes, gerentes de laboratório e verificadores). Essa configuração pode ser sobrescrita por uma determinada análise no modo de exibição de edição do Serviço de Análise. Por padrão, desativado."
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "Se acionado, o nome da análise vai ser escrito em itálico."
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "Se ativado, esta análise e seus resultados não serão exibidos por padrão nos laudos. Essa configuração pode ser alterada em Análise de Perfil e/ou Pedido de Análise "
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "Se nenhum valor de titulo for usado, o ID do lote será usado"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Se solicitado, selecione um cálculo para os serviços de análise ligados a este método. Os cálculos podem ser configuradas no item cálculos das configurações do LIMS."
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Caso necessário, selecione um cálculo para a análise aqui. Cálculos podem ser configurados no item relativo a eles na configuração do LIMS"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "Se o texto for inserido aqui, ele é usado em vez do título quando o serviço for listado em títulos de coluna. Formatação HTML é permitido."
 
@@ -2448,7 +2438,7 @@ msgstr "Se o texto for inserido aqui, ele é usado em vez do título quando o se
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "Se não houver resultados anteriores para um serviço no mesmo lote de pedidos de análise, elas serão exibidas no laudo."
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "Caso este recipiente seja pré-preservado, o método de preservação pode ser selecionado aqui."
 
@@ -2461,7 +2451,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Se desmarcado, os analistas terão acesso a todas as planilhas."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Importar"
@@ -2470,7 +2460,7 @@ msgstr "Importar"
 msgid "Import Analysis Request Data"
 msgstr "Importar Dados da Solicitação de Análise"
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Importado"
@@ -2479,8 +2469,8 @@ msgstr "Importado"
 msgid "In-lab calibration procedure"
 msgstr "Procedimento de calibração no laboratório"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Inativo"
@@ -2489,7 +2479,7 @@ msgstr "Inativo"
 msgid "Include Previous Results From Batch"
 msgstr "Incluir Resultados Anteriores do Lote"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "Inclua todas requisições de análises pertencentes aos objetos selecionados."
 
@@ -2497,7 +2487,7 @@ msgstr "Inclua todas requisições de análises pertencentes aos objetos selecio
 msgid "Include and display pricing information"
 msgstr "Incluir e exibir informações sobre preço"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Incluir descrições"
 
@@ -2505,30 +2495,27 @@ msgstr "Incluir descrições"
 msgid "Include year in ID prefix"
 msgstr "Incluir o ano no prefixo do ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "Número IBAN incorreto: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "Número NIB incorreto: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Resultado indeterminado"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "Indica se anexos, como imagens de microscópio, são necessários para esta análise e se a função de upload de arquivos estará disponível nas telas de captura de dados"
 
-msgid "Info"
-msgstr "Informação"
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "Herdado de"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Revisão inicial"
 
@@ -2552,7 +2539,7 @@ msgstr "Upload de certificado de Instalação"
 msgid "InstallationDate"
 msgstr "Data de instalação"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Instruções"
@@ -2565,17 +2552,17 @@ msgstr "Instruções para rotinas de calibração regulares no laboratório dest
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "Instruções para rotinas de prevenção e manutenção regulares destinados a analistas"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Instrumento"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Calibrações de Instrumento"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr "Arquivo de Instrumentos"
 
@@ -2588,16 +2575,16 @@ msgstr "Importação do Instrumento"
 msgid "Instrument Location"
 msgstr "Localização do Instrumento"
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr "Localizações do Instrumento"
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Manutenção do Instrumento"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Agenda de Tarefas do Instrumento"
 
@@ -2605,19 +2592,19 @@ msgstr "Agenda de Tarefas do Instrumento"
 msgid "Instrument Type"
 msgstr "Tipo do Instrumento"
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Tipo de Instrumento"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "Validação de Instrumento"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr "A atribuição do instrumento é permitida"
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr "A atribuição do instrumento não é requerida"
 
@@ -2661,9 +2648,9 @@ msgstr "Tipo de instrumento"
 msgid "Instrument's calibration certificate expired:"
 msgstr "Certificado de calibração dos instrumentos expirado:"
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Instrumentos"
 
@@ -2687,7 +2674,7 @@ msgstr "Instrumentos em progresso de validação:"
 msgid "Instruments' calibration certificates expired:"
 msgstr "Os certificados de calibração dos instrumentos expiraram:"
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "Testes de calibração interna"
 
@@ -2703,24 +2690,21 @@ msgstr "Interpolação"
 msgid "Interval"
 msgstr "Intervalo"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Inválido"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "RA inválida retestada"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr "Instrumentos inválidos não são exibidos: %s"
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr "Instrumentos inválidos não são mostrados: ${invalid_list}"
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "Caracteres inválidos encontrados: ${wildcards}"
 
@@ -2728,43 +2712,43 @@ msgstr "Caracteres inválidos encontrados: ${wildcards}"
 msgid "Invalidate"
 msgstr "Invalidar"
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Fatura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Data da fatura"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Excluir Fatura"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Número da fatura"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "FaturaLote não possui data final"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "FaturaLote não possui data inicial"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "FaturaLote não possui título"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr "É uma amostra composta"
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Item inativo"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Itens a serem incluídos nas linhas de título do email"
 
@@ -2774,7 +2758,7 @@ msgstr "Itens a serem incluídos nas linhas de título do email"
 msgid "Job Title"
 msgstr "Cargo"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Cargo"
 
@@ -2782,12 +2766,12 @@ msgstr "Cargo"
 msgid "Key"
 msgstr "Chave"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Erro de chave"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Palavra-chave"
@@ -2796,47 +2780,47 @@ msgstr "Palavra-chave"
 msgid "Keywords"
 msgstr "Palavras-chave"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratório"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Análises do Laboratório"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Contatos do Laboratório"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Departamentos do Laboratório"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Preservação do Laboratório"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Produtos do Laboratório"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL do laboratório"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Rótulo"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratório"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Laboratório Certificado"
 
@@ -2856,13 +2840,13 @@ msgstr "Último Horário de Acesso"
 msgid "Last modified"
 msgstr "Última modificação"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Atrasado"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Análise Atrasada"
@@ -2872,7 +2856,7 @@ msgstr "Análise Atrasada"
 msgid "Late Analysis"
 msgstr "Análises Atrasadas"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -2894,11 +2878,11 @@ msgstr "Link Usuário"
 msgid "Link an existing User"
 msgstr "Vincular um usuário existente"
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Amostra Associada"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr "Lista de tipos de identificadores para multiplos registros de identificadores"
 
@@ -2910,7 +2894,7 @@ msgstr "Listar toda amostra recebidas por período"
 msgid "Load Setup Data"
 msgstr "Carregar Dados de Configuração"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Carregar os documentos descrevendo o método"
 
@@ -2922,41 +2906,41 @@ msgstr "Carregue do arquivo"
 msgid "Load the certificate document here"
 msgstr "Carregar o documento certificado aqui"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Carregado"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "Código de localização"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "Descrição do local"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "Título do local"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "Tipo do local"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "Localização onde a amostra é colocada"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "Local onde a amostra foi coletada"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr "Local onde o conjunto de documentos está arquivado"
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Registro"
@@ -2981,35 +2965,35 @@ msgstr "Falha na autenticação. Seu Login foi desativado. Entre em contato com 
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr "Falha na autenticação. Seu Login está vinculado a vários Contatos. Entre em contato com o laboratório para obter mais informações."
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Longitude"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Número do lote"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "Limite de detecção mais baixo (LDL)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Endereço de correspondência"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "Mantedor"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "Tipo de conteúdo"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Masculino"
 
@@ -3017,16 +3001,16 @@ msgstr "Masculino"
 msgid "Manage linked User"
 msgstr "Gerenciar usuário vinculado"
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Gerente"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Email do Gerente"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Telefone do Gerente"
 
@@ -3034,31 +3018,25 @@ msgstr "Telefone do Gerente"
 msgid "Manual"
 msgstr "Manual"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "Entrada Manual"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "Entrada manual de resultados"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr "Entrada manual de resultados para o método ${methodname} não é permitida"
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr "A entrada manual de resultados para o método %s não é permitida e  não foram encontrados instrumentos válidos: %s"
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr "A entrada manual de resultados para o método {methodname} não é permitida e nenhum instrumento válido foi encontrado: ${invalid_list}"
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Fabricante"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Fabricante"
 
@@ -3067,14 +3045,14 @@ msgstr "Fabricante"
 msgid "Margins (mm)"
 msgstr "Margens (mm)"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Máximo"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Tempo Máximo"
 
@@ -3082,30 +3060,30 @@ msgstr "Tempo Máximo"
 msgid "Maximum columns per results email"
 msgstr "Número máximo de colunas em resultados por email"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Tamanho ou volume máximo possível de amostras"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Tempo máximo permitido para a finalização da análise. Um alerta de análise em atraso é acionado quando este tempo se esgota"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Tempo máximo de processamento"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr "Desconto de membro"
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Desconto para o associado %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Há desconto para associado aqui"
 
@@ -3114,22 +3092,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr "Membro registrado e vinculado ao contato atual."
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Método"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Documento do Método"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "ID Método"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Instruções do Método"
 
@@ -3141,9 +3119,9 @@ msgstr "Método: ${method_name}"
 msgid "Method: None"
 msgstr "Método: Nenhum"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Métodos"
 
@@ -3151,17 +3129,17 @@ msgstr "Métodos"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Métodos fazem parte do programa de certificação de ${accreditation_body} para este laboratório. Comentários nas análises não são certificados."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "Inicial do nome do meio"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "Nome do meio"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Mínimo"
 
@@ -3173,8 +3151,8 @@ msgstr "Meu"
 msgid "Minimum 5 characters."
 msgstr "Cinco caracteres no mínimo."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Volume Mínimo"
 
@@ -3182,27 +3160,27 @@ msgstr "Volume Mínimo"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Número mínimo de resultados para cálculos estatísticos de CQ"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Minutos"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr "Amostras de amostragem programadas faltando ou data de amostragem em% s."
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Celular"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Modelo"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "Data de modificação"
 
@@ -3216,7 +3194,7 @@ msgstr "Por mês"
 msgid "More"
 msgstr "Mais"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr "Mais de um instrumento pode ser usado em um teste deste tipo de análise. Uma lista de seleção com os instrumentos selecionados aqui é preenchida na exibição de gerenciamento de resultados para cada teste desse tipo de análise. Os instrumentos disponíveis na lista de seleção serão alterados de acordo com o método selecionado pelo usuário para esse teste na visão de gerenciamento de resultados. Embora um método possa ter mais de um instrumento atribuído, a lista de seleção é preenchida apenas com os instrumentos que são definidos aqui e permitidos para o método selecionado."
 
@@ -3228,13 +3206,13 @@ msgstr "Múltiplo Tipo de verificação"
 msgid "Multi-verification required"
 msgstr "Múltipla verificação requerida "
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "NIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Nome"
 
@@ -3243,17 +3221,17 @@ msgstr "Nome"
 msgid "New"
 msgstr "Novo"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Não"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "Nenhuma pedido de análise acompanhado sua consulta"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr "Nenhum Serviço de Análise definido"
 
@@ -3269,18 +3247,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "Nunhuma ação encontrada para o usuário ${user}"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Nenhuma análise foi selecionada"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "Nenhuma análise encontrada dentro de seu critério"
 
@@ -3292,23 +3270,23 @@ msgstr "Nenhuma análise foi adicionada"
 msgid "No analyses were added to this worksheet."
 msgstr "Nenhuma análise foi adicionada para esta planilha."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "Sem análise selecionada"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "Sem serviço de análise selecionada"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "Nenhum serviço de análise foi selecionado"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Nenhuma modificação foi feita."
 
@@ -3316,7 +3294,7 @@ msgstr "Nenhuma modificação foi feita."
 msgid "No control type specified"
 msgstr "Nenhum tipo de controle especificado"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr "Sem data definida"
 
@@ -3328,17 +3306,17 @@ msgstr "Nenhum recipiente padrão especificado para este serviço"
 msgid "No default preservations specified for this service"
 msgstr "Nenhuma preservação padrão especificada para este serviço"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "Nenhum arquivo selecionado"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "Sem histórico de ações dentro do seu critério."
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "Nenhum item foi selecionado"
 
@@ -3346,7 +3324,7 @@ msgstr "Nenhum item foi selecionado"
 msgid "No items selected"
 msgstr "Nenhum item selecionado"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "Nenhum item novo foi criado"
 
@@ -3356,16 +3334,16 @@ msgstr "Nenhum item novo foi criado"
 msgid "No preservation required"
 msgstr "Não é necessária preservação"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "Nenhuma amostra de referência foi selecionada"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Nenhum laudo especificado no pedido"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "Nenhuma amostra compatível"
 
@@ -3383,25 +3361,22 @@ msgstr "Não há usuário correspondente para ${contact_fullname} e ele/ela não
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr "Nenhum perfil de usuário pode ser encontrado para o usuário. Entre em contato com o administrador do laboratório para obter suporte adicional ou tente relink de usuário."
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr "Nenhum instrumento válido disponível: %s"
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr "Nenhum instrumento válido encontrado: ${invalid_list}"
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Nenhum"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Não Permitido"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "Não disponível"
 
@@ -3421,19 +3396,19 @@ msgstr "Não configurado"
 msgid "Num columns"
 msgstr "Número de colunas"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "Número de Análises"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "Número de requisições de análises e análises"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "Número de requisições de análises e análises por cliente"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr "Número de Recipientes"
 
@@ -3441,30 +3416,30 @@ msgstr "Número de Recipientes"
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr "Número de Pontos de Amostragem"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "Número de análises"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "Número de análises fora da margem por período"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "Número de análises requisitadas por serviço de análise"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "Número de requisições de análises por tipo de amostra"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "Número de análises retestadas para o período"
 
@@ -3472,15 +3447,15 @@ msgstr "Número de análises retestadas para o período"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "Número de análises publicadas e expressas como a porcentagem do total de análises realizadas"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr "Número de recipientes"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "Número de requisições"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr "Número de verificações necessárias"
@@ -3489,31 +3464,31 @@ msgstr "Número de verificações necessárias"
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr "Número de verificações necessárias antes de um determinado resultado ser considerado como \"verificado\". Essa configuração pode ser sobrescrita por qualquer  análise em Serviços Análises. Por padrão, 1"
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr "Número de verificações necessárias de diferentes utilizadores com privilégios suficientes antes de um determinado resultado para esta análise ser considerado como \"verificado\". A opção definida aqui tem prioridade sobre a opção definida no Bika Setup"
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Número de amostras"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr "Número de pontos de amostragem"
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "Valores numéricos indicando a ordem de classificação de objetos que estão priorizados"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "ID Objeto"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "Uma vez preservada, a amostra deve ser descartada dentro do mesmo período de tempo. Caso não especificado, o tempo de retenção da amostra exemplo será utilizado."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr "Somente a entrada do instrumento para esta análise é permitida, mas não há nenhum instrumento atribuído"
 
@@ -3521,15 +3496,12 @@ msgstr "Somente a entrada do instrumento para esta análise é permitida, mas n�
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Somente gerentes de laboratório podem criar e editar carta controle"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr "Somente as análises para as quais o instrumento selecionado é permitido serão adicionadas automaticamente."
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "Somente para campos vazios ou iguais a zero"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Abrir"
@@ -3542,26 +3514,26 @@ msgstr "Sistema de gerenciamento de informações de laboratório baseado em Web
 msgid "Order"
 msgstr "Pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Data do Pedido"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "ID do Pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Número do Pedido"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Pedidos"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "Pedidos: ${orders}"
 
@@ -3569,7 +3541,7 @@ msgstr "Pedidos: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "Organização responsável por conceder o certificado de calibração"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr "Nome do arquivo original"
 
@@ -3581,8 +3553,8 @@ msgstr "Outro valor:"
 msgid "Other productivity reports"
 msgstr "Outros relatórios de produtividade"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "Expirado"
 
@@ -3594,16 +3566,13 @@ msgstr "Formato de saída"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr "Parente"
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Partição"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr "ID Partição"
 
@@ -3624,8 +3593,8 @@ msgstr "Senha"
 msgid "Password lifetime"
 msgstr "Tempo de vida da senha"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Pendente"
@@ -3650,31 +3619,31 @@ msgstr "Performace por"
 msgid "Period"
 msgstr "Período"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Permitido"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "% Erro Permitido"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefone"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefone Comercial"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefone Residencial"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Celular"
 
@@ -3687,8 +3656,8 @@ msgid "Photo of the instrument"
 msgstr "Foto do instrumento"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Endereço físico"
 
@@ -3696,7 +3665,7 @@ msgstr "Endereço físico"
 msgid "Please correct the indicated errors."
 msgstr "Corrija os erros indicados."
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "Por favor, liste todas as opções para os resultados de análises que você deseja restringir apenas para opções específicas apenas, por exemplo 'Positivo', 'Negativo' e 'Indeterminado'. O resultado da opção deve ser um número."
 
@@ -3704,19 +3673,19 @@ msgstr "Por favor, liste todas as opções para os resultados de análises que v
 msgid "Please select a User from the list"
 msgstr "Selecione um usuário na lista"
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "Por favor, especifique aqui as preservações que diferem do tipo padrão de serviço de preservação."
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Por favor, faça o upload o logotipo que você está autorizado a usar, por seu órgão certificador, em seu site e em laudos com os resultados. O tamanho máximo é 175 x 175 pixels."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Local de Captura"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr "Tipos de portal"
 
@@ -3725,13 +3694,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Posição"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Endereço Postal"
 
@@ -3739,16 +3708,16 @@ msgstr "Endereço Postal"
 msgid "Postal code"
 msgstr "CEP"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Pré-preservado"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Precisão em números decimais"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "Precisão como o número de algarismos significativos de acordo com a incerteza. A posição decimal será dada pelo primeiro número diferente de zero na incerteza, nessa posição o sistema arredondará a incerteza e resultados. Por exemplo, com um resultado de 5,243 e uma incerteza de 0,22, o sistema irá exibir corretamente como 5,2+-0.2. Se nenhuma margem de incerteza for definida para o resultado, o sistema usará o conjunto de precisão fixo."
 
@@ -3776,7 +3745,7 @@ msgstr "Preferência de notação científica padrão para laudos"
 msgid "Preferred scientific notation format for results"
 msgstr "Preferência de notação científica para formatação resultados"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Prefixo"
 
@@ -3784,12 +3753,12 @@ msgstr "Prefixo"
 msgid "Prefixes"
 msgstr "Prefixos"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "Premium"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr "Fluxo de trabalho de preparação"
 
@@ -3801,17 +3770,17 @@ msgstr "Preparado por"
 msgid "Prepublish"
 msgstr "Pré-publicar"
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Preservação"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Categoria da Preservação"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr "Método de Preservação"
 
@@ -3822,7 +3791,7 @@ msgid "Preservation required"
 msgstr "Preservação necessária"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Preservações"
 
@@ -3832,14 +3801,14 @@ msgstr "Preservações"
 msgid "Preserve"
 msgstr "Preservar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Preservador"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "Preveção"
 
@@ -3847,34 +3816,34 @@ msgstr "Preveção"
 msgid "Preventive maintenance procedure"
 msgstr "Prever procedimento de manutenção"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Preço"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Preço (excluindo impostos)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "Percentual de preço premium"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Preço excluindo impostos"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Lista de preços"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Listas de preço"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr "Contato primário"
 
@@ -3889,13 +3858,13 @@ msgstr "Impressão"
 msgid "Print date:"
 msgstr "Data de impressão:"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr "Imprimir folhas de amostra"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -3912,34 +3881,34 @@ msgstr "Relatórios de Produtividade"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "LIMS/LIS Profissional de Código Aberto"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Perfil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Análise de Perfil"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Chave de Perfil"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Palavra-chave de Perfil"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Perfis"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma (ainda não faturado)"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "ID de Protocolo"
 
@@ -3947,7 +3916,7 @@ msgstr "ID de Protocolo"
 msgid "Public. Lag"
 msgstr "Público. Lag"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "Especificação da publicação"
 
@@ -3962,21 +3931,21 @@ msgstr "Preferências de publicação"
 msgid "Publish"
 msgstr "Publicar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Publicado"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "Requisições de Análises Publicadas que não foram faturadas."
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Publicado por"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Resultados publicados"
 
@@ -3989,8 +3958,8 @@ msgid "QC Analyses"
 msgstr "Análises do CQ"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "ID da amostra do CQ"
 
@@ -4011,23 +3980,23 @@ msgstr "Quantidade"
 msgid "Quarterly"
 msgstr "Trimestral"
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "Comentário de Intervalo"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "Comentário de intervalo"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Variação máxima"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Variação mínima"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "Especificação da variação"
 
@@ -4049,9 +4018,9 @@ msgstr "Receber"
 msgid "Receive sample"
 msgstr "Receber amostra"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Recebido"
 
@@ -4059,11 +4028,11 @@ msgstr "Recebido"
 msgid "Recept. Lag"
 msgstr "Recept. Atraso"
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr "Recepção pendente"
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "Recipientes"
 
@@ -4072,31 +4041,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "Referência em <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\">Criando novo modelo de laudo</a> documentação wiki de Bika LIMS para obter mais ou adicionar os seus próprios modelos de laudos."
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referência"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "Análises de Referência"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Definição de Referência"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Definições de Referências"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "Amostra de Referência"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Amostras de Referência"
 
@@ -4104,16 +4073,16 @@ msgstr "Amostras de Referência"
 msgid "Reference Supplier"
 msgstr "Fornecedor de Referência"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Tipo de Referência"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "Valor de referência"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "CQ de análise de referência"
@@ -4122,7 +4091,7 @@ msgstr "CQ de análise de referência"
 msgid "Reference analysis quality control graphs"
 msgstr "Gráficos de controle de qualidade de análise de referência"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "Gráficos de controle de qualidade de análise de referência"
 
@@ -4130,21 +4099,21 @@ msgstr "Gráficos de controle de qualidade de análise de referência"
 msgid "Reference sample"
 msgstr "Amostra de referência"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Valores de referência da amostra são brancos ou nulos"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "IDGrupoAnálisesReferência"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "DefiniçãoReferência representa a Definição de Referência ou tipo de amostra utilizada para o teste de controle de qualidade."
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "Refs: ${references}"
 
@@ -4167,8 +4136,8 @@ msgstr "Reintegração"
 msgid "Reject"
 msgstr "Rejeitar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr "Rejeitado"
@@ -4177,9 +4146,9 @@ msgstr "Rejeitado"
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Porcentagem de diferença relativa, ${variation_here} %, está fora da margem (${variation} %))"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Notas"
 
@@ -4187,7 +4156,7 @@ msgstr "Notas"
 msgid "Remarks to take into account before calibration"
 msgstr "Observações a considerar antes da calibração"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "Observações a considerar antes da calibração"
 
@@ -4195,7 +4164,7 @@ msgstr "Observações a considerar antes da calibração"
 msgid "Remarks to take into account before validation"
 msgstr "Observações a considerar antes da calibração"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "Observações a considerar para o processo de manutênção"
 
@@ -4204,8 +4173,8 @@ msgstr "Observações a considerar para o processo de manutênção"
 msgid "Remove"
 msgstr "Remover"
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "Reparar"
 
@@ -4214,7 +4183,7 @@ msgid "Repeated analyses"
 msgstr "Análises repetidas"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Laudo"
 
@@ -4228,14 +4197,14 @@ msgstr "Data de emissão"
 msgid "Report ID"
 msgstr "ID do Laudo"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Tipo deLaudo"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Reportar como Matéria Seca"
 
@@ -4260,7 +4229,7 @@ msgstr "Emitir tabela de resultados do número de amostras recebidas em um perí
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "Emitir tabelas de Resultados de Análises Solicitadas e totais submetidos entre um período de tempo"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Tipo de Laudo"
 
@@ -4268,7 +4237,7 @@ msgstr "Tipo de Laudo"
 msgid "Report upload"
 msgstr "Upload de Laudo"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Laudos"
 
@@ -4277,15 +4246,15 @@ msgstr "Laudos"
 msgid "Republish"
 msgstr "Republicar"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Requisição"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID da Requisição"
 
@@ -4293,26 +4262,26 @@ msgstr "ID da Requisição"
 msgid "Request new analyses"
 msgstr "Requisitar nova análise"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Requisitada"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Requisições"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Requerido"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Volume Requerido"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "Campos requeridos estão sem valor: ${field_names}"
 
@@ -4320,13 +4289,13 @@ msgstr "Campos requeridos estão sem valor: ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Categorias restritas"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Resultado"
 
@@ -4334,15 +4303,15 @@ msgstr "Resultado"
 msgid "Result Footer"
 msgstr "Rodapé dos Resultados"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Opções de Resultado"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Valor Final"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr "O resultado para ${analysis} não pôde ser salvo porque ele já foi enviado por outro usuário."
 
@@ -4360,11 +4329,11 @@ msgstr "Resultado fora do intervalo"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "Valores de resultado com pelo menos esse número de dígitos significativos são exibidos em notação científica com a letra 'e' para indicar o expoente. A precisão pode ser configurado em Serviços de análises individuais"
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "Interpretação de Resultados"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "Interpretação de resultados"
 
@@ -4372,7 +4341,7 @@ msgstr "Interpretação de resultados"
 msgid "Results attachments permitted"
 msgstr "Permitidos anexos em resultados"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "Resultados têm sido retirados"
 
@@ -4380,11 +4349,11 @@ msgstr "Resultados têm sido retirados"
 msgid "Results interpretation"
 msgstr "Interpretação de resultados"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr "Resultados pendentes"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "Resultados por local de amostragem"
@@ -4393,14 +4362,14 @@ msgstr "Resultados por local de amostragem"
 msgid "Results per samplepoint and analysis service"
 msgstr "Resultados por local de amostragem e serviço de análise"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Período de Retenção"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Retestado"
@@ -4419,11 +4388,11 @@ msgstr "Retratado"
 msgid "Retracted analyses"
 msgstr "Análises retratadas"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "Relatório de retratação indisponível"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "Retratações"
 
@@ -4439,12 +4408,12 @@ msgstr "Amostras de rotina (análises)"
 msgid "SMTP server disconnected. User creation aborted."
 msgstr "Servidor SMTP desconectado. A criação do usuário foi interrompida."
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "Código SWIFT"
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Cumprimento"
 
@@ -4452,19 +4421,19 @@ msgstr "Cumprimento"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "O mesmo que acima, mas estabelece o padrão para serviços de análises. Esta configuração pode ser feita individualmente para cada análise"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Amostra"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "Condição da amostra"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Condições da amostra"
 
@@ -4473,8 +4442,8 @@ msgid "Sample Due"
 msgstr "Amostras pendentes"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "ID da Amostra"
 
@@ -4486,12 +4455,12 @@ msgstr "Lacunas para o ID da Amostra"
 msgid "Sample ID Sequence Start"
 msgstr "Iniciar sequência de ID de amostra"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Matrizes de Amostras"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Matriz de Amostras"
 
@@ -4501,52 +4470,52 @@ msgstr "Número da Amostra"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Partições de Amostra"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Local de Amostragem"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Locais de Amostragem"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr "Rejeição de amostra"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Tipo de Amostra"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Prefixo do Tipo de Amostra"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "Especificações do tipo de amostra (Cliente)"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "Especificações do tipo de amostra (Laboratório)"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Tipos de Amostra"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "Condição da amostra"
 
@@ -4556,9 +4525,9 @@ msgstr "Condição da amostra"
 msgid "Sample due"
 msgstr "Amostra devida"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Local de amostragem"
 
@@ -4586,17 +4555,17 @@ msgstr "Amostra registrada"
 msgid "Sample related reports"
 msgstr "Laudos de amostras relacionadas"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Tipo de amostra"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "Matriz da amostra"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "Tipo de amostra"
 
@@ -4606,30 +4575,30 @@ msgstr "Tipo de amostra"
 msgid "Sampled"
 msgstr "Amostrado"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Particionador"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr "Coletor para amostragem programada"
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Amostras"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Amostras deste tipo devem ser tratadas como perigosas"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "Amostras recebidas vs reportadas"
@@ -4638,62 +4607,62 @@ msgstr "Amostras recebidas vs reportadas"
 msgid "Samples received vs. samples reported"
 msgstr "Amostras recebidas vs amostras reportadas"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "Amostras: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Data de Amostragem"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "Desvio de Amostragem"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Desvios de Amostragens"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Frequência de Amostragem"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr "Ponto de amostragem"
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr "Rodada de Amostragem"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr "Modelo da rodada de amostragem"
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr "Modelos de rodada de amostragem"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr "Rodada de amostragem"
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr "Modelo de rodadas de amostragem"
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr "Data da amostragem"
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr "Frequência de amostragem"
 
@@ -4703,9 +4672,9 @@ msgstr "Frequência de amostragem"
 msgid "Sampling workflow"
 msgstr "Processo de amostragem"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Salvar"
 
@@ -4718,17 +4687,17 @@ msgstr "Salvar comentários"
 msgid "Schedule sampling"
 msgstr "Amostragem programada"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr "Amostragem programada"
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "Agenda de tarefas"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "Nome científico"
 
@@ -4736,16 +4705,16 @@ msgstr "Nome científico"
 msgid "Search"
 msgstr "Busca"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Segundos"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr "Selo de segurança intacto"
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr "Selo de segurança intacto S/N"
 
@@ -4757,11 +4726,11 @@ msgstr "Selecione 'Registrar' se você quiser que as etiquetas sejam automaticam
 msgid "Select AR Templates to include"
 msgstr "Selecione Modelo AR para incluir"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Selecione a interface de dados"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "Selecione uma preservação padrão para este serviço de análise. Caso a preservação dependa da combinação do tipo de amostra, especifique a preservação por tipo de amostra na tabela abaixo"
 
@@ -4769,11 +4738,11 @@ msgstr "Selecione uma preservação padrão para este serviço de análise. Caso
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Selecione uma posição de destino e RA a ser duplicada."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Selecione um gerente a partir da equipe disponível configurada no item 'contatos do laboratório'. Gerentes departamentais são referenciados em relatórios de resultados de análises contendo dados de seus departamentos."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "Selecione uma amostra para ciar uma RA secundária"
 
@@ -4785,7 +4754,7 @@ msgstr "Selecionar todos os itens"
 msgid "Select an Export interface for this instrument."
 msgstr "Selecione uma interface de exportação para este instrumento."
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "Selecione as análises a incluir neste modelo"
 
@@ -4797,11 +4766,11 @@ msgstr "Selecionar Analista"
 msgid "Select existing file"
 msgstr "Selecione arquivo existente"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr "Selecione os identificadores pelos quais este objeto pode ser referenciado."
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Selecione caso a análise deva ser excluída da fatura"
 
@@ -4809,19 +4778,19 @@ msgstr "Selecione caso a análise deva ser excluída da fatura"
 msgid "Select if is an in-house calibration certificate"
 msgstr "Selecione se for um certificado de calibração interno"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "Selecione se o cálculo a ser utilizado no conjunto de cálculos definidos por padrão no método padrão. Se não selecionado, o cálculo pode ser selecionado manualmente"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Selecione caso as descrições devem ser incluídas"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr "Selecione se os resultados para os testes deste tipo de análise podem ser definidos usando um instrumento. Se estiver desativado, não haverá instrumentos disponíveis para testes desse tipo de análise na exibição de resultados de gerenciamento, mesmo que o método selecionado para o teste tenha instrumentos atribuídos."
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr "Selecione se os resultados para os testes desse tipo de análise podem ser definidos manualmente. Se selecionado, o usuário poderá definir um resultado para um teste deste tipo de análise na exibição de resultados de gerenciamento sem a necessidade de selecionar um instrumento, mesmo que o método selecionado para o teste tenha instrumentos atribuídos."
 
@@ -4847,7 +4816,7 @@ msgstr "Selecione o pais que o site vai ser mostrado como padrão"
 msgid "Select the currency the site will use to display prices."
 msgstr "Selecione a moeda que o site usará para exibir os preços."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "Selecione o recipiente padrão a ser usado por este serviço de análise. Caso o recipiente a ser usado dependa da combinação entre o tipo de amostra e sua preservação, especifique o recipiente na tabela de tipo de amostra abaixo."
 
@@ -4859,7 +4828,7 @@ msgstr "Seleccione a página inicial padrão. Isso é usado quando um usuário c
 msgid "Select the filter to apply"
 msgstr "Selecione o filtro a ser aplicado"
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Selecione o instrumento preferencial."
 
@@ -4867,7 +4836,7 @@ msgstr "Selecione o instrumento preferencial."
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr "Selecione o modelo que será usado por padrão, ao publicar ARs."
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr "Selecione os tipos que esse ID é usado para identificar."
 
@@ -4891,7 +4860,7 @@ msgstr "Selecione aqui para ativar os passos do processo (workflow) de coleção
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr "Selecione isto para permitir que um Coordenador de Amostragem programe uma amostragem. Esta funcionalidade só tem efeito quando o 'Fluxo de trabalho de amostragem' está ativo"
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Selecione quais Análises devem ser incluídas na Planilha"
 
@@ -4907,7 +4876,7 @@ msgstr "Selecione qual etiqueta deve ser usada como a etiqueta 'pequena' por pad
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "Selecione qual etiqueta imprimir quando a impressão automática estiver habilitada."
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr "Auto-verificação dos resultados"
 
@@ -4919,7 +4888,7 @@ msgstr "Enviar e-mail"
 msgid "Separate"
 msgstr "Separar"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "Recipiente Separado"
 
@@ -4927,32 +4896,28 @@ msgstr "Recipiente Separado"
 msgid "Serial No"
 msgstr "Número de série"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Serviço"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr "Dependências de serviços"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "Serviço incluído em  ${accreditation_body_abbrev}"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Serviços"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr "Defina o fluxo de trabalho de Rejeição de amostra e as razões"
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "Configurar a tarefa de manutenção como fechada."
 
@@ -4960,31 +4925,31 @@ msgstr "Configurar a tarefa de manutenção como fechada."
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Configure o número máximo de requisições de análises por email com resultados. Muitas colunas em um email tornam a leitura difícil para alguns clientes, que preferem um número menor de resultados por email."
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "Defina a especificação a ser usada antes de publicar uma RA"
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Configurar as especificações de resultado do serviço de análise do laboratório"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "Código de prateleira"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "Descrição de prateleira"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "Título da prateleira"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Endereço de entrega"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "Titulo abreviado"
 
@@ -5000,7 +4965,7 @@ msgstr "Mostrar Análises do CQ"
 msgid "Show more"
 msgstr "Show more"
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Mostre apenas as categorias selecionadas em visualizações do cliente"
 
@@ -5012,29 +4977,25 @@ msgstr "Mostrar / ocultar o resumo do cronograma"
 msgid "Signature"
 msgstr "Assinatura"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "Código do Site"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "Descrição do Site"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "Título do Site"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Tamanho"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr "Encaixe"
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Ícone pequeno"
 
@@ -5042,14 +5003,14 @@ msgstr "Ícone pequeno"
 msgid "Small sticker"
 msgstr "Etiqueta pequena"
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "Algumas análises estão desatualizadas ou instrumentos não calibrados. Edição resultados não permitidos"
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "Chave de classificação"
 
@@ -5057,41 +5018,41 @@ msgstr "Chave de classificação"
 msgid "Specification"
 msgstr "Especificação"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Especificações"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Especifique o tamanho da Planilha, por exemplo, em correspondência com o tamanho específico da bandeja de um instrumento. Depois, selecione o 'tipo' de Análise por posição na Planilha. Quando amostras de CQ forem selecionadas, selecione também qual Amostra de Referência deve ser usada. Se uma análise duplicada for selecionada, indique de qual posição da amostra esta duplicata deve ser feita."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "Especifique um valor de incerteza para uma determinada variação, por exemplo, em uma variação de 0 a 10, onde o valor de incerteza é 0,5 - um resultado de 6,67 será reportado como 6,67 +- 0,5. Você também pode especificar o valor de incerteza como uma porcentagem do valor do resultado, adicionando um '%' no valor encontrado na coluna \"incerteza de Valor\", exemplo: para resultados entre um intervalo mínimo de 10,01 e máximo de 100, onde o valor de incerteza é 2% - um resultado de 100 será reportado como 100 +- 2. Por favor, certifique-se de que variações sucessivas são contínuas, por exemplo 0,00 - 10,00 é seguido de 10,01 - 20,00; 20,01 - 30,00 e assim por diante."
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "Data inicial"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr "A data de início deve ser anterior à data de término"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Estado"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr "Afirmações"
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Estado"
 
@@ -5099,33 +5060,33 @@ msgstr "Estado"
 msgid "Sticker templates"
 msgstr "Modelos de adesivos"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "Local de armazenamento"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Locais de armazenamento"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "Subgrupo"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Subgrupos"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "Subgrupos são classificadas com esta tecla em grupos vistos"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Submeter"
 
@@ -5133,37 +5094,34 @@ msgstr "Submeter"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Enviar um arquivo válido Open XML (.xlsx) contendo registros de configuração do BIka para continuar."
 
-msgid "Submit for verification"
-msgstr "Enviar para verificação"
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr "Enviado e verificado pelo mesmo usuário-"
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr "Enviando AR Importação"
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Fornecedor"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Fornecedor"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "Pedido de suprimento"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Sobrenome"
 
@@ -5183,11 +5141,11 @@ msgstr "Mudar para a pagina inicial"
 msgid "System Dashboard"
 msgstr "Painel de Controle do Sistema"
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr "Padrão do Sistema"
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Tarefa"
 
@@ -5196,20 +5154,20 @@ msgid "Task ID"
 msgstr "ID da tarefa"
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "Tipo de Tarefa"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Descrição técnica e instruções a serem seguidas por analistas"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5227,35 +5185,35 @@ msgstr "Resultado do teste"
 msgid "Tests requested"
 msgstr "Testes solicitados"
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "A seleção do Perfil de Análise para este modelo"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "O ID designado à requisição do cliente pelo laboratório"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "O ID designado à amostra do cliente pelo laboratório"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "O endereço web do Laboratório"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "O limite inferior de detecção é o menor valor para o qual o parâmetro medido pode ser medido usando a metodologia de teste especificado. Resultados encontrados que são inferiores a este valor será relatado como < LDL (Menor limite de detecção)"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "O limite inferior de detecção é o menor valor para o qual o parâmetro medido pode ser medido usando a metodologia de teste especificado. Resultados encontrados que são superiores a este valor será relatado como > UDL (Maior limite de detecção)"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Padrões de certificação aplicáveis, como ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "As análises inclusas neste perfil, agrupadas por categoria"
 
@@ -5267,7 +5225,7 @@ msgstr "As análises a serem usadas para determinar a matéria seca."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "Analista ou técnico responsável pela calibração"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "Analista ou técnico responsável pela manutenção"
 
@@ -5275,12 +5233,12 @@ msgstr "Analista ou técnico responsável pela manutenção"
 msgid "The analyst responsible of the validation"
 msgstr "Analista responsável pela validação"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Anexos associados às requisições de análise e análises"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "A categoria da análise a qual este serviço pertence"
 
@@ -5288,19 +5246,19 @@ msgstr "A categoria da análise a qual este serviço pertence"
 msgid "The date the instrument was installed"
 msgstr "A data o instrumento foi instalado"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr "A data para fazer o processo de amostragem"
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "O marcador decimal nas configurações Bika serão usados."
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr "O coletador padrão para estas rodadas de amostragem"
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "O tipo padrão de recipiente. Novas partições de amostra receberão, automaticamente, um recipiente deste tipo a não ser que isto tenha sido especificado com mais detalhes por serviço de análise"
 
@@ -5312,7 +5270,7 @@ msgstr "O percentual de desconto digitado aqui é aplicado aos preços para os c
 msgid "The full URL: http://URL/path:port"
 msgstr "A URL completa: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "A altura ou profundidade na qual a amostra deve ser obtida"
 
@@ -5329,24 +5287,24 @@ msgstr "O número do modelo do instrumento"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr "O intervalo é calculado a partir do campo 'De' e define quando o certificado expira em dias. Definir esta inversão sobrescreve o campo 'Fazer' em salvar."
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr "O item %s não pode ser transferido."
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr "O item não pode ser transferido."
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr "O departamento de laboratório responsável pela rodada de amostragem"
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Este laboratório não é certificado, ou a certificação não foi configurada."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "O departamento do laboratório"
@@ -5363,27 +5321,27 @@ msgstr "A quantidade de zeros para o preenchimento dos IDs das Amostras."
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "A quantidade de zeros para o preenchimento do número da RA nos IDs das RAs"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "A lista de locais de amostragem a partir dos quais esta amostra pode ser coletada. Se nenhum local de amostragem for selecionado, então todos os locais de amostragem estarão disponíveis."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "A lista de tipos de amostras que podem ser coletadas neste local de amostragem. Se nenhum tipo de amostra for selecionado, então todos os tipos estão disponíveis."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "As unidades de medida para os resultados deste serviço de análise, por exemplo mg/l, ppm, dB, mV, etc."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr "O método %s não é válido: nenhuma entrada manual permitida e nenhum instrumento atribuído"
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr "O método %s não é válido: somente a entrada pelo instrumento para essa análise é permitida, mas o método não possui nenhum instrumento atribuído"
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "O mínimo volume de amostra necessário para a análise, exemplo '10 ml' ou '1 kg'."
 
@@ -5407,7 +5365,7 @@ msgstr "O número de dias antes que uma senha expire. O número '0' desabilita a
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "O número de dias antes que uma amostra expire e não possa mais ser analisada. Esta configuração pode ser definida por tipo individual de amostra"
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr "O número de dias entre viagens de campo recorrentes"
@@ -5424,11 +5382,11 @@ msgstr "Número de requisições e análises"
 msgid "The number of requests and analyses per client"
 msgstr "Número de requisições e análises por cliente"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "O percentual usado para calcular o preço para análises nesta prioridade"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "O período no qual amostras não preservadas deste tipo podem ser mantidas antes que expirem e não mais possam ser analisadas"
 
@@ -5445,19 +5403,19 @@ msgstr "A pessoa do fornecedor que executou a tarefa"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "A pessoa do fornecedor que aprovou o certificado"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "O preço cobrado a clientes qualificados para descontos por volume"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "ID comercial do perfil para fins contábeis."
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "A palavra-chave do perfil é usada unicamente para identificá-lo em arquivos de importação. Ela deve ser única e não pode ser a mesma usada em campos interinos de cálculos."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "O código de referência emitido pelo órgão de certificação."
 
@@ -5465,11 +5423,11 @@ msgstr "O código de referência emitido pelo órgão de certificação."
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr "O resultado após o cálculo foi realizado com valores de teste. Você precisará salvar o cálculo antes que esse valor seja calculado."
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "Os resultados para os serviços de análise que usam este método podem ser definidos manualmente"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Os resultados das análises de campo que são capturados no local de amostragem, como a temperatura de uma amostra de água de um rio onde a amostra foi tomada. As análises são feitas no laboratório."
 
@@ -5477,7 +5435,7 @@ msgstr "Os resultados das análises de campo que são capturados no local de amo
 msgid "The room and location where the instrument is installed"
 msgstr "A sala e local onde os instrumentos estão instalados"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "Os instrumentos selecionados têm suporte para este método. Use a visualização de editar instrumento para designar o método para um instrumento específico"
 
@@ -5489,11 +5447,11 @@ msgstr "A página de destino selecionada é exibida para usuários não autentic
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "O número de série que identifica, de forma única, o instrumento."
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "ID de protocolo de serviço analítico"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "ID serviço do perfil para fins contábeis."
 
@@ -5501,19 +5459,19 @@ msgstr "ID serviço do perfil para fins contábeis."
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "A configuração padrão para todo o sistema que define se anexos são requeridos, permitidos ou não por requisição de análise"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr "Os testes desse tipo de análise podem ser realizados usando mais de um método com a opção \"Entrada manual de resultados\" ativada. Uma lista de seleção com os métodos selecionados aqui é preenchida na exibição de resultados de gerenciamento para cada teste desse tipo de análise. Observe que somente os métodos com a opção 'Permitir entrada manual' ativada são exibidos aqui; Se você deseja que o usuário seja capaz de atribuir um método que requer a entrada do instrumento, habilite a opção 'Instrumento atribuído é permitida'."
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr "O número total de recipientes incluídos na Rodada."
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "O tempo de processamento das análises."
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "O tempo de processamento das análises exibido em um período."
 
@@ -5525,7 +5483,7 @@ msgstr "Tempo de processamento das análises"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "O tempo de processamento das análises exibido em um período."
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "A palavra-chave única usada para identificar o serviço de análise em arquivos de importação ou em requisições de análise em grandes volumes e resultados importados dos instrumentos. Também usada para identificar serviços dependentes de análises em resultados de cálculos definidos por usuários"
 
@@ -5537,37 +5495,37 @@ msgstr "Sem resultados"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr "Essas razões serão exibidas para sua seleção durante o processo de rejeição."
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "Estes resultados podem ser reportados como matéria seca"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "Estes resultados tem sido retirados e estão aqui listados para propósitos de rastreabilidade. Por favor, siga o enlace para retestar"
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "Este pedido de análise foi gerado automaticamente devido à retratação da requisição de análise ${retracted_request_id}."
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "Esta requisição de análise foi retirada e é exibida somente para propósito de rastreabilidade. ${retest_child_id}."
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "O Serviço de Análise não pode ser ativado pois seu cálculo está inativo."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "O Serviço de Análise não pode ser desativado pois um ou mais cálculos ativos o listam como dependência"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr "Este é o instrumento que o sistema atribuirá por padrão a testes desse tipo de análise na exibição de resultados de gerenciamento. O método associado a este instrumento será atribuído como o método padrão também. Observe que o método do instrumento prevalecerá sobre qualquer um dos métodos escolhidos se a opção 'A atribuição do instrumento não é necessária' estiver ativada."
 
@@ -5579,7 +5537,7 @@ msgstr "Este serviço não requer uma partição separada"
 msgid "This service requires a separate container."
 msgstr "Este serviço requer um recipiente separado."
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr "Este texto também é exibido ao passar o mouse sobre o campo Título"
 
@@ -5587,13 +5545,9 @@ msgstr "Este texto também é exibido ao passar o mouse sobre o campo Título"
 msgid "This text will be appended to results reports."
 msgstr "Este texto será incluído nos Laudos"
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "Este valor é reportado no final dos Laudos publicados"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr "Isso removerá todas as especificações de análise de cliente existentes e criará cópias de todas as especificações de laboratório. Você tem certeza de que quer fazer isso?"
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5607,63 +5561,63 @@ msgstr "Essa planilha foi rejeitada. A planilha de substituição é a de R $ {}
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "Dica. Documentos anexados não serão carregados a menos que eles estão presentes na instância."
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Título"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "Título do Local"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "Título da prateleira"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "Título do Site"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "Para"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "A Ser Preservado"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "A Ser Amostrado"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "A ser exibido abaixo de cada seção de Categoria de Análise nos Laudos."
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Para ser preservado"
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr "A ser publicado"
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Para ser amostrado"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "A verificar"
 
@@ -5675,13 +5629,13 @@ msgstr "Para testar o cálculo, insira aqui valores para todos os parâmetros de
 msgid "To:"
 msgstr "Para:"
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr "Poucas linhas no arquivo CSV"
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Total"
 
@@ -5689,22 +5643,22 @@ msgstr "Total"
 msgid "Total Lag"
 msgstr "Total Lag"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Preço Total"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "Total de análises"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "Total de pontos de dados"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Preço total"
 
@@ -5716,11 +5670,11 @@ msgstr "Total;"
 msgid "Traceability"
 msgstr "Rastreabilidade"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr "Transição feita."
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr "Transposto"
 
@@ -5728,61 +5682,55 @@ msgstr "Transposto"
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Ative se você quiser trabalhar com partições de amostra"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Tempo de processamento (h)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tipo"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "Erro de tipo"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr "Tipo de documento (por exemplo, manual do utilizador, especificações do instrumento, imagem, ...)"
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "Tipo de Local"
 
-msgid "Unable to apply the selected instrument"
-msgstr "Não é possível aplicar o instrumento selecionado"
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr "Não foi possível carregar os instrumentos: ${invalid_list}"
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "Não foi possível carregar o template"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "Incapaz de enviar um e-mail para alertar os contatos dos clientes do laboratório que a requisição de análise foi retratada: ${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Não designado"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Incerteza"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Valor de incerteza"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Indefinido"
 
@@ -5790,13 +5738,13 @@ msgstr "Indefinido"
 msgid "Unique ID"
 msgstr "ID único"
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Unidade"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "IBAN países desconhecidos %s"
 
@@ -5821,17 +5769,17 @@ msgstr "Usuário desvinculado e excluído"
 msgid "Unpublished"
 msgstr "Sem publicar"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "Formato do arquivo não reconhecido ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "Formato do arquivo não reconhecido ${fileformat}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr "Formato de arquivo não reconhecido ${format}"
 
@@ -5843,11 +5791,11 @@ msgstr "Desassociar"
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "Faça o upload de uma assinatura digitalizada a ser usada em Laudos impressos. O tamanho ideal é 250 pixels de largura por 150 pixels de altura"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "Limite de detecção mais baixo (UDL)"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "Use Perfil de Análise de Preço"
 
@@ -5855,7 +5803,7 @@ msgstr "Use Perfil de Análise de Preço"
 msgid "Use Dashboard as default front page"
 msgstr "Usar o Painel de Controle como página inicial padrão"
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "Usar cálculo padrão"
 
@@ -5867,13 +5815,13 @@ msgstr "Use servidor externo de ID"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Use este campo para passar parâmetros arbitrários aos módulos de importação/exportação."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Usuário"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Nome do usuário"
@@ -5886,7 +5834,7 @@ msgstr "Histórico de usuário"
 msgid "User linked to this Contact"
 msgstr "Usuário vinculado a este contato"
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "Históricos dos usuários"
@@ -5895,27 +5843,27 @@ msgstr "Históricos dos usuários"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "Usar muito poucos dados não faz sentido estatisticamente. Configure um número mínimo aceitável de resultados antes que as estatísticas de CQ possam ser calculadas e exibidas"
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "IVA"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% DE IVA"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Valor do IVA"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "Total de impostos"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Número do IVA"
 
@@ -5923,11 +5871,11 @@ msgstr "Número do IVA"
 msgid "Valid"
 msgstr "Válido"
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Válido de"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "Validado por"
 
@@ -5935,181 +5883,181 @@ msgstr "Validado por"
 msgid "Validate"
 msgstr "Validar"
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validação"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Validação falhou: '${keyword}': palavra-chave duplicada"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Validação falhou: '${title}': Esta palavra-chave já está em uso pelo cálculo  '${used_by}'"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Validação falhou: '${title}': Esta palavra-chave já está em uso pelo serviço  '${used_by}'"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Validação falhou: '${title}': título duplicado"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Validação falhou: '${value}' não é único"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Validação falhou: Direção deve ser E/W (Leste/Oeste)"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Validação falhou: Direção deve ser N/S (Norte/Sul)"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "Validação falhou: Percentual de erro deve estar entre 0 e 100"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "Falha de validação: valor de erro deve ser 0 ou maior"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "Falha de validação: valor de erro deve ser numérico"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "Validação falhou: Valores esperados devem estar entre os valores mínimo e máximo"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "Validação falhou: Valores esperados devem ser numéricos"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Validação falhou: '${keyword}' é inválida"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "Validação falhou: Valores máximos devem ser maiores que os valores mínimos"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "Validação falhou: Valores máximos devem ser numéricos"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "Validação falhou: Valores mínimos devem ser numéricos"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "Validação falhou: Percentuais de erro devem estar entre 0 e 100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "Validação falhou: Percentuais de erro devem ser numéricos"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "Validação falhou: recipientes pré-preservados devem ter uma preservação selecionada"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "Validação falhou: texto de resultado não pode estar em branco"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Validação falhou: Valores Resultantes devem ser números"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "Validação falhou: A seleção requer que as seguintes categorias sejam selecionadas: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "Falha de validação: Valores devem ser números"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "Validação falhou: o título da coluna  ${title}' deve ter a palavra-chave '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Validação falhou: graus são 180; minutos devem ser zero"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Validação falhou: graus são 180; segundos devem ser zero"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "Validação falhou: graus são 90; minutos devem ser zero"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "Validação falhou: graus são 90; segundos devem ser zero"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "Validação falhou: graus devem estar entre 0 e 180"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Validação falhou: graus devem estar entre 0 e 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Validação falhou: graus devem ser números"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "Validação falhou: a palavra-chave '${keyword}' deve ter o título da coluna  ${title}' "
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Validação falhou: palavra-chave contém caracteres inválidos"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "Validação falhou: palavra-chave requerida"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Validação falhou: minutos devem estar entre 0 e 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Validação falhou: minutos devem ser numéricos"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "Falha de validação: valores percentuais devem estar entre 0 e 100"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "Falha de validação: valores percentuais devem ser números"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Validação falhou: segundos devem estar entre 0 e 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Validação falhou: segundos devem ser numéricos"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "Validação falhou: título requerido"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr "Falha na validação: o valor deve estar entre 0 e 1000"
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr "Falha na validação: o valor deve ser flutuante"
 
@@ -6117,7 +6065,7 @@ msgstr "Falha na validação: o valor deve ser flutuante"
 msgid "Validation report date"
 msgstr "Data de validação do relatório"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Validador"
@@ -6128,12 +6076,12 @@ msgstr "Validador"
 msgid "Value"
 msgstr "Valor"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "Valores podem ser inseridos aqui os quais substituirão os predefinidos especificados nos Campos de Cálculo Provisório"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Verificado"
@@ -6144,7 +6092,7 @@ msgstr "Verificado"
 msgid "Verify"
 msgstr "Verificar"
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versão"
 
@@ -6154,11 +6102,11 @@ msgstr "Versão"
 msgid "Volume"
 msgstr "Volume"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "Endereço web para o órgão de certificação"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "Website."
 
@@ -6166,24 +6114,24 @@ msgstr "Website."
 msgid "Weekly"
 msgstr "Semanal"
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "Semanas para expirar"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "Quando definido, o sistema usa o preço do perfil de análise para cotar, e o IVA do sistema é substituído pelo IVA específico do perfil de análise"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "Quando os resultados de análises em duplicata nas planilhas, feitas a partir de uma mesma amostra, diferirem em mais do que este percentual, um alerta será gerado"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "Caracteres para interinos não são permitidos: ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "Performance de trabalho"
@@ -6194,25 +6142,25 @@ msgstr "Fluxo de trabalho"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Planilha"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Layout da Planilha"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Modelos de Planilhas"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Planilhas"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Tamanho de IBAN errado por %s: %s muito curto por %i"
 
@@ -6220,9 +6168,9 @@ msgstr "Tamanho de IBAN errado por %s: %s muito curto por %i"
 msgid "Yearly"
 msgstr "Anual"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Sim"
 
@@ -6234,7 +6182,7 @@ msgstr "Você não tem privilégios suficientes para gerenciar planilhas."
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "Você não tem privilegios suficientes para ver as planilhas ${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "Você deve designar esta requisição a um cliente"
 
@@ -6242,11 +6190,11 @@ msgstr "Você deve designar esta requisição a um cliente"
 msgid "You must select an instrument"
 msgstr "Você deve selecionar um instrumento"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "Você deve introduzir uma chave de resultado padrão."
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "ação"
 
@@ -6262,15 +6210,15 @@ msgstr "análises"
 msgid "analysis requests selected"
 msgstr "serviços de análises selecionados"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "e outros"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr "Atribuído"
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr "Anexo feito"
 
@@ -6293,7 +6241,7 @@ msgstr "bika-descrição-paginainicial"
 msgid "bika-frontpage-title"
 msgstr "bika-titulo-paginainicial"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "comentário"
 
@@ -6301,38 +6249,9 @@ msgstr "comentário"
 msgid "daily"
 msgstr "diariamente"
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "datalines"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr "Formato_de_data_longo"
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr "Formato_de_data_curto"
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-#, fuzzy
-msgid "date_format_short_datepicker"
-msgstr "Formato_de_data_curto_datepicker"
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6343,7 +6262,7 @@ msgstr "desativar"
 msgid "heading_arpriority"
 msgstr "cabecalho_prioridadera"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "inativo"
 
@@ -6392,19 +6311,19 @@ msgstr "descricao_nova_versao_disponivel"
 msgid "new_version_available_title"
 msgstr "titulo_nova_versao_disponivel"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr "de"
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr "aberto"
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr "outro_status"
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr "Publicados"
 
@@ -6412,19 +6331,19 @@ msgstr "Publicados"
 msgid "quarterly"
 msgstr "trimestral"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "repetindo todos"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "repetirperíodo"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr "amostra_devida"
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr "amostra_recebida"
 
@@ -6443,20 +6362,9 @@ msgstr "listagem_sumária_de_conteúdo"
 msgid "text_default_site_title"
 msgstr "texto_padrao_titulo_site"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
 msgstr "O número total de Pontos de Amostra definidos na Rodada."
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
-msgstr "formato_hora"
 
 #. Default: "Required"
 #: bika/lims/browser/templates/header_table.pt:39
@@ -6467,7 +6375,7 @@ msgstr "etiqueta_requerido"
 msgid "to"
 msgstr "para"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr "a_ser_verificado"
 
@@ -6475,7 +6383,7 @@ msgstr "a_ser_verificado"
 msgid "type"
 msgstr "tipo"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "até"
 
@@ -6501,7 +6409,7 @@ msgstr "valor"
 msgid "verification(s) pending"
 msgstr "Verificação(s) pendente"
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr "verificado"
 
@@ -6513,6 +6421,6 @@ msgstr "semanal"
 msgid "yearly"
 msgstr "anual"
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr "{} Semanas e {} dia(s)"

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/bikalabs/bika-lims/language/ro_RO/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} așteaptă conservarea."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} așteaptă să fie primite."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} invalidate."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} au fost create cu succes."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} așteaptă conservarea."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} așteaptă să fie primit."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} a fost creat cu succes."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Eroare"
 
@@ -96,15 +96,15 @@ msgstr "% Efectuat"
 msgid "% Published"
 msgstr "% Publicat"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s nu are coloana '%s'."
 
@@ -116,15 +116,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Gol)"
@@ -137,7 +137,7 @@ msgstr "(Control)"
 msgid "(Duplicate)"
 msgstr "(Duplicat)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Periculos)"
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr "(Necesar)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Max"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -211,17 +205,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -229,54 +223,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Nume cont"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Număr cont"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Tip cont"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Acreditare"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Acreditat"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Activ"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Adaugă"
 
@@ -324,11 +318,7 @@ msgstr "Adaugă referință de control"
 msgid "Add Duplicate"
 msgstr "Adaugă duplicat"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Adaugă șablon"
 
@@ -336,16 +326,16 @@ msgstr "Adaugă șablon"
 msgid "Add a remarks field to all analyses"
 msgstr "Adaugă un câmp de mențiuni pentru toate analizele"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Adaugă"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Mențiuni suplimentare:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adresă"
@@ -358,26 +348,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr "Rapoarte administrative"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "După ${end_date}"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Agenție"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Toate"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -389,7 +379,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Permite funcționarilor din laborator să creeze și să editeze clienți"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -397,15 +387,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -425,48 +415,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Calcul alternativ"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Cantitate"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analize"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -480,7 +470,7 @@ msgstr "Analize per serviciu"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -493,27 +483,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Analize repetate"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Analize retestate"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Analize care au fost retestate"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analiză"
 
@@ -521,52 +511,52 @@ msgstr "Analiză"
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Categorii analize"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Categorie analiză"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Cuvânt cheie analiză"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Profil analiză"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Profile analiză"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Cerere analiză"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID cerere analiză"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Cereri analize"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Serviciu analiză"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Servicii analize"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Specificație analiză"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Specificații analize"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Stare analiză"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Tip analiză"
@@ -641,46 +631,46 @@ msgstr "Tip analiză"
 msgid "Analysis category"
 msgstr "Categorie analiză"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Rezultate analiză"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -688,12 +678,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Serviciu analiză"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -709,17 +699,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analist"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr "Analistul trebuie specificat."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Orice"
 
@@ -740,7 +730,7 @@ msgstr "Aplică"
 msgid "Apply template"
 msgstr "Aplică șablon"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -758,15 +748,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Asignat"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Asignat la foaia de lucru"
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Atașează la"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Atașament"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Chei atașament"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Opțiune atașament"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Tip atașament"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Tipuri atașamente"
 
@@ -814,25 +804,25 @@ msgstr "Tipuri atașamente"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Atașamentul nu este permis"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Atașamentul este necesar"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Tip atașament"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Atașamente"
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Completare automată"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Import automat"
 
@@ -861,27 +851,27 @@ msgstr ""
 msgid "Available templates"
 msgstr "Șabloane disponibile"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr "Bază"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Lot"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "ID lot"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Etichete lot"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Loturi"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -922,7 +912,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -930,7 +920,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -938,63 +928,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Adresă facturare"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Gol"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Analize QC goale"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Marcă"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "De"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Calcul"
 
@@ -1002,8 +996,8 @@ msgstr "Calcul"
 msgid "Calculation Formula"
 msgstr "Formulă calcul"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1016,11 +1010,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Calcule"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Calibrare"
 
@@ -1032,12 +1026,12 @@ msgstr "Certificate calibrare"
 msgid "Calibration report date"
 msgstr "Dată raport calibrare"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Calibrator"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Anulat"
 
@@ -1069,18 +1063,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Capacitate"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Capturat"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr "Cardinal"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Număr catalog"
 
@@ -1097,17 +1091,17 @@ msgstr "Număr catalog"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Categorie"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1120,31 +1114,31 @@ msgstr "Cod certificat"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "Verifică dacă metoda a fost acreditată"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1152,7 +1146,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr "Oraș"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Clasic"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1188,19 +1182,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "Click pentru a descărca"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Client"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "ID lot client"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID client"
 
@@ -1208,59 +1202,59 @@ msgstr "ID client"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Nume client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Comandă client"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Număr comandă client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ref. client"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Referință client"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID client"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Clienți"
 
@@ -1269,39 +1263,39 @@ msgstr "Clienți"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Închis"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "Cod pentru locație"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "Cod pentru raft"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Virgulă (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Comentarii"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "ID comercial"
 
@@ -1309,21 +1303,21 @@ msgstr "ID comercial"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Compozit"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Nivel de încredere %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "Confirmă parola"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Contact"
@@ -1347,8 +1341,8 @@ msgstr "Contact"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Contacte"
@@ -1357,48 +1351,48 @@ msgstr "Contacte"
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Container"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Tip container"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Tipuri containere"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Containere"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Tip conținut"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "Tip conținut"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Control"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1414,12 +1408,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Copiază de la"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Număr"
 
@@ -1432,18 +1426,18 @@ msgstr "Țară"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "Creează o mostră nouă de acest tip"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Creat"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Creat de"
 
@@ -1451,7 +1445,7 @@ msgstr "Creat de"
 msgid "Created by:"
 msgstr "Creat de:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Autor"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Criterii"
 
@@ -1468,12 +1462,12 @@ msgstr "Criterii"
 msgid "Currency"
 msgstr "Monedă"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Curent"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Dată"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr "Data până când certificatul este valabil"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1624,11 +1618,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr "Data de emitere a certificatului de calibrare"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Zile"
 
@@ -1640,17 +1634,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Implicit"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1658,49 +1652,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Calcul implicit"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Container implicit"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Tip implicit container"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Instrument implicit"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Metodă implicită"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Conservare implicită"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Prioritate implicită?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Categorii implicite"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr "Format implicit notație științifică pentru rapoarte"
 msgid "Default scientific notation format for results"
 msgstr "Format implicit notație științifică pentru rezultate"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Valoare implicită"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1757,11 +1751,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1769,16 +1763,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1786,9 +1780,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Departament"
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Analize dependente"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Descriere"
 
@@ -1815,7 +1809,7 @@ msgstr "Descriere"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1823,19 +1817,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1851,16 +1845,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1872,7 +1866,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1881,8 +1875,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1891,54 +1885,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1951,20 +1945,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1998,35 +1992,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2034,7 +2028,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2073,16 +2067,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2090,15 +2084,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2106,7 +2100,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2114,45 +2108,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2161,19 +2155,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2181,44 +2175,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2226,19 +2216,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2277,18 +2267,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2298,7 +2288,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2310,37 +2300,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2349,8 +2339,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2358,31 +2348,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2394,7 +2384,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2430,7 +2420,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2452,7 +2442,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2461,8 +2451,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2471,7 +2461,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2479,7 +2469,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2487,30 +2477,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2534,7 +2521,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2547,17 +2534,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2587,19 +2574,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2685,24 +2672,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2710,43 +2694,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2756,7 +2740,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2764,12 +2748,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2778,47 +2762,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2854,7 +2838,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2904,41 +2888,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2999,16 +2983,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3016,31 +3000,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3049,14 +3027,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3064,30 +3042,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3123,9 +3101,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3133,17 +3111,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3155,8 +3133,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3164,27 +3142,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3225,17 +3203,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3274,23 +3252,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3298,7 +3276,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3328,7 +3306,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3338,16 +3316,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3365,25 +3343,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3454,15 +3429,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3551,7 +3523,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3576,16 +3548,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3632,31 +3601,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3678,7 +3647,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3686,19 +3655,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3721,16 +3690,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3758,7 +3727,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3766,12 +3735,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3814,14 +3783,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3829,34 +3798,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3894,34 +3863,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3929,7 +3898,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3944,21 +3913,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3993,23 +3962,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4031,9 +4000,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4041,11 +4010,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4086,16 +4055,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4104,7 +4073,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4112,21 +4081,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4169,7 +4138,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4177,7 +4146,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4186,8 +4155,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4210,14 +4179,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4242,7 +4211,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4250,7 +4219,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4259,15 +4228,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4275,26 +4244,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4302,13 +4271,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4316,15 +4285,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4354,7 +4323,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4362,11 +4331,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4375,14 +4344,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4434,19 +4403,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4468,12 +4437,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4538,9 +4507,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4588,30 +4557,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4620,62 +4589,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4700,17 +4669,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4718,16 +4687,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4767,7 +4736,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4779,11 +4748,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4791,19 +4760,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4849,7 +4818,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4909,32 +4878,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4942,31 +4907,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5024,14 +4985,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5039,41 +5000,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5081,33 +5042,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5115,37 +5076,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5249,7 +5207,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5257,12 +5215,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5270,19 +5228,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5294,7 +5252,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5311,24 +5269,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5345,27 +5303,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5389,7 +5347,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5427,19 +5385,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5447,11 +5405,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5459,7 +5417,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5483,19 +5441,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5507,7 +5465,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5519,37 +5477,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,12 +5527,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5589,63 +5543,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5671,22 +5625,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5698,11 +5652,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5772,13 +5720,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5837,7 +5785,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5849,13 +5797,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5868,7 +5816,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5877,27 +5825,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5905,11 +5853,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5917,181 +5865,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6110,12 +6058,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6126,7 +6074,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6136,11 +6084,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6148,24 +6096,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6176,25 +6124,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6202,9 +6150,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6216,7 +6164,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6224,11 +6172,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6244,15 +6192,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6273,7 +6221,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6281,36 +6229,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6322,7 +6242,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6370,19 +6290,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6390,19 +6310,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6421,19 +6341,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6445,7 +6354,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6453,7 +6362,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6478,7 +6387,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6490,6 +6399,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ru/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ru/LC_MESSAGES/bika.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Russian (http://www.transifex.com/bikalabs/bika-lims/language/ru/)\n"
@@ -30,49 +30,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} ожидаются на хранение."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} ожидается получение."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} недействительные."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} были успешно созданы."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -88,7 +88,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% ошибки"
 
@@ -102,15 +102,15 @@ msgstr "% Выполнено"
 msgid "% Published"
 msgstr "% Опубликовано"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr "%s отклонено"
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -122,15 +122,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Бланк)"
@@ -143,7 +143,7 @@ msgstr "(Контроль)"
 msgid "(Duplicate)"
 msgstr "(Повторно)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Опасный)"
 
@@ -152,32 +152,26 @@ msgid "(Required)"
 msgstr "(Требуется)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Мин."
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -188,16 +182,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Макс."
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -209,7 +203,7 @@ msgstr "Опции вложения AR"
 msgid "AR ID Padding"
 msgstr "Дополнительный ID ЗА"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Импорт ЗА"
 
@@ -217,17 +211,17 @@ msgstr "Импорт ЗА"
 msgid "AR Import options"
 msgstr "Параметры импорта ЗА"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "ЗА: Шаблоны"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -235,54 +229,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Имя учетной записи"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Номер счета"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Тип счета"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Аккредитация"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Аббревиатура органа аккредитации"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL-адрес органа аккредитации"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Аккредитация логотип"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Сылка на аккредитацию"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Аккредитованные"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -296,21 +290,21 @@ msgstr ""
 msgid "Activate"
 msgstr "Активировать"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Активные"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Добавить"
 
@@ -330,11 +324,7 @@ msgstr "Добавление ссылки на контроль"
 msgid "Add Duplicate"
 msgstr "Добавить повторный"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr "Добавить замечание"
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Добавить шаблон"
 
@@ -342,16 +332,16 @@ msgstr "Добавить шаблон"
 msgid "Add a remarks field to all analyses"
 msgstr "Добавить замечания ко всем анализам"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Добавить новый"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Дополнительные замечания:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Адрес"
@@ -364,26 +354,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr "Административные отчеты"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Все"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Все аккредитованные услуги на анализ находятся здесь."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Все назначенные анализы "
 
@@ -395,7 +385,7 @@ msgstr "Все анализы этого типа"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Разрешить Клерку Лаборатории создавать и редактировать клиентов"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "Разрешить ручной ввод определения лимитов"
 
@@ -403,15 +393,15 @@ msgstr "Разрешить ручной ввод определения лими
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Разрешить доступ к рабочим листам только для назначенных аналитиков"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -419,11 +409,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -431,48 +421,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Всегда расширять выбранные категории в представлениях клиента"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Количество"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Анализы"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Анализы, выходящие за допустимые пределы"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Анализы по типу образца "
@@ -486,7 +476,7 @@ msgstr "Анализы по службам"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -499,27 +489,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Повторный анализ"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Анализ"
 
@@ -527,52 +517,52 @@ msgstr "Анализ"
 msgid "Analysis Attachment Option"
 msgstr "Варианты вложений анализов"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Анализы: Категории"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Категория анализа"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Ключевые слова исследования"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Профиль анализа "
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Анализы: Профили"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID запроса на анализы"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Импорт запросов на анализ"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -580,65 +570,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Запрос на анализ"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr "Запросы на анализ к проверке"
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr "Запросы на анализ с ожиданием результата"
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Услуга по анализам"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Анализы: Услуги"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Анализы: Спецификации"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Тип анализа"
@@ -647,46 +637,46 @@ msgstr "Тип анализа"
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Запросы на анализ и анализы"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Запросы на анализ и анализы одного клиента"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Запросы на анализ без счета"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -694,12 +684,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Результаты анализа из лаборатории или из клиента в указанном диапазоне Обратите внимание, что это может занять несколько минут"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Сбросить спецификаций анализа к значениям по умолчанию лаборатории."
 
@@ -715,17 +705,17 @@ msgstr "Анализ затрат времени"
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Аналитик"
 
@@ -734,7 +724,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Любое"
 
@@ -746,7 +736,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "Применить шаблон"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -764,15 +754,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Назначен"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -790,27 +780,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Прикрепить к"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Вложение"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Кличи вложения"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Опции вложения"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Тип вложения"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Типы вложений"
 
@@ -820,25 +810,25 @@ msgstr "Типы вложений"
 msgid "Attachment due"
 msgstr "Ожидает назначения"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "Вложение не допускается"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Требуется вложение"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Вложения"
 
@@ -850,7 +840,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -867,27 +857,27 @@ msgstr ""
 msgid "Available templates"
 msgstr "Доступные шаблоны"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Отделение банка"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Название банка"
 
@@ -896,31 +886,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Пачка: Этикетки"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Подшипник"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Biannual"
 msgstr "Полугодие"
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -936,7 +926,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -944,63 +934,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Адрес для выставления счета"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Бланк"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Производитель(ТМ)"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Основная цена (без НДС)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "Рабочий телефон "
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "Копию контактам"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "Копия Emails"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Калькуляция"
 
@@ -1008,8 +1002,8 @@ msgstr "Калькуляция"
 msgid "Calculation Formula"
 msgstr "Формула вычисления"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Расчет временных полей"
@@ -1022,11 +1016,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Вычисления"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1038,12 +1032,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1057,9 +1051,9 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отменить"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "Отменено"
 
@@ -1075,18 +1069,18 @@ msgstr "Не удается отключить вычисление, так ка
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Емкость"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1095,7 +1089,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Номер по каталогу"
 
@@ -1103,17 +1097,17 @@ msgstr "Номер по каталогу"
 msgid "Categorise analysis services"
 msgstr "Категоризация аналитических услуг"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Категория"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Категория нельзя отключить, поскольку она содержит службы Analysis Services"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1126,31 +1120,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Пометить этот квадрат, если анализ включен в список аккредитованных анализов лаборатории "
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "Установите этот флажок, если проб, взятых в данный момент «композиционных» и положить вместе с более чем одной суб выборки, например несколько поверхности образцов от плотины смешиваться быть репрезентативной для плотины. По умолчанию флажок не установлен, указывает захватить образцов"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Этот флажок, если ваша лаборатория аккредитована"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1158,7 +1152,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1174,19 +1168,19 @@ msgstr ""
 msgid "City"
 msgstr "Город"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Классический"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1194,19 +1188,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Клиент"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID клиента"
 
@@ -1214,59 +1208,59 @@ msgstr "ID клиента"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Имя клиента"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Заказ клиента"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Ссылка Клиента"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Ссылка клиента "
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID Клиента"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr "Периодический отбор проб у клиента"
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Требуется контактное лицо Клиента для утверждения запроса"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Клиенты"
 
@@ -1275,39 +1269,39 @@ msgstr "Клиенты"
 msgid "Close"
 msgstr "Закрыть"
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Закрытые"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1315,21 +1309,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Составной"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Доверительный интервал%"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1338,13 +1332,13 @@ msgid "Confirm password"
 msgstr "Подтверждение пароля"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Контакт"
@@ -1353,8 +1347,8 @@ msgstr "Контакт"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr "Контакт деактивирован. Пользователь не может быть несвязанными."
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Контакты"
@@ -1363,48 +1357,48 @@ msgstr "Контакты"
 msgid "Contacts to CC"
 msgstr "Контакты в копию"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Контейнер"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Тип контейнера"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Контейнеры: Типы"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Контейнеры"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Тип содержимого"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Контроль"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1420,12 +1414,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "Копировать из"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "Копировать в новый"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1438,18 +1432,18 @@ msgstr "Страна"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1457,7 +1451,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1465,8 +1459,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1474,12 +1468,12 @@ msgstr ""
 msgid "Currency"
 msgstr "Валюта"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Текущий"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1492,7 +1486,7 @@ msgstr ""
 msgid "Daily"
 msgstr "Дневной"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1506,88 +1500,88 @@ msgstr "Интерфейс данных"
 msgid "Data Interface Options"
 msgstr "Настройки интерфейса данных"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Дата"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Дата направления"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Дата удаления"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Конечная дата"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Дата импорта"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Дата загрузки"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Дата открытия"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Дата публикации"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Дата получения"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Дата запроса"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Дата получения пробы"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr "Дата проверки"
 
@@ -1603,7 +1597,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1621,7 +1615,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1630,11 +1624,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Дни"
 
@@ -1646,17 +1640,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr "Отключить"
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1664,49 +1658,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1715,11 +1709,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1743,11 +1737,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Значение по умолчанию"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1755,7 +1749,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1763,11 +1757,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1775,16 +1769,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Градусы"
 
@@ -1792,9 +1786,9 @@ msgstr "Градусы"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Подразделение"
 
@@ -1807,13 +1801,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Анализы подразделения"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "Описывает метод в терминах, понятных для неспециалиста. Эта информация становится доступной для клиентов лаборатории"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Описание"
 
@@ -1821,7 +1815,7 @@ msgstr "Описание"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1829,19 +1823,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1849,7 +1843,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "% скидки"
 
@@ -1857,16 +1851,16 @@ msgstr "% скидки"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Отправлено"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Отобразить значение"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1878,7 +1872,7 @@ msgstr "Оповещать о выходе новых версий Bika LIMS"
 msgid "Display individual sample partitions "
 msgstr "Отображение отдельных партий образца"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1887,8 +1881,8 @@ msgstr ""
 msgid "Dispose"
 msgstr "Ликвидировать"
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Извлечено"
@@ -1897,54 +1891,54 @@ msgstr "Извлечено"
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Отложенный"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1957,20 +1951,20 @@ msgstr "Сухое"
 msgid "Dry matter analysis"
 msgstr "Анализ для сухого вещества"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Ожидается"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Дата ожидания"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1979,20 +1973,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Дубликат"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -2004,35 +1998,35 @@ msgstr "Дублировать анализа КК"
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Продолжительность"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Например SANAS, APLAC и т.д."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Earliness"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Высота"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Отправить по электронной почте"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Адрес электронной почты"
 
@@ -2040,7 +2034,7 @@ msgstr "Адрес электронной почты"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Строка темы электронной почты"
 
@@ -2060,14 +2054,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2079,16 +2073,16 @@ msgstr "Введите имя пользователя, обычно что-то
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Введите адрес электронной почты. Это необходимо в случае утери пароля. Мы уважаем вашу частную жизнь и не будет передавать адреса третьим лицам."
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "Введите процентное значение скидки"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "Введите процентное значение напр. 14,0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2096,15 +2090,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Введите процентное значение напр. 14.0. Это процент всей прикладной системе но может быть переписан для отдельных элементов"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "Введите значение  процента напр. 33,0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Введите Образец точки широты в 0-90 градусов, минут 0-59, секунд-0-59 и N/S индикатор"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2112,7 +2106,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2120,45 +2114,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Исключить из счета"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Ожидаемый результат"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2167,19 +2161,19 @@ msgstr ""
 msgid "Expire"
 msgstr "Просрочен"
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Срок действия истек"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Дата истечения срока действия"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2187,44 +2181,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Факс"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Факс (рабочий)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Женский"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Поле"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Анализы \"в поле\""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Название поля"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Файл"
 
@@ -2232,19 +2222,19 @@ msgstr "Файл"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Имя файла"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2264,16 +2254,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Имя"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Формула"
 
@@ -2283,18 +2273,18 @@ msgstr "Формула"
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Полное имя"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2304,7 +2294,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Приветствие напр. Г-Н, миссис, Dr"
 
@@ -2316,37 +2306,37 @@ msgstr "Группировка аналитических услуг в табл
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Опасные"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Часы"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2355,8 +2345,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "URL-адрес ID-сервера "
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID-сервер не доступен"
 
@@ -2364,31 +2354,31 @@ msgstr "ID-сервер не доступен"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2400,7 +2390,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2408,27 +2398,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "Если необходимо, здесь вы можете выбрать расчёт для анализа. Расчёты можно настроить в разделе \"Расчёты\" в панели настроек LIMS"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2436,7 +2426,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2449,7 +2439,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "Если флажок не установлен, аналитики будут иметь доступ ко всем рабочим листам."
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "Импорт"
@@ -2458,7 +2448,7 @@ msgstr "Импорт"
 msgid "Import Analysis Request Data"
 msgstr "Импорт запросов на анализ"
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Импортированно"
@@ -2467,8 +2457,8 @@ msgstr "Импортированно"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Неактивные"
@@ -2477,7 +2467,7 @@ msgstr "Неактивные"
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2485,7 +2475,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr "Включить и отображать информацию о ценах"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Включить описания"
 
@@ -2493,30 +2483,27 @@ msgstr "Включить описания"
 msgid "Include year in ID prefix"
 msgstr "Включить год в префикс Идентификатора"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Неопределенный результат"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Первоначальная редакция"
 
@@ -2540,7 +2527,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2553,17 +2540,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Инструмент"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2576,16 +2563,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2593,19 +2580,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Оборудование: Типы"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2649,9 +2636,9 @@ msgstr "Тип инструмента"
 msgid "Instrument's calibration certificate expired:"
 msgstr "Сертификат калибровки прибора истек:"
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Оборудование"
 
@@ -2675,7 +2662,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2691,24 +2678,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "Недействительный"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2716,43 +2700,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr "Недействительный"
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Исключить счета"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Элемент неактивен."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "Пункты для включения в теме письма"
 
@@ -2762,7 +2746,7 @@ msgstr "Пункты для включения в теме письма"
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Название должности"
 
@@ -2770,12 +2754,12 @@ msgstr "Название должности"
 msgid "Key"
 msgstr "Ключ"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Ключевое слово"
@@ -2784,47 +2768,47 @@ msgstr "Ключевое слово"
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Лаборатория"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Лабораторные анализы"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Лаборатория: Контакты"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Лаборатория: Департаменты"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Лаборатория: Расходные матриалы"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL-адрес лаборатории"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Лаборатория"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Аккредитованные лаборатории"
 
@@ -2844,13 +2828,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Последнее изменение:"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Отложить"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Отложенные анализы"
@@ -2860,7 +2844,7 @@ msgstr "Отложенные анализы"
 msgid "Late Analysis"
 msgstr "Отложенный анализ"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Широта"
 
@@ -2882,11 +2866,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Связанные образцы"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr "Перечень типов удостоверений личности"
 
@@ -2898,7 +2882,7 @@ msgstr "Список всех образцов полученные в пери�
 msgid "Load Setup Data"
 msgstr "Данные настройки загрузки"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Загрузить документы, описывающие метод "
 
@@ -2910,41 +2894,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Журнал"
@@ -2969,35 +2953,35 @@ msgstr "Ошибка входа. Ваш Логин был деактивиров
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Долгота"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Номер лота"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Почтовый адрес"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Мужской"
 
@@ -3005,16 +2989,16 @@ msgstr "Мужской"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Менеджер"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "электронная почта менеджера"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Телефон менеджера"
 
@@ -3022,31 +3006,25 @@ msgstr "Телефон менеджера"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Производитель"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Производители"
 
@@ -3055,14 +3033,14 @@ msgstr "Производители"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Макс"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Максимальное время"
 
@@ -3070,30 +3048,30 @@ msgstr "Максимальное время"
 msgid "Maximum columns per results email"
 msgstr "Максимальная столбцов на результаты для электронной почты"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Максимально возможный размер или количество образцов."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Максимальное время"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Членская скидка %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Член скидка распространяется"
 
@@ -3102,22 +3080,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Метод"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Документация к методу"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Инструкции к методу"
 
@@ -3129,9 +3107,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Методы"
 
@@ -3139,17 +3117,17 @@ msgstr "Методы"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Методы, включенные в ${accreditation_body} аккредитации для этой лаборатории. Анализ замечаний не аккредитованы"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3161,8 +3139,8 @@ msgstr "Мои"
 msgid "Minimum 5 characters."
 msgstr "Минимум 5 символов."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3170,27 +3148,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Минуты"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Телефон мобильный"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Модель"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3204,7 +3182,7 @@ msgstr "Месячный"
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3216,13 +3194,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "Имя"
 
@@ -3231,17 +3209,17 @@ msgstr "Имя"
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3257,18 +3235,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Не было выбрано ни одного анализа"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3280,23 +3258,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3304,7 +3282,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3316,17 +3294,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3334,7 +3312,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3344,16 +3322,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3371,25 +3349,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "Не допускается"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3409,19 +3384,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "Кол-во столбцов"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3429,30 +3404,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3460,15 +3435,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3477,31 +3452,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Количество образцов"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3509,15 +3484,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Только менеджеры лаборатории могут создавать и управлять рабочими листами"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Открытые"
@@ -3530,26 +3502,26 @@ msgstr "Свободное WEB-ориентированная Лаборатор
 msgid "Order"
 msgstr "Заказ"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Дата заказа"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "КОД заказа"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Номер заказа"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Заказы"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3557,7 +3529,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3569,8 +3541,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3582,16 +3554,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3612,8 +3581,8 @@ msgstr "Пароль"
 msgid "Password lifetime"
 msgstr "Время существования пароля"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Ожидание"
@@ -3638,31 +3607,31 @@ msgstr ""
 msgid "Period"
 msgstr "Период"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "Допускается"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "Допустимое отклонение %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Телефон"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Телефон (рабочий)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Телефон (домашний)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Телефон (моб.)"
 
@@ -3675,8 +3644,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Физический адрес"
 
@@ -3684,7 +3653,7 @@ msgstr "Физический адрес"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3692,19 +3661,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Место отбора пробы"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3713,13 +3682,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Почтовый адрес"
 
@@ -3727,16 +3696,16 @@ msgstr "Почтовый адрес"
 msgid "Postal code"
 msgstr "Почтовый индекс"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3764,7 +3733,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3772,12 +3741,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr "Префиксы"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3789,17 +3758,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Сохранение"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3810,7 +3779,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Образец: Хранение"
 
@@ -3820,14 +3789,14 @@ msgstr "Образец: Хранение"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3835,34 +3804,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Цена"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Цена (без НДС)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Цена без НДС"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Прейскурант для"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Прейскуранты"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3877,13 +3846,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3900,34 +3869,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr "Профессиональная открытая ЛИМС/ЛИС"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Профиль"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Аналитический профиль"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Профиль ключ"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Ключевые слова профиля"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Профили"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3935,7 +3904,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3950,21 +3919,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Опубликовано"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3977,8 +3946,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3999,23 +3968,23 @@ msgstr "Количество"
 msgid "Quarterly"
 msgstr "Квартальный"
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Диапазон Макс"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Диапазон мин"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4037,9 +4006,9 @@ msgstr "Получить"
 msgid "Receive sample"
 msgstr "Получить образец"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Получено"
 
@@ -4047,11 +4016,11 @@ msgstr "Получено"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr "Ожидают прием"
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4060,31 +4029,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Эталон"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Определение эталона"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Эталон: Определения"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Образцы эталона"
 
@@ -4092,16 +4061,16 @@ msgstr "Образцы эталона"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Тип эталона"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "Стандартные анализы СК"
@@ -4110,7 +4079,7 @@ msgstr "Стандартные анализы СК"
 msgid "Reference analysis quality control graphs"
 msgstr "Стандартный анализ качества контрольный график"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4118,21 +4087,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr "Эталонный образец"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Значения эталонного образца 0 или \"пусто\""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "ReferenceDefinition представляет определение эталона или тип образца, используемые для проверки службой качества"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4155,8 +4124,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4165,9 +4134,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Замечания"
 
@@ -4175,7 +4144,7 @@ msgstr "Замечания"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4183,7 +4152,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4192,8 +4161,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4202,7 +4171,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Отчет"
 
@@ -4216,14 +4185,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Отчет на сухое вещество"
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4256,7 +4225,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4265,15 +4234,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID Запроса"
 
@@ -4281,26 +4250,26 @@ msgstr "ID Запроса"
 msgid "Request new analyses"
 msgstr "Запросить новые анализы"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Запросы"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Требуется"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Требуемый объем"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4308,13 +4277,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Результат"
 
@@ -4322,15 +4291,15 @@ msgstr "Результат"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Параметры результата"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Значение результата"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4348,11 +4317,11 @@ msgstr "Результат за пределами допустимого диа
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4360,7 +4329,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4368,11 +4337,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr "Ожидают результатов"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4381,14 +4350,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Повторный анализ"
@@ -4407,11 +4376,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4427,12 +4396,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Приветствие"
 
@@ -4440,19 +4409,19 @@ msgstr "Приветствие"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "То же, что и предыдущее, только устанавливает умолчания для услуг по анализам. Установки отдельно по анализам в могут быть настроены в их полях конфигурации."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Образец"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "Образец: Условия"
 
@@ -4461,8 +4430,8 @@ msgid "Sample Due"
 msgstr "Образец ожидается"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "Образец ID"
 
@@ -4474,12 +4443,12 @@ msgstr "Дополнение к ID образца"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Образец: Матрицы"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4489,52 +4458,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Место взятия образца"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Образец: Места сбора"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Тип образца"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Тип префикса образца"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Образец: Типы"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4544,9 +4513,9 @@ msgstr ""
 msgid "Sample due"
 msgstr "Образец ожидается"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4574,17 +4543,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4594,30 +4563,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Пробоотборщик"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Образцы"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "С образцами этого типа следует обращаться как с опасными"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4626,62 +4595,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Дата отбора"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "Отбор проб: Отклонения"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Частота взятия образца"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr "Периодический отбор проб: Шаблоны"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr "Периодический отбор проб: Приоритеты"
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr "Периодические отборы проб: Шаблон"
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr "Дата отбора"
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4691,9 +4660,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Сохранить"
 
@@ -4706,17 +4675,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4724,16 +4693,16 @@ msgstr ""
 msgid "Search"
 msgstr "Поиск"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Секунд"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4745,11 +4714,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Выберете интерфейс данных"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4757,11 +4726,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Выберете позицию назначения и ЗА для дублирования"
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "Выберите менеджера из списка доступных сотрудников, созданного в разделе настройки \"lab contacts\". На менеджеров подразделений ссылаются отчеты о результатах анализов, содержащие анализы, произведенные в их подразделениях."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4773,7 +4742,7 @@ msgstr "Выделить все элементы"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4785,11 +4754,11 @@ msgstr "Выбор аналитика"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Выберите, если анализы будут исключены из счета"
 
@@ -4797,19 +4766,19 @@ msgstr "Выберите, если анализы будут исключены 
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Выберите, если описания должны быть включены"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4835,7 +4804,7 @@ msgstr "Выберите страну, сайт будет отображать 
 msgid "Select the currency the site will use to display prices."
 msgstr "Выберите валюту, сайт будет использовать для отображения цены."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Выберите предпочтительный инструмент"
 
@@ -4855,7 +4824,7 @@ msgstr "Выберите предпочтительный инструмент"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4879,7 +4848,7 @@ msgstr "Выберите эту опцию, чтобы активировать 
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Выберете, какие анализы должны быть включены в Журнал"
 
@@ -4895,7 +4864,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4907,7 +4876,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4915,32 +4884,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "Серийный номер"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Услуга"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Услуги"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4948,31 +4913,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "Установите максимальное число запросов на анализы в электронном письме с результатами. Некоторым клиентам, предпочитающим небольшое количество колонок в письме, сложно читать слишком большое количество колонок. "
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Настройка лаборатории службы результаты анализа спецификации"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Адрес доставки"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4988,7 +4953,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -5000,29 +4965,25 @@ msgstr "Показать/скрыть график"
 msgid "Signature"
 msgstr "Подпись"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Размер"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5030,14 +4991,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5045,41 +5006,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "Установить размер Журнала, например соответственно специфическому размеру кюветы инструмента. Затем выберете \"тип\" анализа по позициям журнала. Когда выбраны образцы СК, также выберете, какой эталонный образец должен использоваться. Если выбран повторный анализ, отразите какая позиция образца должна быть скопирована"
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Статус"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr "Заявки"
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Статус"
 
@@ -5087,33 +5048,33 @@ msgstr "Статус"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "Места хранения проб"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "Образец: Подгруппы"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Отправить"
 
@@ -5121,37 +5082,34 @@ msgstr "Отправить"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "Предоставьте валидный файл Open XML (.xlsx), содержащий настройки для Bika."
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr "Утвердить импорт ЗА"
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Итого"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Поставщик"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Поставщики"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Фамилия"
 
@@ -5171,11 +5129,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr "Системная панель"
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5184,20 +5142,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Техническое описание и инструкции, предназначенные для аналитиков"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Температура"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5215,35 +5173,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "веб-адрес лаборатория "
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Стандарт аккредитации , который применяется, например, ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Анализы, включенные в этот профиль, сгруппированных по категориям"
 
@@ -5255,7 +5213,7 @@ msgstr "Анализ, который будет использоваться д�
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5263,12 +5221,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Вложения, связанные с запросами анализа и анализами"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5276,19 +5234,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5300,7 +5258,7 @@ msgstr "Процент скидки введен здесь, применяет�
 msgid "The full URL: http://URL/path:port"
 msgstr "Полный URL-адрес: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5317,24 +5275,24 @@ msgstr "Номер модели инструмента"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Лаборатория не аккредитована, или аккредитация не был настроена. "
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Департамент лаборатории "
@@ -5351,27 +5309,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Единицы измерения для этой службы анализа ' результаты, например мг/л, ppm, дБ, МВ, и т.д."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5395,7 +5353,7 @@ msgstr "Количество дней до истечения срока дей�
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "Количество дней до того, как образец будет просрочен и не может быть проанализирован. Этот параметр может быть перезаписан каждый тип отдельных образцов в типы Установка образцов"
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5412,11 +5370,11 @@ msgstr "Количество запросов и анализов"
 msgid "The number of requests and analyses per client"
 msgstr "Количество запросов и анализа на одного клиента"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5433,19 +5391,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "Профиль ключевое слово используется для уникальной идентификации в файлы импорта. Он должен быть уникальным, и он не может быть таким же, как поля Код любых временных вычислений."
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Код ссылки, выданного органом аккредитации лаборатории"
 
@@ -5453,11 +5411,11 @@ msgstr "Код ссылки, выданного органом аккредит�
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "Результаты анализов поля фиксируются во время отбора проб на контрольной точке, например температура образца воды в реке, где пробы отбирались. Лабораторные анализы проводятся в лаборатории"
 
@@ -5465,7 +5423,7 @@ msgstr "Результаты анализов поля фиксируются в
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5477,11 +5435,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Серийный номер, который однозначно идентифицирует инструмент"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5489,19 +5447,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "Конфигурация системы по умолчанию для обозначения вложенных файлов должны ли, разрешенных или не одного анализа запроса"
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5513,7 +5471,7 @@ msgstr "Установленные сроки анализов"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "Уникальное ключевое слово используется для идентификации услуг по анализам в файлах импорта ЗА (запросов на анализ) и импорта результатов, полученных из оборудования. Он также используется для идентификации услуг по анализу при составлении формулы расчетов (вычисления) определенных пользователем."
 
@@ -5525,37 +5483,37 @@ msgstr "Нет никаких результатов."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Услуга по анализу не может быть активирована, т.к. ее вычисление не задано"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Услуга по анализу не может быть деактивирована, т.к. она используется для некоторых вычислений"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5567,7 +5525,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5575,12 +5533,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5595,63 +5549,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Название"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Должны быть сохранены"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Ожидаемый образец"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Должны быть сохранены"
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr "Будет опубликовано"
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Ожидаемые образцы"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "На проверку"
 
@@ -5663,13 +5617,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Итого"
 
@@ -5677,22 +5631,22 @@ msgstr "Итого"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Полная стоимость"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Полная стоимость"
 
@@ -5704,11 +5658,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5716,61 +5670,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "Включите это, если вы хотите работать с раздельными партиями образца"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Тип"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Неопределенность"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Значение неопределенности"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5778,13 +5726,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Единица"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5809,17 +5757,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5831,11 +5779,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5843,7 +5791,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5855,13 +5803,13 @@ msgstr "Использовать внешний ID сервер"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "Используйте это поле для передачи произвольных параметров для экспорта / импорта модулей."
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Пользователь"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Имя пользователя"
@@ -5874,7 +5822,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5883,27 +5831,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "НДС"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% НДС"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Количество НДС"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "номер НДС"
 
@@ -5911,11 +5859,11 @@ msgstr "номер НДС"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Действительно с"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5923,181 +5871,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Ошибка контроля данных: Bearing must be E/W"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Ошибка контроля данных: Bearing must be N/S"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Ошибка контроля данных: значение результата должно быть числовым"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "Ошибка контроля данных: значение минут должно быть числовым"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "Ошибка контроля данных: значение градусов равно 180; секунды должны быть равны нулю."
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Ошибка контроля данных: градус должен быть от 0 до 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Ошибка контроля данных: значение градусов должно быть числовым"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Ошибка контроля данных: ключевое слово содержит недопустимые символы"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Ошибка контроля данных: значение минут должно быть от 0 до 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Ошибка контроля данных: значение минут должно быть числовым"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Ошибка контроля данных: значение секунд должно быть от 0 до 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Ошибка контроля данных: значение секунд должно быть числом"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6105,7 +6053,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6116,12 +6064,12 @@ msgstr ""
 msgid "Value"
 msgstr "Значение"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Проверено"
@@ -6132,7 +6080,7 @@ msgstr "Проверено"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Версия"
 
@@ -6142,11 +6090,11 @@ msgstr "Версия"
 msgid "Volume"
 msgstr "Объём"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6154,24 +6102,24 @@ msgstr ""
 msgid "Weekly"
 msgstr "Недельный"
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6182,25 +6130,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Рабочий лист: Шаблоны"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Рабочие листы"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6208,9 +6156,9 @@ msgstr ""
 msgid "Yearly"
 msgstr "Годовой"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6222,7 +6170,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6230,11 +6178,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Вы должны выбрать инструмент"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6250,15 +6198,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr "Ожидают назначения"
 
@@ -6279,7 +6227,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6287,36 +6235,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6328,7 +6248,7 @@ msgstr "отключить"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr "Неактивные"
 
@@ -6376,19 +6296,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr "Открыто"
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr "Другой статус"
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr "Опубликовано"
 
@@ -6396,19 +6316,19 @@ msgstr "Опубликовано"
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr "Ожидание образца"
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr "Образец принят"
 
@@ -6427,19 +6347,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr "На проверку"
 
@@ -6459,7 +6368,7 @@ msgstr "На проверку"
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6484,7 +6393,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr "Проверено"
 
@@ -6496,6 +6405,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/sv/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/sv/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Swedish (http://www.transifex.com/bikalabs/bika-lims/language/sv/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ta/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ta/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Tamil (http://www.transifex.com/bikalabs/bika-lims/language/ta/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/te_IN/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/te_IN/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Telugu (India) (http://www.transifex.com/bikalabs/bika-lims/language/te_IN/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/bika.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/bikalabs/bika-lims/language/tr_TR/)\n"
@@ -27,49 +27,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "Sayın, ${contact_fullname} LIMS girişi için kullanıcı adınız: ${contact_username} Kullanıcılar şifrelerini kendileri değiştirmelidir. Şifrenizi unutursanız giriş formundaki yeni şifre bağlantısını kullanabilirsiniz."
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "Muhafaza altına alan ve muhafaza altına alınma tarihi eksik olan numuneler: ${items}"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} muhafaza için bekliyor."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} alınmayı bekliyor."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} için validasyon yapılmadı."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} başarılı şekilde oluşturuldu."
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: bölümler alınmayı bekliyor."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "Muhafaza altına alan ve muhafaza altına alınma tarihi eksik olan numune: ${item}"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${items} muhafaza için bekliyor."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${items} alınmayı bekliyor."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} başarılı şekilde oluşturuldu."
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} alınmayı bekliyor."
 
@@ -85,7 +85,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% Hata"
 
@@ -99,15 +99,15 @@ msgstr "Yapılan %"
 msgid "% Published"
 msgstr "Yayınlanan %"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s için '%s' kolonu bulunamadı."
 
@@ -119,15 +119,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'Profil' seçeneğinde, çoklu analiz hizmeti seçmek için analiz profili anahtar sözcükleri kullanılmalıdır. 'Klasik' terimi analiz hizmeti seçimi ve her bir numune için analiz talebi girişini belirtir."
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Kör)"
@@ -140,7 +140,7 @@ msgstr "(Kontrol)"
 msgid "(Duplicate)"
 msgstr "(Tekerrür)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(Tehlikeli)"
 
@@ -149,32 +149,26 @@ msgid "(Required)"
 msgstr "(Gerekli)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "Bu önceliğin listelenmesinde 16x16 piksellik simge kullanılıyor."
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "Bu önceliğin incelenmesinde 32x32 piksellik simge kullanılıyor."
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< Min"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -185,16 +179,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> Maks"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "AT ${ar_number}"
 
@@ -206,7 +200,7 @@ msgstr "Analiz Talebi Eklenti Seçeneği"
 msgid "AR ID Padding"
 msgstr "Analiz Talebi ID Kodlama"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Analiz Taleplerini İçe Aktarma"
 
@@ -214,17 +208,17 @@ msgstr "Analiz Taleplerini İçe Aktarma"
 msgid "AR Import options"
 msgstr "Analiz Talebi İçe Aktarma seçenekleri"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "AT Şablonlar"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "Yeniden test edilenlerin sonuçları için AT'ler"
 
@@ -232,54 +226,54 @@ msgstr "Yeniden test edilenlerin sonuçları için AT'ler"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "AT'ler: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Hesap Adı"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Hesap No"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Hesap Tipi"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Akreditasyon"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Akreditasyon Kurumu Kısaltması"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "Akreditasyon Kurumu Linki"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "Akreditasyon Logosu"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Akreditasyon Referansı"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "Akreditasyon sayfa başlığı"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Akredite Edilmiş"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -293,21 +287,21 @@ msgstr "Kullanıcılar (ya da tek bir kullanıcı) tarafından belirli bir zaman
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Etkin"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "Ad-Hoc"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Ekle"
 
@@ -327,11 +321,7 @@ msgstr "Kontrol Referans Ekle"
 msgid "Add Duplicate"
 msgstr "Tekerrür Ekle"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "Şablon Ekle"
 
@@ -339,16 +329,16 @@ msgstr "Şablon Ekle"
 msgid "Add a remarks field to all analyses"
 msgstr "Tüm analizler için açıklama alanı ekle"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "Yeni ekle"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "Daha detaylı yorum:"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "Adres"
@@ -361,26 +351,26 @@ msgstr "ID ön ekinden sonra iki basamaklı yıl bilgisi ekler"
 msgid "Administrative Reports"
 msgstr "İdari Raporlar"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "${end_date} Sonrası"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "Kurum"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Tümü"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "Tüm akredite analiz hizmetleri burada listelenmiştir."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Tüm analizler sevk edildi"
 
@@ -392,7 +382,7 @@ msgstr "Bu türdeki tüm analizler"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "Lab analistleri müşteri bilgileri ekleyip düzenleyebilsin"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -400,15 +390,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "Yalnızca atanmış analiste iş-emri dosyasına erişim ver"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -416,11 +406,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -428,48 +418,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "Alternatif Hesaplama"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "Müşteri ekranında seçili kategorileri her zaman genişletilmiş olarak göster"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "Miktar"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Analizler"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "Hata aralığındaki analizler"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Aralığın dışındaki analizler"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "Analiz hizmeti başına analizler"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Örnek türü başına analizler"
@@ -483,7 +473,7 @@ msgstr "Hizmet başına analizler"
 msgid "Analyses performed and published as % of total"
 msgstr "Analizlerin toplamda tamamlanan ve yayınlanan % değeri"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "Analizlerin toplamda tamamlanan % değeri"
 
@@ -496,27 +486,27 @@ msgstr "Analizlerin ilgili raporları"
 msgid "Analyses repeated"
 msgstr "Tekrarlanan analizler"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "Belirtilmiş aralık dışında sonuçlanan analizler"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "Tekrar test edilen analizler"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "Departman başına analizlerin özetleri"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "Yeniden test edilmiş analizler"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Analiz"
 
@@ -524,52 +514,52 @@ msgstr "Analiz"
 msgid "Analysis Attachment Option"
 msgstr "Analiz Eklenti Seçeneği"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Analiz Kategorileri"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Analiz Kategorisi"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Analiz Anahtar Kelimesi"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Analiz Profili"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "Analiz Profilleri"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "Analiz Talebi"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "Analiz Talep ID No"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Analiz Talebi Girişi"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "Analiz Talepleri Öncelikleri"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "Analiz Talepleri Özellikleri"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -577,65 +567,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Analiz Talepleri"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Analiz Hizmeti"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Analiz Hizmetleri"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "Analiz Özellikleri"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Analiz Özellikleri"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "Analiz Durumu"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "Analiz Türü"
@@ -644,46 +634,46 @@ msgstr "Analiz Türü"
 msgid "Analysis category"
 msgstr "Analiz Kategorisi"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "Analiz Talebi ${AR} oluşturuldu."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "Analiz talepleri ${ARs} oluşturuldu."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "Analiz talepleri ve analizler"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "Müşterilere göre analiz talepleri ve analizler"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "Faturalanmamış analiz talepleri"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "Hata aralığındaki analiz sonucu"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "Analiz sonuçları"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "${subject_parts} için analiz sonuçları"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "Analiz hizmeti ve örnekleme noktasına göre analiz sonuçları"
 
@@ -691,12 +681,12 @@ msgstr "Analiz hizmeti ve örnekleme noktasına göre analiz sonuçları"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "Sonuçları müşteri veya laboratuvar tarafından belirtilen aralığın dışında kalan analizler Not: bu işlem bir kaç dakika sürebilir"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "Analiz Hizmeti"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "Analiz özellikleri laboratuvar varsayılan değerlerine sıfırlanır."
 
@@ -712,17 +702,17 @@ msgstr "Analiz gerçekleştirme süresi"
 msgid "Analysis turnaround time over time"
 msgstr "Zamanla analizi gerçekleştirme süresi"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "Analiz gerçekleştirme süreleri"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "Zamanla analizi gerçekleştirme süreleri"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "Analist"
 
@@ -731,7 +721,7 @@ msgid "Analyst must be specified."
 msgstr "Analist belirtilmelidir."
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "Herhangi"
 
@@ -743,7 +733,7 @@ msgstr "Uygula"
 msgid "Apply template"
 msgstr "Şablonu uygula"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "Uygula"
 
@@ -761,15 +751,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Sevk Edildi"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "Çalışmaya sevk edildi"
 
@@ -787,27 +777,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "Ekle"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "Eklenti"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "Eklenti Tuşları"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "Eklenti Seçeneği"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "Eklenti Türü"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "Eklenti Türleri"
 
@@ -817,25 +807,25 @@ msgstr "Eklenti Türleri"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "İzin verilmeyen eklentiler"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "Eklenti gerekli"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "Eklenti türü"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "Eklentiler"
 
@@ -847,7 +837,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "Otomatik tamamla"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "Otomatik içe aktar"
 
@@ -864,27 +854,27 @@ msgstr "Otomatik etiket baskısı"
 msgid "Available templates"
 msgstr "Uygun şablonlar"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "Ortalama TAT"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "Ortalama zamanından önce"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "Ortalama zamanından sonra"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "Hatalı oluşturulmuş durum: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "Banka şubesi"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "Banka adı"
 
@@ -893,31 +883,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "Toplu İş"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "Toplu İş ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "Toplu İş Etiketleri"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "Toplu İşler"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "Etki"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "${start_date} öncesi"
 
@@ -925,7 +915,7 @@ msgstr "${start_date} öncesi"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "Büyük Simge"
 
@@ -933,7 +923,7 @@ msgstr "Büyük Simge"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS Konfigürasyonu"
 
@@ -941,63 +931,67 @@ msgstr "Bika LIMS Konfigürasyonu"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "Fatura adresi"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "Kör"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "Boş QC analizleri"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "Markası"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "Toplu indirim uygulanır"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "Toplu fiyat (KDV hariç)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "İş Telefonu"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "CC Yetkililer"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "CC E-Posta"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "Belirsizliklerden Kesinlik Derecesini Hesapla"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "Hesaplama"
 
@@ -1005,8 +999,8 @@ msgstr "Hesaplama"
 msgid "Calculation Formula"
 msgstr "Hesaplama Formülü"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "Hesaplama Ara Alanları"
@@ -1019,11 +1013,11 @@ msgstr "Hesaplama: ${calc_name}"
 msgid "Calculation: None"
 msgstr "Hesaplama: Yok"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "Hesaplamalar"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "Kalibrasyon"
 
@@ -1035,12 +1029,12 @@ msgstr "Kalibrasyon Sertifikaları"
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "Kalibrasyonu yapan"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1054,9 +1048,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "İptal edildi"
 
@@ -1072,18 +1066,18 @@ msgstr "${calc_services} tarafından kullanımda olduğundan hesaplama devre dı
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "Kapasite"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "Alındı"
 
@@ -1092,7 +1086,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "Katalog Numarası"
 
@@ -1100,17 +1094,17 @@ msgstr "Katalog Numarası"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "Kategori"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "Analiz hizmeti içerdiğinden kategori devre dışı bırakılamadı."
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1123,31 +1117,31 @@ msgstr "Sertifikasyon Kodu"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "Analiz hizmeti, laboratuvarın akredite analizler takvimine dahil ise bu kutucuğu işaretleyin."
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "Bu numune kabı muhafaza altındaysa bu kutucuğu işaretleyin. Bu kutucuğu işaretlemeniz durumunda muhafaza iş akışı kısayoldan muhafaza edilmiş olarak belirlenecek."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "Laboratuvarınız akredite ise bu kutucuğu işaretleyin."
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "Analiz hizmeti için ayrı bir numune kabı kullanıldıysa için bu kutucuğu işaretleyin."
 
@@ -1155,7 +1149,7 @@ msgstr "Analiz hizmeti için ayrı bir numune kabı kullanıldıysa için bu kut
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "Ayrı bir ID sunucusu kullanmak istiyorsanız bu kutucuğu işaretleyin. Ön-ekler her bir Bika sitesinde ayrıca ayarlanabilir."
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1171,19 +1165,19 @@ msgstr ""
 msgid "City"
 msgstr "Şehir"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "Klasik"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "Her bir analiz kategorisinin altında analiz hizmetlerini görmek için analiz kategorilerine tıklayın. Analizlerin geçerli sonuç aralığında raporlanabilmesi için minimum ve maksimum değerleri girmelisiniz. Bu değerler dışında sonuç girilmesi durumunda sistem alarm verir. Hata % değeri analiz hizmetinin değerlerinin % belirsizlik olarak geçerli değer aralığının yorumlanmasını sağlar. Minimum - maksimum değerler dışında girilen bir sonuç % belirsizlik sonucu içindeyse değerlendirmeye girer, onay sonrası raporlanabilir."
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1191,19 +1185,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "İndirmek için tıklayın"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "Müşteri"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "Müşteri Toplu İş ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "Müşteri ID"
 
@@ -1211,59 +1205,59 @@ msgstr "Müşteri ID"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Müşteri Adı"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Müşteri Siparişi"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "Müşteri Sipariş Numarası"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Müşteri Referansı"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Müşteri Referansı"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "Müşteri SID"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "Müşteri Numune ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Talebin alınabilmesi için müşteri iletişim bilgileri gereklidir"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Müşteriler"
 
@@ -1272,39 +1266,39 @@ msgstr "Müşteriler"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "Kapalı"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "Virgül (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "Yorumlar"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "Ticari Kimlik"
 
@@ -1312,21 +1306,21 @@ msgstr "Ticari Kimlik"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Bileşim"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "Güvenilirlik Seviyesi %"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1335,13 +1329,13 @@ msgid "Confirm password"
 msgstr "Şifreyi onayla"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "Dikkat Edilecek Hususlar"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Yetkili"
@@ -1350,8 +1344,8 @@ msgstr "Yetkili"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Yetkililer"
@@ -1360,48 +1354,48 @@ msgstr "Yetkililer"
 msgid "Contacts to CC"
 msgstr "CC yapılacak Yetkililer"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Numune Kabı"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "Numune Kabı Türü"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "Numune Kabı Türleri"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "Numune Kapları"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "İçerik Türü"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "İçerik türü"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Kontrol"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1417,12 +1411,12 @@ msgstr "Analiz Servislerini Kopyala"
 msgid "Copy from"
 msgstr "Şuradan kopyala"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "Say"
 
@@ -1435,18 +1429,18 @@ msgstr "Ülke"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "Oluşturuldu"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "Oluşturan"
 
@@ -1454,7 +1448,7 @@ msgstr "Oluşturan"
 msgid "Created by:"
 msgstr "Oluşturan:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1462,8 +1456,8 @@ msgstr ""
 msgid "Creator"
 msgstr "Oluşturan"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "Kriter"
 
@@ -1471,12 +1465,12 @@ msgstr "Kriter"
 msgid "Currency"
 msgstr "Para birimi"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Geçerli"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1489,7 +1483,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1503,88 +1497,88 @@ msgstr "Veri arayüzü"
 msgid "Data Interface Options"
 msgstr "Veri Arayüzü Seçenekleri"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "Veri girişi günlüğü"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Tarih"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "Oluşturulduğu Tarih"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Gönderildiği Tarih"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "İstek Yapılan Tarih"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Geçerliliğini Yitirme Tarihi"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Giriş Tarihi"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Yükleme Tarihi"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Açılma Tarihi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "Muhafaza Tarihi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Yayınlanma Tarihi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Teslim Alma Tarihi"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Talep Edilme Tarihi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Numune Alınma Tarihi"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1600,7 +1594,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr "Cihazın kalibrasyona alınma tarihi"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "Cihazın bakıma alınma tarihi"
 
@@ -1618,7 +1612,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "Cihazın tekrar kullanıma gireceği tarih"
@@ -1627,11 +1621,11 @@ msgstr "Cihazın tekrar kullanıma gireceği tarih"
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Gün"
 
@@ -1643,17 +1637,17 @@ msgstr "Bir sonraki kalibrasyon testine kadar devre dışı bırak"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "Varsayılan"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "Varsayılan AR Spesifikasyonları"
 
@@ -1661,49 +1655,49 @@ msgstr "Varsayılan AR Spesifikasyonları"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "Varsayılan Hesaplama"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "Varsayılan Numune Kabı"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "Varsayılan Numune Kabı Türü"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "Varsayılan Araç"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "Varsayılan Metod"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "Varsayılan Muhafaza Yöntemi"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "Varsayılan Öncelik?"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "Varsayılan kategoriler"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1712,11 +1706,11 @@ msgid "Default containers: ${container_list}"
 msgstr "Varsayılan kategoriler: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1740,11 +1734,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Varsayılan değer"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1752,7 +1746,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1760,11 +1754,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1772,16 +1766,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Derece"
 
@@ -1789,9 +1783,9 @@ msgstr "Derece"
 msgid "Delete attachment"
 msgstr "Eklentiyi sil"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Bölüm"
 
@@ -1804,13 +1798,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "Bağımlı Analizler"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "En genel şekilde metodu tanımlayın. Bu bilgi laboratuvar müşterileri ile paylaşılır."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "Tanım"
 
@@ -1818,7 +1812,7 @@ msgstr "Tanım"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1826,19 +1820,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1846,7 +1840,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "İndirim %"
 
@@ -1854,16 +1848,16 @@ msgstr "İndirim %"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Gönderildi"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "Görüntülenen Değer"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1875,7 +1869,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "İmha Etme Tarihi"
 
@@ -1884,8 +1878,8 @@ msgstr "İmha Etme Tarihi"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "İstek Yapıldı"
@@ -1894,54 +1888,54 @@ msgstr "İstek Yapıldı"
 msgid "District"
 msgstr "İlçe"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "Hareketsiz"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "Nokta (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "Buradan aşağı"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "Aşağısına"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1954,20 +1948,20 @@ msgstr "Kuru"
 msgid "Dry matter analysis"
 msgstr "Kuru madde analizi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "Beklenti"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "Beklenen Tarih"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "Tekerrür Varyansı"
 
@@ -1976,20 +1970,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "Tekerrür"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "Tekerrürü olduğu numune"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "Tekerrür Varyasyonu %"
 
@@ -2001,35 +1995,35 @@ msgstr "Tekerrür Analizi QC"
 msgid "Duplicate analysis quality control graphs"
 msgstr "Tekerrür analiz kalite kontrol grafikleri"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "Süre"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Ör: SANAS, APLAC, vb."
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "Erken Tamamlanma"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "Erken"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "Yükseltme"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "E-Posta"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "E-Posta Adresi"
 
@@ -2037,7 +2031,7 @@ msgstr "E-Posta Adresi"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "E-Posta konu satırı"
 
@@ -2057,14 +2051,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "Bitis Tarihi"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2076,16 +2070,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "İndirim yüzdesini girin"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "İndirim yüzdesini girin Ör: 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2093,15 +2087,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "Yüzde değer giriniz ör. 14.0. Girilen değer tüm sisteme uygulanacaktır, ancak bireysel maddelerde değişiklik yapabilirsiniz."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "İndirim yüzdesini girin Ör: 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "Örnekleme noktasının enlemlerini girin. Derece 0-90, Dakika 0-59, Saniye 0-59, K / G"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "Örnekleme noktasının boylamlarını girin. Derece 0-180, Dakika 0-59, Saniye 0-59, D / B"
 
@@ -2109,7 +2103,7 @@ msgstr "Örnekleme noktasının boylamlarını girin. Derece 0-180, Dakika 0-59,
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2117,45 +2111,45 @@ msgstr ""
 msgid "Entity"
 msgstr "Varlık"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "Faturadan hariç tut"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "Beklenen Sonuç"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "Beklenen Değerler"
 
@@ -2164,19 +2158,19 @@ msgstr "Beklenen Değerler"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "Süresi doldu"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "Son Kullanma Tarihi"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2184,44 +2178,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "Faks"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "Faks (iş)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "Bayan"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "Saha"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "Sana Analizleri"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "Saha Koruması"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "Saha Başlığı"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "Dosya"
 
@@ -2229,19 +2219,19 @@ msgstr "Dosya"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "Dosya adı"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2261,16 +2251,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "Adı"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "Formül"
 
@@ -2280,18 +2270,18 @@ msgstr "Formül"
 msgid "From"
 msgstr "Kimden"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "Adı Soyadı"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "İleri tarihli numune"
 
@@ -2301,7 +2291,7 @@ msgstr "İleri tarihli numune"
 msgid "Generate report"
 msgstr "Rapor oluştur"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Karşılama ünvanı örn. Bay, Bayan, Dr"
 
@@ -2313,37 +2303,37 @@ msgstr ""
 msgid "Group by"
 msgstr "Şu özelliğe göre grupla"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "Gruplama süresi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "Tehlikeli"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "Gizli"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "Gizli alan"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "Saat"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2352,8 +2342,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID Sunucu Linki"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID Server kullanımdışı"
 
@@ -2361,31 +2351,31 @@ msgstr "ID Server kullanımdışı"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2397,7 +2387,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2405,27 +2395,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2433,7 +2423,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2446,7 +2436,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "İçe aktar"
@@ -2455,7 +2445,7 @@ msgstr "İçe aktar"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "İçe aktarıldı"
@@ -2464,8 +2454,8 @@ msgstr "İçe aktarıldı"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "Etkin değil"
@@ -2474,7 +2464,7 @@ msgstr "Etkin değil"
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2482,7 +2472,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Tanımları dahil et"
 
@@ -2490,30 +2480,27 @@ msgstr "Tanımları dahil et"
 msgid "Include year in ID prefix"
 msgstr "ID önekinde yılı göster"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "yanlis IBAN numarasi: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "yanlis NIB numarasi: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "Kesin olmayan sonuç"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "İlk revizyon"
 
@@ -2537,7 +2524,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr "YüklemeTarihi"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "Talimatlar"
@@ -2550,17 +2537,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Cihaz"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "Cihaz kalibrasyonu"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2573,16 +2560,16 @@ msgstr "Cihazdan Veri Aktar"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "Cihaz Bakımı"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "Cihazdaki Planlanmış Görevler"
 
@@ -2590,19 +2577,19 @@ msgstr "Cihazdaki Planlanmış Görevler"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "Cihaz Türleri"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2646,9 +2633,9 @@ msgstr "Cihaz türü"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Cihazlar"
 
@@ -2672,7 +2659,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2688,24 +2675,21 @@ msgstr "Interpolasyon"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2713,43 +2697,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "Fatura"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "Fatura Tarihi"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Faturadan hariç"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "Fatura Numarası"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Etkin değil."
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "E-posta konu satırında gösterilecek olan nesneler"
 
@@ -2759,7 +2743,7 @@ msgstr "E-posta konu satırında gösterilecek olan nesneler"
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "İş Ünvanı"
 
@@ -2767,12 +2751,12 @@ msgstr "İş Ünvanı"
 msgid "Key"
 msgstr "Anahtar"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "Anahtar Hata"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Anahtar kelime"
@@ -2781,47 +2765,47 @@ msgstr "Anahtar kelime"
 msgid "Keywords"
 msgstr "Anahtar kelimeler"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Laboratuvar"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Lab Analizleri"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Lab Yetkilileri"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Lab Bölümleri"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "Lab. Muhafaza"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Lab Ürünleri"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "Lab Linki"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "Etiket"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Laboratuvar"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Akredite Laboratuvar"
 
@@ -2841,13 +2825,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Son değiştirilme tarihi"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Geç Kalmış"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Geç Kalmış Analizler"
@@ -2857,7 +2841,7 @@ msgstr "Geç Kalmış Analizler"
 msgid "Late Analysis"
 msgstr "Geç Kalmış Analiz"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Enlem"
 
@@ -2879,11 +2863,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Bağlı Numune"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2895,7 +2879,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr "Kurulum Verilerini Yükle"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "Metodu açıklayan dökümanı yükleyiniz."
 
@@ -2907,41 +2891,41 @@ msgstr "Dosyadan yükle"
 msgid "Load the certificate document here"
 msgstr "Sertifika belgesini buraya yükle"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "Yüklendi"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Kayıt"
@@ -2966,35 +2950,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Boylam"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Lot Numarası"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Postalama adresi"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Erkek"
 
@@ -3002,16 +2986,16 @@ msgstr "Erkek"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Yönetici"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Yönetici E-postası"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Yönetici Telefon Numarası"
 
@@ -3019,31 +3003,25 @@ msgstr "Yönetici Telefon Numarası"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Üretici"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "Üreticiller"
 
@@ -3052,14 +3030,14 @@ msgstr "Üreticiller"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Max"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Max Süre"
 
@@ -3067,30 +3045,30 @@ msgstr "Max Süre"
 msgid "Maximum columns per results email"
 msgstr "Sonuç e-postası başına maksimum kolon sayısı"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Numunelerin maksimum büyüklüğü veya hacmi"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Analizin tamamlanması için izin verilen maksimum süre. Bu süre sonunda değer girilmemiş olursa \"Geciken Analiz\" olarak işaretlenecektir."
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Maksimum geri dönüş süresi"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "Üye indirimi %"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Uygulanan üye indirimi"
 
@@ -3099,22 +3077,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "Metot"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "Metot Dosyası"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "Metot Talimatları"
 
@@ -3126,9 +3104,9 @@ msgstr "Metot: ${method_name}"
 msgid "Method: None"
 msgstr "Metot: Hiçbiri"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "Metotlar"
 
@@ -3136,17 +3114,17 @@ msgstr "Metotlar"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "Metotlar ${accreditation_body} tarafından akreditasyonda kullanılmak üzere takvime alınmıştır. Analiz açıklamaları akreditasyona dahil değildir."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "Min"
 
@@ -3158,8 +3136,8 @@ msgstr "Maden"
 msgid "Minimum 5 characters."
 msgstr "En az 5 karakter."
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "Minimum Hacim"
 
@@ -3167,27 +3145,27 @@ msgstr "Minimum Hacim"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "QC değerlerini hesaplamak için gereken minimum sonuç sayısı."
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "Dakika"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "Cep Telefonu"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "Model"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3201,7 +3179,7 @@ msgstr ""
 msgid "More"
 msgstr "Devamı"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3213,13 +3191,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "İsim"
 
@@ -3228,17 +3206,17 @@ msgstr "İsim"
 msgid "New"
 msgstr "Yeni"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "Hayır"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3254,18 +3232,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "${user} kullanıcısı için işlem bulunamadı"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "Hiç bir analiz seçilmedi"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3277,23 +3255,23 @@ msgstr "Hiçbir analiz eklenmedi."
 msgid "No analyses were added to this worksheet."
 msgstr "Bu çalışmaya hiçbir analiz eklenmedi."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "Hiçbir değişiklik yapılmadı."
 
@@ -3301,7 +3279,7 @@ msgstr "Hiçbir değişiklik yapılmadı."
 msgid "No control type specified"
 msgstr "Hiç bir kontrol türü belirlenmedi"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3313,17 +3291,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3331,7 +3309,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3341,16 +3319,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "Talepte rapor belirtilmemiş"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3368,25 +3346,22 @@ msgstr "${contact_fullname} için hiçbir kullanıcı giriş yapmak üzere mevcu
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "Hiçbiri"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "İzin verilmedi"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3406,19 +3381,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3426,30 +3401,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3457,15 +3432,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3474,31 +3449,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "Numune sayısı"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3506,15 +3481,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "Yalnızca laboratuvar müdürleri çalışma planı oluşturup değiştirebilirler."
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "Açık"
@@ -3527,26 +3499,26 @@ msgstr ""
 msgid "Order"
 msgstr "Sipariş"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "Sipariş Tarihi"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "Sipariş ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "Sipariş Numarası"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "Siparişler"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3554,7 +3526,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3566,8 +3538,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3579,16 +3551,13 @@ msgstr ""
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "Bölümleme"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3609,8 +3578,8 @@ msgstr "Şifre"
 msgid "Password lifetime"
 msgstr "Şifre geçerlilik süresi"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "Beklemede"
@@ -3635,31 +3604,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "İzin verildi"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "İzin verilen hata %"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "Telefon"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "Telefon (iş)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "Telefon (ev)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "Telefon (GSM)"
 
@@ -3672,8 +3641,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "Adres"
 
@@ -3681,7 +3650,7 @@ msgstr "Adres"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3689,19 +3658,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "Akreditasyon kurumunuz tarafından kullanmanıza izin verilen akreditasyon logosunu yükeyiniz. Maksimum boyut 175 x 175 piksel"
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "Alınma Noktası"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3710,13 +3679,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "Pozisyon"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "Posta adresi"
 
@@ -3724,16 +3693,16 @@ msgstr "Posta adresi"
 msgid "Postal code"
 msgstr "Posta kodu"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "Ön-muhafazada"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "Ondalık sayı olarak hassasiyet"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3761,7 +3730,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "Ön ek"
 
@@ -3769,12 +3738,12 @@ msgstr "Ön ek"
 msgid "Prefixes"
 msgstr "Önekler"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3786,17 +3755,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "Muhafaza"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "Muhafaza Kategorisi"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3807,7 +3776,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "Muhafaza"
 
@@ -3817,14 +3786,14 @@ msgstr "Muhafaza"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "Muhafaza eden"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3832,34 +3801,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Fiyat"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Fiyat (KDV hariç)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "KDV hariç fiyat"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Fiyat listesi"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "Fiyat listeleri"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3874,13 +3843,13 @@ msgstr "Yazdır"
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "Öncelik"
 
@@ -3897,34 +3866,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Profil"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Profil Analizleri"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Profil Tuşu"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Profil Anahtar Kelimeler"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Profiller"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "Proforma Fatura"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3932,7 +3901,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3947,21 +3916,21 @@ msgstr "Yayınlanma tercihleri"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Yayınlandı"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "Yayınlayan"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "Yayınlanan sonuçlar"
 
@@ -3974,8 +3943,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3996,23 +3965,23 @@ msgstr "Miktar"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Max aralık"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Min aralık"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4034,9 +4003,9 @@ msgstr "Teslim alma"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Alındı"
 
@@ -4044,11 +4013,11 @@ msgstr "Alındı"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4057,31 +4026,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Referans"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Referans Tanımı"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Referans Tanımları"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Referans Numuneler"
 
@@ -4089,16 +4058,16 @@ msgstr "Referans Numuneler"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Referans Türü"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4107,7 +4076,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4115,21 +4084,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr "Referans Numune"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Referans örnek değerleri sıfır ya da 'kör' olan"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4152,8 +4121,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4162,9 +4131,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "Yüzde fark, ${variation_here} %, geçerli aralığın dışında  (${variation} %))"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Düşünceler"
 
@@ -4172,7 +4141,7 @@ msgstr "Düşünceler"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4180,7 +4149,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4189,8 +4158,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4199,7 +4168,7 @@ msgid "Repeated analyses"
 msgstr "Tekrarlanan analizler"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Rapor"
 
@@ -4213,14 +4182,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "Rapor Türü"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Kuru Madde Olarak Raporla"
 
@@ -4245,7 +4214,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "Rapor türü"
 
@@ -4253,7 +4222,7 @@ msgstr "Rapor türü"
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "Raporlar"
 
@@ -4262,15 +4231,15 @@ msgstr "Raporlar"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "Talep"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "Talep eden ID"
 
@@ -4278,26 +4247,26 @@ msgstr "Talep eden ID"
 msgid "Request new analyses"
 msgstr "Yeni analizler talep et"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "Talep edildi"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Talepler"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Mecburi"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "Gerekli Hacim"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4305,13 +4274,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "Kısıtlanan kategoriler"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Sonuç"
 
@@ -4319,15 +4288,15 @@ msgstr "Sonuç"
 msgid "Result Footer"
 msgstr "Sonuç Altbilgisi"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Sonuç Seçenekleri"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Sonuç Değeri"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4345,11 +4314,11 @@ msgstr "Sonuç aralık dışında kaldı"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4357,7 +4326,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4365,11 +4334,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4378,14 +4347,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "Saklama Süresi"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Tekrar analiz edildi"
@@ -4404,11 +4373,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4424,12 +4393,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "Hitap"
 
@@ -4437,19 +4406,19 @@ msgstr "Hitap"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "Numune"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4458,8 +4427,8 @@ msgid "Sample Due"
 msgstr "Numune Beklenmekte"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "Numune ID"
 
@@ -4471,12 +4440,12 @@ msgstr "Numune ID Atama"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "Numune Matrisleri"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "Numune Matrisi"
 
@@ -4486,52 +4455,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "Numune bölümlemeleri"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "Örnekleme Noktası"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "Örnekleme Noktaları"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "Numune Türü"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "Numune Türü Öneki"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "Numune Türleri"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4541,9 +4510,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "Numune alma noktası"
 
@@ -4571,17 +4540,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "Numune Türü"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4591,30 +4560,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "Numuneyi Alan"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "Numuneler"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "Bu tip numuneler tehlikeli olarak ele alınmalıdır."
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4623,62 +4592,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "Numune Alma Tarihi"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "Numune Alma Sıklığı"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4688,9 +4657,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "Kaydet"
 
@@ -4703,17 +4672,17 @@ msgstr "Açıklamaları kaydet"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4721,16 +4690,16 @@ msgstr ""
 msgid "Search"
 msgstr "Ara"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "Saniye"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4742,11 +4711,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "Bir ver arayüzü seçin"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4754,11 +4723,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "Çoğaltmak için bir hedef konumu ve Analiz Talebi seçin."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4770,7 +4739,7 @@ msgstr "Tüm maddeleri seç"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4782,11 +4751,11 @@ msgstr "Analiz Seç"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "Analizler faturaya işlenmeyecekse işaretleyin."
 
@@ -4794,19 +4763,19 @@ msgstr "Analizler faturaya işlenmeyecekse işaretleyin."
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "Açıklamalar da dahil edilecekse işaretleyin."
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4832,7 +4801,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr "Görüntülenecek döviz cinsini seçin."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4844,7 +4813,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "Tercih edilen cihazı seçin."
 
@@ -4852,7 +4821,7 @@ msgstr "Tercih edilen cihazı seçin."
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4876,7 +4845,7 @@ msgstr "Numune toplama detaylı iş akışını etkinleştirmek için bu kutucu�
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "Hangi analizlerin çalışmada yer alacağını seçin."
 
@@ -4892,7 +4861,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4904,7 +4873,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4912,32 +4881,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "Seri No"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "Hizmet"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "Hizmetler"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4945,31 +4910,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "Laboratuvar analiz hizmeti sonuç özelliklerini ayarla"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "Teslim adresi"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4985,7 +4950,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "Müşteri ekranında yalnızca seçili kategorileri göster"
 
@@ -4997,29 +4962,25 @@ msgstr ""
 msgid "Signature"
 msgstr "İmza"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "Boyut"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "Küçük Simge"
 
@@ -5027,14 +4988,14 @@ msgstr "Küçük Simge"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5042,41 +5003,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "Özellikler"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "Durum"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "Durum"
 
@@ -5084,33 +5045,33 @@ msgstr "Durum"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "Gönder"
 
@@ -5118,37 +5079,34 @@ msgstr "Gönder"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "Aratoplam"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "Tedarikçi"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "Tedarikçiler"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "Soyisim"
 
@@ -5168,11 +5126,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "Görev"
 
@@ -5181,20 +5139,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "Analistlere yönelik teknik açıklama ve talimatlar"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "Sıcaklık"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5212,35 +5170,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "Laboratuvar tarafından müşterinin talebine atanan ID"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "Laboratuvar tarafından müşterinin numunesine atanan ID"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "Laboratuvarın web adresi"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "Uygulanan akreditasyon standardı, ör: ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "Bu profile dahil olan analizler, kategori başına gruplandırılmış"
 
@@ -5252,7 +5210,7 @@ msgstr "Kuru madde miktarının belirlenmesi için kullanılacak analiz."
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5260,12 +5218,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "Ekler, analiz talepleri ve analizlere atanmıştır."
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "Analiz Hizmetinin ait olduğu kategori"
 
@@ -5273,19 +5231,19 @@ msgstr "Analiz Hizmetinin ait olduğu kategori"
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5297,7 +5255,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr "Tam URL adresi: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "Numune alınması gereken yükseklik veya derinlik"
 
@@ -5314,24 +5272,24 @@ msgstr "Cihazın model numarası"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "Laboratuvar akredite değil veya akreditasyon bilgileri girilmemiş."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "Laboratuvar bölümü"
@@ -5348,27 +5306,27 @@ msgstr "Numune ID'leri için öndeki 0 atama sayısı"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "Analiz Talepleri ID'leri için Analiz Talebine numarası önüne 0 atama sayısı"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "Bu analiz hizmetinin sonuçları için kullanılacak birim, ör: mg/l, ppm, dB, mV, vb."
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5392,7 +5350,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5409,11 +5367,11 @@ msgstr "İsteklerin ve analizlerin sayısı"
 msgid "The number of requests and analyses per client"
 msgstr "Müşteri başına isteklerin ve analizlerin sayısı"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5430,19 +5388,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5450,11 +5408,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5462,7 +5420,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5474,11 +5432,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5486,19 +5444,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "Analizin tamamlanma süresi"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5510,7 +5468,7 @@ msgstr "Analizlerin gerçekleştirme süreleri"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5522,37 +5480,37 @@ msgstr "Sonuç yok."
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Bu Analiz Hizmeti etkinleştirilemedi: Hesaplama metodu devre dışı."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Bu Analiz Hizmeti bağlı hesaplama yöntemleri etkin olduğundan devre dışı bırakılamadı."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5564,7 +5522,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5572,12 +5530,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5592,63 +5546,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Başlık"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "Muhafazaya Alınacak"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "Numune Alınacak"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "Doğrulanacak"
 
@@ -5660,13 +5614,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Toplam"
 
@@ -5674,22 +5628,22 @@ msgstr "Toplam"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Toplam Fiyat"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Toplam fiyat"
 
@@ -5701,11 +5655,11 @@ msgstr "Toplam:"
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5713,61 +5667,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "Tamamlanma süresi (S)"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Tür"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "Sevk edilmedi."
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Belirsizlik"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Belirsizlik değeri"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "Tanımlanmamış"
 
@@ -5775,13 +5723,13 @@ msgstr "Tanımlanmamış"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Birim"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5806,17 +5754,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "Yayınlanmadı"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5828,11 +5776,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5840,7 +5788,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5852,13 +5800,13 @@ msgstr "Harici ID sunucusu kullan"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Kullanıcı"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Kullanıcı Adı"
@@ -5871,7 +5819,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5880,27 +5828,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "KDV"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "KDV %"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "KDV Tutarı"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Vergi Numarası"
 
@@ -5908,11 +5856,11 @@ msgstr "Vergi Numarası"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Geçerlilik Başlangıç Tarihi"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5920,181 +5868,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "Validasyon"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "Validasyon yapılamadı: '${keyword}': anahtar kelime tekrarı"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "Validasyon yapılamadı: '${title}': Bu anahtar kelime '${used_by}' hesaplamasında zaten kullanımda"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "Validasyon yapılamadı: '${title}': Bu anahtar kelime '${used_by}' hizmetinde zaten kullanımda"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "Validasyon yapılamadı: '${title}': başlık tekrarı"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "Validasyon yapılamadı: girilen değer '${value}' özgün değil."
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "Validasyon başarısız: Yön Doğu / Batı olmalıdır."
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "Validasyon başarısız: Yön Kuzey / Güney olmalıdır."
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "Validasyon yapılamadı: Anahtar kelime '${keyword}' geçersiz"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Validasyon başarısız: Sonuç değerleri sayısal olmalıdır."
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Validasyon başarısız: derece değeri 0-90 aralığında olmalıdır."
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Validasyon başarısız: derece değerleri sayısal olmalıdır."
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Validasyon başarısız: anahtar sözcükler geçersiz karakter içeriyor."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Validasyon başarısız: dakika değeri 0 - 59 aralığında olmalıdır."
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Validasyon başarısız: dakika değeri sayısal olmalıdır."
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Validasyon başarısız: saniye değeri 0 - 59 aralığında olmalıdır."
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Validasyon başarısız: saniye değeri sayısal olmalıdır."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6102,7 +6050,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "Onaylayan"
@@ -6113,12 +6061,12 @@ msgstr "Onaylayan"
 msgid "Value"
 msgstr "Değer"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Doğrulandı"
@@ -6129,7 +6077,7 @@ msgstr "Doğrulandı"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Versiyon"
 
@@ -6139,11 +6087,11 @@ msgstr "Versiyon"
 msgid "Volume"
 msgstr "Hacim"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6151,24 +6099,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6179,25 +6127,25 @@ msgstr "İş akışı"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Çalışma"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Çalışma Görünümü"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Çalışma Şablonları"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Çalışmalar"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6205,9 +6153,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "Evet"
 
@@ -6219,7 +6167,7 @@ msgstr "Çalışma sayfası yüzdesini % düzenlemek için gerekli kullanıcı i
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6227,11 +6175,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Bir cihaz seçmelisiniz"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "işlem"
 
@@ -6247,15 +6195,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6276,7 +6224,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "yorum"
 
@@ -6284,36 +6232,8 @@ msgstr "yorum"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6325,7 +6245,7 @@ msgstr "Pasifleştir"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6373,19 +6293,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6393,19 +6313,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6424,19 +6344,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6448,7 +6357,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6456,7 +6365,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "bitiş tarihi"
 
@@ -6481,7 +6390,7 @@ msgstr "Değer"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6493,6 +6402,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/bika.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Ukrainian (Ukraine) (http://www.transifex.com/bikalabs/bika-lims/language/uk_UA/)\n"
@@ -23,49 +23,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "% помилки"
 
@@ -95,15 +95,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(Пусто)"
@@ -136,7 +136,7 @@ msgstr "(Контроль)"
 msgid "(Duplicate)"
 msgstr "(Повторно)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -145,32 +145,26 @@ msgid "(Required)"
 msgstr "(Потребується)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "+-"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -181,16 +175,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -202,7 +196,7 @@ msgstr "Властивості вкладень ЗА"
 msgid "AR ID Padding"
 msgstr "Додатковий ID ЗА"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "Імпорт ЗА"
 
@@ -210,17 +204,17 @@ msgstr "Імпорт ЗА"
 msgid "AR Import options"
 msgstr "Властивості імпорту ЗА"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -228,54 +222,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "Найменування рахунку"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "Номер рахунку"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "Тип рахунку"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "Акредитація"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "Абревіатура тіла акредитації"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "URL тіла акредитації"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "Еталон акредитації"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "Акредитовано"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -289,21 +283,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "Активний"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "Додати"
 
@@ -323,11 +317,7 @@ msgstr "Додати контрольний еталон"
 msgid "Add Duplicate"
 msgstr "Додати повторний"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -335,16 +325,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -357,26 +347,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "Всі"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "Всі аналізи призначено"
 
@@ -388,7 +378,7 @@ msgstr "Всі аналізи типу"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -396,15 +386,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -412,11 +402,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -424,48 +414,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "Аналізи"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "Аналізи поза межами"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "Аналізи по типу зразка"
@@ -479,7 +469,7 @@ msgstr "Аналізи по послугам"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -492,27 +482,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "Аналізи повторено"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "Аналіз"
 
@@ -520,52 +510,52 @@ msgstr "Аналіз"
 msgid "Analysis Attachment Option"
 msgstr "Властивості вкладень до аналізів"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "Категорії аналізів"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "Категорія аналізів"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "Ключове слово аналізу"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "Профіль аналізу"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "ID запиту на аналіз"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "Імпорт запиту на аналіз"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -573,65 +563,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "Запити на аналіз"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "Послуга по аналізам"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "Послуги по аналізам"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "Специфікації аналізу"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -640,46 +630,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -687,12 +677,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -708,17 +698,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -727,7 +717,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -739,7 +729,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -757,15 +747,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -783,27 +773,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -813,25 +803,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -843,7 +833,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -860,27 +850,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -889,31 +879,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -921,7 +911,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -929,7 +919,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -937,63 +927,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1001,8 +995,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1015,11 +1009,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1031,12 +1025,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1050,9 +1044,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1068,18 +1062,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1088,7 +1082,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1096,17 +1090,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1119,31 +1113,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1151,7 +1145,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1167,19 +1161,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1187,19 +1181,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "ID клієнта"
 
@@ -1207,59 +1201,59 @@ msgstr "ID клієнта"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "Ім'я клієнта"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "Замовлення клієнта"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "Пос. клієнта"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "Посилання клієнта"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "SID клієнта"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "Для затвердження запиту потрібен контакт клієнта"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "Клієнти"
 
@@ -1268,39 +1262,39 @@ msgstr "Клієнти"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1308,21 +1302,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "Складений"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "% рівня надійності"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1331,13 +1325,13 @@ msgid "Confirm password"
 msgstr "Підтвердіть пароль"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "Контакт"
@@ -1346,8 +1340,8 @@ msgstr "Контакт"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "Контакти"
@@ -1356,48 +1350,48 @@ msgstr "Контакти"
 msgid "Contacts to CC"
 msgstr "Контакти для копії"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "Контейнер"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "Тип змісту"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "Контроль"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1413,12 +1407,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1431,18 +1425,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1450,7 +1444,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1458,8 +1452,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1467,12 +1461,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "Дійсний"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1485,7 +1479,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1499,88 +1493,88 @@ msgstr "Інтерфейс даних"
 msgid "Data Interface Options"
 msgstr "Властивості інтерфейсу даних"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "Дата"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "Дата відправки"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "Дата вилучення"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "Кінцева дата"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "Дата імпорту"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "Дата завантаження"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "Дата відкриття"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "Дата публікації"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "Дата отримання"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "Дата запиту"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "Дата взяття зразка"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1596,7 +1590,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1614,7 +1608,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1623,11 +1617,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "Дні"
 
@@ -1639,17 +1633,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1657,49 +1651,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1708,11 +1702,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1736,11 +1730,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "Стандартне значення"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1748,7 +1742,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1756,11 +1750,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1768,16 +1762,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "Градуси"
 
@@ -1785,9 +1779,9 @@ msgstr "Градуси"
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "Підрозділ"
 
@@ -1800,13 +1794,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1814,7 +1808,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1822,19 +1816,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1842,7 +1836,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1850,16 +1844,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1871,7 +1865,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1880,8 +1874,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1890,54 +1884,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1950,20 +1944,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1972,20 +1966,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1997,35 +1991,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2033,7 +2027,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2053,14 +2047,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2072,16 +2066,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2089,15 +2083,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2105,7 +2099,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2113,45 +2107,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2160,19 +2154,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2180,44 +2174,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2225,19 +2215,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2257,16 +2247,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2276,18 +2266,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2297,7 +2287,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2309,37 +2299,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2348,8 +2338,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2357,31 +2347,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2393,7 +2383,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2401,27 +2391,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2429,7 +2419,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2442,7 +2432,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2451,7 +2441,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "Імпортовано"
@@ -2460,8 +2450,8 @@ msgstr "Імпортовано"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2470,7 +2460,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2478,7 +2468,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "Включати опис"
 
@@ -2486,30 +2476,27 @@ msgstr "Включати опис"
 msgid "Include year in ID prefix"
 msgstr "Включати рік в префіксі ID"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "Початкова перевірка"
 
@@ -2533,7 +2520,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2546,17 +2533,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "Інструмент"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2569,16 +2556,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2586,19 +2573,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2642,9 +2629,9 @@ msgstr "Тип інструмента"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "Інструменти"
 
@@ -2668,7 +2655,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2684,24 +2671,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2709,43 +2693,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "Виключити рахунок"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "Позиція не активна"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2755,7 +2739,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "Заголовок роботи"
 
@@ -2763,12 +2747,12 @@ msgstr "Заголовок роботи"
 msgid "Key"
 msgstr "Ключ"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "Ключове слово"
@@ -2777,47 +2761,47 @@ msgstr "Ключове слово"
 msgid "Keywords"
 msgstr "Ключові слова"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "Лабораторія"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "Аналізи лабораторії"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "Контакти лабораторії"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "Підрозділи лабораторії"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "Продукти лабораторії"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "URL лабораторії"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "Лабораторія"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "Лабораторію акредитовано"
 
@@ -2837,13 +2821,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "Востаннє змінено"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "Пізно"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "Запізнілі аналізи"
@@ -2853,7 +2837,7 @@ msgstr "Запізнілі аналізи"
 msgid "Late Analysis"
 msgstr "Запізнілий аналіз"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "Широта"
 
@@ -2875,11 +2859,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "Зв'язаний зразок"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2891,7 +2875,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2903,41 +2887,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "Лог"
@@ -2962,35 +2946,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "Довгота"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "Номер лоту"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "Поштова адреса"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "Пошта"
 
@@ -2998,16 +2982,16 @@ msgstr "Пошта"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "Керівник"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "Електронна адреса керівника"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "Телефон керівника"
 
@@ -3015,31 +2999,25 @@ msgstr "Телефон керівника"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "Вировник"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3048,14 +3026,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "Макс"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "Макс. час"
 
@@ -3063,30 +3041,30 @@ msgstr "Макс. час"
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "Максимальний можливий розмір або об'єм зразків."
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "Максимально допустимий час для завершення аналізів. При перевищенні цього періоду з'являється попередження про запізнілі аналізи"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "Максимальний тривалість"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "% членської знижки"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "Членська знижка застосовується"
 
@@ -3095,22 +3073,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3122,9 +3100,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3132,17 +3110,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3154,8 +3132,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3163,27 +3141,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr "Мінімальна кількість результатів для обрахування статистики СЯ"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3197,7 +3175,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3209,13 +3187,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3224,17 +3202,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3250,18 +3228,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3273,23 +3251,23 @@ msgstr "Не було додано жодного аналізу"
 msgid "No analyses were added to this worksheet."
 msgstr "Не було додано жодного аналізу до цього журналу."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3297,7 +3275,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3309,17 +3287,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3327,7 +3305,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3337,16 +3315,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3364,25 +3342,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3402,19 +3377,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3422,30 +3397,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3453,15 +3428,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3470,31 +3445,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "При зберіганні зразок має бути видалено протягом цього періоду часу. Якщо він не вказаний, буде застосовано період зберігання для типу зразка."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3502,15 +3477,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3523,26 +3495,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3550,7 +3522,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3562,8 +3534,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3575,16 +3547,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3605,8 +3574,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3631,31 +3600,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3668,8 +3637,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3677,7 +3646,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3685,19 +3654,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3706,13 +3675,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3720,16 +3689,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3757,7 +3726,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3765,12 +3734,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3782,17 +3751,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3803,7 +3772,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3813,14 +3782,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3828,34 +3797,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "Ціна"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "Ціна (без ПДВ)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "Ціна з ПДВ"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "Прайс-лист для"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3870,13 +3839,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3893,34 +3862,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "Профіль"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "Аналізи профілю"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "Ключ профілю"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "Ключове слово профілю"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "Профілі"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3928,7 +3897,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3943,21 +3912,21 @@ msgstr "Налаштування публікації"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "Опубліковано"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3970,8 +3939,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3992,23 +3961,23 @@ msgstr "Кількість"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "Максимум межі"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "Мінімум межі"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4030,9 +3999,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "Отримано"
 
@@ -4040,11 +4009,11 @@ msgstr "Отримано"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4053,31 +4022,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "Посилання"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "Визначення еталону"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "Визначення еталонів"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "Еталонні зразки"
 
@@ -4085,16 +4054,16 @@ msgstr "Еталонні зразки"
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "Тип еталону"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4103,7 +4072,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4111,21 +4080,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4148,8 +4117,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4158,9 +4127,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "Коментарі"
 
@@ -4168,7 +4137,7 @@ msgstr "Коментарі"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4176,7 +4145,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4185,8 +4154,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4195,7 +4164,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "Звіт"
 
@@ -4209,14 +4178,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "Давати у звіті як суху сировину"
 
@@ -4241,7 +4210,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4249,7 +4218,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4258,15 +4227,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "ID запиту"
 
@@ -4274,26 +4243,26 @@ msgstr "ID запиту"
 msgid "Request new analyses"
 msgstr "Запитати нові аналізи"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "Запити"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "Потребується"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4301,13 +4270,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "Результат"
 
@@ -4315,15 +4284,15 @@ msgstr "Результат"
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "Налаштування результату"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "Значення результату"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4341,11 +4310,11 @@ msgstr "Результат виходить за межі"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4353,7 +4322,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4361,11 +4330,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4374,14 +4343,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "Досліджено повторно"
@@ -4400,11 +4369,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4420,12 +4389,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4433,19 +4402,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4454,8 +4423,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4467,12 +4436,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4482,52 +4451,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4537,9 +4506,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4567,17 +4536,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4587,30 +4556,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4619,62 +4588,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4684,9 +4653,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4699,17 +4668,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4717,16 +4686,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4738,11 +4707,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4750,11 +4719,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4766,7 +4735,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4778,11 +4747,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4790,19 +4759,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4828,7 +4797,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4840,7 +4809,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4848,7 +4817,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4872,7 +4841,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4888,7 +4857,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4900,7 +4869,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4908,32 +4877,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4941,31 +4906,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4981,7 +4946,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4993,29 +4958,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5023,14 +4984,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5038,41 +4999,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5080,33 +5041,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5114,37 +5075,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5164,11 +5122,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5177,20 +5135,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5208,35 +5166,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5248,7 +5206,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5256,12 +5214,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5269,19 +5227,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5293,7 +5251,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5310,24 +5268,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5344,27 +5302,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5388,7 +5346,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5405,11 +5363,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr "Кількість запитів і аналізів на клієнта"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5426,19 +5384,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5446,11 +5404,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5458,7 +5416,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5470,11 +5428,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5482,19 +5440,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5506,7 +5464,7 @@ msgstr "Тривалість досліджень"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5518,37 +5476,37 @@ msgstr "Результату немає"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "Послуга по аналізам не може бути активована, бо її калькуляція не активна."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "Послуга по аналізам не може бути деактивована, оскільки має залежні калькуляції."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5560,7 +5518,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5568,12 +5526,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5588,63 +5542,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "Заголовок"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "На перевірку"
 
@@ -5656,13 +5610,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "Всього"
 
@@ -5670,22 +5624,22 @@ msgstr "Всього"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "Загальна ціна"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "Загальна ціна"
 
@@ -5697,11 +5651,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5709,61 +5663,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "Тип"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "Невизначеність"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "Значення невизначеності"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5771,13 +5719,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "Одиниця"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5802,17 +5750,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5824,11 +5772,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5836,7 +5784,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5848,13 +5796,13 @@ msgstr "Використовувати зовнішній ID сервер"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "Користувач"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "Ім'я користувача"
@@ -5867,7 +5815,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5876,27 +5824,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "ПДВ"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "% ПДВ"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "Кількість ПДВ"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "Номер ПДВ"
 
@@ -5904,11 +5852,11 @@ msgstr "Номер ПДВ"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "Дійсно з"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5916,181 +5864,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "Перевірку не пройдено: значення результату повинно бути числовим"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "Перевірку не пройдено: градуси мають бути від 0 до 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "Перевірку не пройдено: градуси мають бути в числах"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "Перевірку не пройдено: ключове слово містить недопустимі символи"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "Перевірку не пройдено: хвилини мають бути від 0 до 59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "Перевірку не пройдено: хвилини мають бути в числах"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "Перевірку не пройдено:  секунди мають бути від 0 до 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "Перевірку не пройдено: секунди мають бути в числах"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6098,7 +6046,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6109,12 +6057,12 @@ msgstr ""
 msgid "Value"
 msgstr "Значення"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "Перевірено"
@@ -6125,7 +6073,7 @@ msgstr "Перевірено"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "Версія"
 
@@ -6135,11 +6083,11 @@ msgstr "Версія"
 msgid "Volume"
 msgstr "Об'єм"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6147,24 +6095,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6175,25 +6123,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "Журнал"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "Вигляд журнала"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "Шаблони журналу"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "Журнали"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6201,9 +6149,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6215,7 +6163,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6223,11 +6171,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "Ви маєте вибрати інструмент"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6243,15 +6191,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6272,7 +6220,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6280,36 +6228,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6321,7 +6241,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6369,19 +6289,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6389,19 +6309,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6420,19 +6340,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6444,7 +6353,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6452,7 +6361,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6477,7 +6386,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6489,6 +6398,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/ur/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/ur/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Urdu (http://www.transifex.com/bikalabs/bika-lims/language/ur/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/vi/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/vi/LC_MESSAGES/bika.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/bikalabs/bika-lims/language/vi/)\n"
@@ -22,49 +22,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr ""
 
@@ -80,7 +80,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr ""
 
@@ -94,15 +94,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -114,15 +114,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "(Duplicate)"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr ""
 
@@ -144,32 +144,26 @@ msgid "(Required)"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -180,16 +174,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -201,7 +195,7 @@ msgstr ""
 msgid "AR ID Padding"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr ""
 
@@ -209,17 +203,17 @@ msgstr ""
 msgid "AR Import options"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -227,54 +221,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr ""
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr ""
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr ""
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -288,21 +282,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr ""
 
@@ -322,11 +316,7 @@ msgstr ""
 msgid "Add Duplicate"
 msgstr ""
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr ""
 
@@ -334,16 +324,16 @@ msgstr ""
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr ""
@@ -356,26 +346,26 @@ msgstr ""
 msgid "Administrative Reports"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr ""
 
@@ -387,7 +377,7 @@ msgstr ""
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -395,15 +385,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -411,11 +401,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -423,48 +413,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr ""
@@ -478,7 +468,7 @@ msgstr ""
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -491,27 +481,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr ""
 
@@ -519,52 +509,52 @@ msgstr ""
 msgid "Analysis Attachment Option"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -572,65 +562,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr ""
@@ -639,46 +629,46 @@ msgstr ""
 msgid "Analysis category"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -686,12 +676,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr ""
 
@@ -707,17 +697,17 @@ msgstr ""
 msgid "Analysis turnaround time over time"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr ""
 
@@ -726,7 +716,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr ""
 
@@ -738,7 +728,7 @@ msgstr ""
 msgid "Apply template"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -756,15 +746,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr ""
 
@@ -782,27 +772,27 @@ msgstr ""
 msgid "Attach to"
 msgstr ""
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr ""
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr ""
 
@@ -812,25 +802,25 @@ msgstr ""
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr ""
 
@@ -842,7 +832,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -859,27 +849,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr ""
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr ""
 
@@ -888,31 +878,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -920,7 +910,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -928,7 +918,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -936,63 +926,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr ""
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr ""
 
@@ -1000,8 +994,8 @@ msgstr ""
 msgid "Calculation Formula"
 msgstr ""
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr ""
@@ -1014,11 +1008,11 @@ msgstr ""
 msgid "Calculation: None"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1030,12 +1024,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1049,9 +1043,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr ""
 
@@ -1067,18 +1061,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr ""
 
@@ -1087,7 +1081,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr ""
 
@@ -1095,17 +1089,17 @@ msgstr ""
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1118,31 +1112,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr ""
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr ""
 
@@ -1150,7 +1144,7 @@ msgstr ""
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1166,19 +1160,19 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1186,19 +1180,19 @@ msgstr ""
 msgid "Click to download"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr ""
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr ""
 
@@ -1206,59 +1200,59 @@ msgstr ""
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr ""
 
@@ -1267,39 +1261,39 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1307,21 +1301,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr ""
 
@@ -1330,13 +1324,13 @@ msgid "Confirm password"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr ""
@@ -1345,8 +1339,8 @@ msgstr ""
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr ""
@@ -1355,48 +1349,48 @@ msgstr ""
 msgid "Contacts to CC"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr ""
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr ""
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1412,12 +1406,12 @@ msgstr ""
 msgid "Copy from"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr ""
 
@@ -1430,18 +1424,18 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1449,7 +1443,7 @@ msgstr ""
 msgid "Created by:"
 msgstr ""
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1457,8 +1451,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1466,12 +1460,12 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr ""
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1484,7 +1478,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1498,88 +1492,88 @@ msgstr ""
 msgid "Data Interface Options"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr ""
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1595,7 +1589,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1613,7 +1607,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1622,11 +1616,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr ""
 
@@ -1638,17 +1632,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1656,49 +1650,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1707,11 +1701,11 @@ msgid "Default containers: ${container_list}"
 msgstr ""
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1735,11 +1729,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr ""
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1747,7 +1741,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1755,11 +1749,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1767,16 +1761,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr ""
 
@@ -1784,9 +1778,9 @@ msgstr ""
 msgid "Delete attachment"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr ""
 
@@ -1799,13 +1793,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr ""
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
@@ -1813,7 +1807,7 @@ msgstr ""
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1821,19 +1815,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1841,7 +1835,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr ""
 
@@ -1849,16 +1843,16 @@ msgstr ""
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1870,7 +1864,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr ""
 
@@ -1879,8 +1873,8 @@ msgstr ""
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr ""
@@ -1889,54 +1883,54 @@ msgstr ""
 msgid "District"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr ""
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1949,20 +1943,20 @@ msgstr ""
 msgid "Dry matter analysis"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1971,20 +1965,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr ""
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr ""
 
@@ -1996,35 +1990,35 @@ msgstr ""
 msgid "Duplicate analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr ""
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr ""
 
@@ -2032,7 +2026,7 @@ msgstr ""
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr ""
 
@@ -2052,14 +2046,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2071,16 +2065,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2088,15 +2082,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr ""
 
@@ -2104,7 +2098,7 @@ msgstr ""
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2112,45 +2106,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr ""
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2159,19 +2153,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2179,44 +2173,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr ""
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr ""
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr ""
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr ""
 
@@ -2224,19 +2214,19 @@ msgstr ""
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2256,16 +2246,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr ""
 
@@ -2275,18 +2265,18 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr ""
 
@@ -2296,7 +2286,7 @@ msgstr ""
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr ""
 
@@ -2308,37 +2298,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr ""
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr ""
@@ -2347,8 +2337,8 @@ msgstr ""
 msgid "ID Server URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2356,31 +2346,31 @@ msgstr ""
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2392,7 +2382,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2400,27 +2390,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr ""
 
@@ -2441,7 +2431,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr ""
@@ -2450,7 +2440,7 @@ msgstr ""
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr ""
@@ -2459,8 +2449,8 @@ msgstr ""
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2469,7 +2459,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2477,7 +2467,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr ""
 
@@ -2485,30 +2475,27 @@ msgstr ""
 msgid "Include year in ID prefix"
 msgstr ""
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr ""
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr ""
 
@@ -2532,7 +2519,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2545,17 +2532,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2568,16 +2555,16 @@ msgstr ""
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2585,19 +2572,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2641,9 +2628,9 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
 
@@ -2667,7 +2654,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2683,24 +2670,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2708,43 +2692,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr ""
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr ""
 
@@ -2754,7 +2738,7 @@ msgstr ""
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr ""
 
@@ -2762,12 +2746,12 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr ""
@@ -2776,47 +2760,47 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr ""
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr ""
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr ""
 
@@ -2836,13 +2820,13 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr ""
@@ -2852,7 +2836,7 @@ msgstr ""
 msgid "Late Analysis"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr ""
 
@@ -2874,11 +2858,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2890,7 +2874,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr ""
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr ""
 
@@ -2902,41 +2886,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr ""
@@ -2961,35 +2945,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr ""
 
@@ -2997,16 +2981,16 @@ msgstr ""
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr ""
 
@@ -3014,31 +2998,25 @@ msgstr ""
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3047,14 +3025,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr ""
 
@@ -3062,30 +3040,30 @@ msgstr ""
 msgid "Maximum columns per results email"
 msgstr ""
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
-msgstr ""
-
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr ""
 
 #: bika/lims/content/analysis.py:115
 #: bika/lims/content/analysisservice.py:716
+msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgstr ""
+
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr ""
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr ""
 
@@ -3094,22 +3072,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr ""
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr ""
 
@@ -3121,9 +3099,9 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
 
@@ -3131,17 +3109,17 @@ msgstr ""
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr ""
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr ""
 
@@ -3153,8 +3131,8 @@ msgstr ""
 msgid "Minimum 5 characters."
 msgstr ""
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr ""
 
@@ -3162,27 +3140,27 @@ msgstr ""
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr ""
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3196,7 +3174,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3208,13 +3186,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr ""
 
@@ -3223,17 +3201,17 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3249,18 +3227,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr ""
 
@@ -3272,23 +3250,23 @@ msgstr ""
 msgid "No analyses were added to this worksheet."
 msgstr ""
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr ""
 
@@ -3296,7 +3274,7 @@ msgstr ""
 msgid "No control type specified"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3308,17 +3286,17 @@ msgstr ""
 msgid "No default preservations specified for this service"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr ""
 
@@ -3326,7 +3304,7 @@ msgstr ""
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3336,16 +3314,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3363,25 +3341,22 @@ msgstr ""
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr ""
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3401,19 +3376,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3421,30 +3396,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr ""
 
@@ -3452,15 +3427,15 @@ msgstr ""
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3469,31 +3444,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3501,15 +3476,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr ""
@@ -3522,26 +3494,26 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr ""
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3549,7 +3521,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3561,8 +3533,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3574,16 +3546,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3604,8 +3573,8 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3630,31 +3599,31 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr ""
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr ""
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr ""
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr ""
 
@@ -3667,8 +3636,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -3676,7 +3645,7 @@ msgstr ""
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3684,19 +3653,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3705,13 +3674,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr ""
 
@@ -3719,16 +3688,16 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3756,7 +3725,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr ""
 
@@ -3764,12 +3733,12 @@ msgstr ""
 msgid "Prefixes"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3781,17 +3750,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr ""
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr ""
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3802,7 +3771,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr ""
 
@@ -3812,14 +3781,14 @@ msgstr ""
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3827,34 +3796,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr ""
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3869,13 +3838,13 @@ msgstr ""
 msgid "Print date:"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3892,34 +3861,34 @@ msgstr ""
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr ""
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3927,7 +3896,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3942,21 +3911,21 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3969,8 +3938,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3991,23 +3960,23 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr ""
 
@@ -4029,9 +3998,9 @@ msgstr ""
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr ""
 
@@ -4039,11 +4008,11 @@ msgstr ""
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4052,31 +4021,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr ""
 
@@ -4084,16 +4053,16 @@ msgstr ""
 msgid "Reference Supplier"
 msgstr ""
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr ""
@@ -4102,7 +4071,7 @@ msgstr ""
 msgid "Reference analysis quality control graphs"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr ""
 
@@ -4110,21 +4079,21 @@ msgstr ""
 msgid "Reference sample"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr ""
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4147,8 +4116,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4157,9 +4126,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr ""
 
@@ -4167,7 +4136,7 @@ msgstr ""
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4175,7 +4144,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4184,8 +4153,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4194,7 +4163,7 @@ msgid "Repeated analyses"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr ""
 
@@ -4208,14 +4177,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr ""
 
@@ -4240,7 +4209,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr ""
 
@@ -4248,7 +4217,7 @@ msgstr ""
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr ""
 
@@ -4257,15 +4226,15 @@ msgstr ""
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr ""
 
@@ -4273,26 +4242,26 @@ msgstr ""
 msgid "Request new analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr ""
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4300,13 +4269,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr ""
 
@@ -4314,15 +4283,15 @@ msgstr ""
 msgid "Result Footer"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4340,11 +4309,11 @@ msgstr ""
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4352,7 +4321,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4360,11 +4329,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr ""
@@ -4373,14 +4342,14 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr ""
@@ -4399,11 +4368,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4419,12 +4388,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr ""
 
@@ -4432,19 +4401,19 @@ msgstr ""
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr ""
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4453,8 +4422,8 @@ msgid "Sample Due"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr ""
 
@@ -4466,12 +4435,12 @@ msgstr ""
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4481,52 +4450,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr ""
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4536,9 +4505,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr ""
 
@@ -4566,17 +4535,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4586,30 +4555,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4618,62 +4587,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4683,9 +4652,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr ""
 
@@ -4698,17 +4667,17 @@ msgstr ""
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4716,16 +4685,16 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4737,11 +4706,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr ""
 
@@ -4749,11 +4718,11 @@ msgstr ""
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr ""
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4765,7 +4734,7 @@ msgstr ""
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4777,11 +4746,11 @@ msgstr ""
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr ""
 
@@ -4789,19 +4758,19 @@ msgstr ""
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4827,7 +4796,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4839,7 +4808,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr ""
 
@@ -4847,7 +4816,7 @@ msgstr ""
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4871,7 +4840,7 @@ msgstr ""
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr ""
 
@@ -4887,7 +4856,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4899,7 +4868,7 @@ msgstr ""
 msgid "Separate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4907,32 +4876,28 @@ msgstr ""
 msgid "Serial No"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
-msgstr ""
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4940,31 +4905,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4980,7 +4945,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr ""
 
@@ -4992,29 +4957,25 @@ msgstr ""
 msgid "Signature"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr ""
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5022,14 +4983,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5037,41 +4998,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr ""
 
@@ -5079,33 +5040,33 @@ msgstr ""
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr ""
 
@@ -5113,37 +5074,34 @@ msgstr ""
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr ""
 
@@ -5163,11 +5121,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5176,20 +5134,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5207,35 +5165,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr ""
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr ""
 
@@ -5247,7 +5205,7 @@ msgstr ""
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5255,12 +5213,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr ""
 
@@ -5268,19 +5226,19 @@ msgstr ""
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5292,7 +5250,7 @@ msgstr ""
 msgid "The full URL: http://URL/path:port"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr ""
 
@@ -5309,24 +5267,24 @@ msgstr ""
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr ""
@@ -5343,27 +5301,27 @@ msgstr ""
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5387,7 +5345,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5404,11 +5362,11 @@ msgstr ""
 msgid "The number of requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr ""
 
@@ -5425,19 +5383,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr ""
 
@@ -5445,11 +5403,11 @@ msgstr ""
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr ""
 
@@ -5457,7 +5415,7 @@ msgstr ""
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5469,11 +5427,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5481,19 +5439,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5505,7 +5463,7 @@ msgstr ""
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5517,37 +5475,37 @@ msgstr ""
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5559,7 +5517,7 @@ msgstr ""
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5567,12 +5525,8 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
 msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
@@ -5587,63 +5541,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr ""
 
@@ -5655,13 +5609,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr ""
 
@@ -5669,22 +5623,22 @@ msgstr ""
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -5696,11 +5650,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5708,61 +5662,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr ""
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5770,13 +5718,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr ""
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5801,17 +5749,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5823,11 +5771,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5835,7 +5783,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5847,13 +5795,13 @@ msgstr ""
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr ""
@@ -5866,7 +5814,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5875,27 +5823,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr ""
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr ""
 
@@ -5903,11 +5851,11 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5915,181 +5863,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr ""
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr ""
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr ""
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr ""
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr ""
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr ""
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr ""
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr ""
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr ""
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr ""
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr ""
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr ""
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr ""
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr ""
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr ""
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6097,7 +6045,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6108,12 +6056,12 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr ""
@@ -6124,7 +6072,7 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr ""
 
@@ -6134,11 +6082,11 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr ""
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6146,24 +6094,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6174,25 +6122,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr ""
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6200,9 +6148,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr ""
 
@@ -6214,7 +6162,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6222,11 +6170,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6242,15 +6190,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6271,7 +6219,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6279,36 +6227,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6320,7 +6240,7 @@ msgstr ""
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6368,19 +6288,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6388,19 +6308,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6419,19 +6339,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6443,7 +6352,7 @@ msgstr ""
 msgid "to"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6451,7 +6360,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6476,7 +6385,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6488,6 +6397,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/zh/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh/LC_MESSAGES/bika.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (http://www.transifex.com/bikalabs/bika-lims/language/zh/)\n"
@@ -26,49 +26,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} 等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: 部分等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} 等待接收."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} 等待接收."
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "%误差"
 
@@ -98,15 +98,15 @@ msgstr ""
 msgid "% Published"
 msgstr ""
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -118,15 +118,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'典型的'表示按样品和分析服务板块导入的分析请求. 在多选分析服务时, 在''配置'中分析配置关键词"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(空白)"
@@ -139,7 +139,7 @@ msgstr "(对照)"
 msgid "(Duplicate)"
 msgstr "(重复样)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(有害废弃物)"
 
@@ -148,32 +148,26 @@ msgid "(Required)"
 msgstr "(要求的)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr ""
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -184,16 +178,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -205,7 +199,7 @@ msgstr "分析请求附件选项"
 msgid "AR ID Padding"
 msgstr "分析请求编号长度"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "导入分析请求"
 
@@ -213,17 +207,17 @@ msgstr "导入分析请求"
 msgid "AR Import options"
 msgstr "分析请求导入选项"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "分析请求模板"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr ""
 
@@ -231,54 +225,54 @@ msgstr ""
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "帐户名"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "帐号"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "帐户类型"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "认证"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "认证方缩写"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "认证方网址链接"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "认证标志"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "认证编码"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "已认证"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -292,21 +286,21 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "活跃的"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -326,11 +320,7 @@ msgstr "添加对照参考"
 msgid "Add Duplicate"
 msgstr "添加重复样"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "添加模板"
 
@@ -338,16 +328,16 @@ msgstr "添加模板"
 msgid "Add a remarks field to all analyses"
 msgstr ""
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "地址"
@@ -360,26 +350,26 @@ msgstr "在ID前缀后面添加2位年"
 msgid "Administrative Reports"
 msgstr "管理员报告"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "所有的"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "所有已认证的分析服务均列于此."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "所有已分派分析"
 
@@ -391,7 +381,7 @@ msgstr "所有分析类型"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr ""
 
@@ -399,15 +389,15 @@ msgstr ""
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr ""
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -415,11 +405,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr ""
 
@@ -427,48 +417,48 @@ msgstr ""
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr ""
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "始终扩展客户端视图中选定的类别"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "数量"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "分析"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "范围外分析"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "分析 - 按分析服务"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "类型分析 - 按样品"
@@ -482,7 +472,7 @@ msgstr "分析 - 按服务"
 msgid "Analyses performed and published as % of total"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr ""
 
@@ -495,27 +485,27 @@ msgstr ""
 msgid "Analyses repeated"
 msgstr "重复的分析"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "已重新分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "已重新测试的分析"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "分析"
 
@@ -523,52 +513,52 @@ msgstr "分析"
 msgid "Analysis Attachment Option"
 msgstr "分析附件选项"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "多个分析类别"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "单个分析类别"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "分析关键词"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "分析属性"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr ""
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "分析请求编号"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "导入分析请求"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr ""
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -576,65 +566,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "分析请求"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "单个分析服务"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "多个分析服务"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "分析祥述"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "分析类型"
@@ -643,46 +633,46 @@ msgstr "分析类型"
 msgid "Analysis category"
 msgstr "分析类别"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "分析请求 ${AR} 已成功创建."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "分析请求 ${ARs} 已成功创建."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "分析请求与分析"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "分析请求与分析 - 按客户"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "未结算的分析请求"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "误差范围内的分析结果"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr ""
 
@@ -690,12 +680,12 @@ msgstr ""
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "分析结果超出实验室或客户指定范围 - 注意这可能需要花费几分钟"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "分析服务"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "重置分析规格至实验室默认值"
 
@@ -711,17 +701,17 @@ msgstr "分析周转时间"
 msgid "Analysis turnaround time over time"
 msgstr "分析周转时间超时"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "分析周转时间"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "分析周转时间超时"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "分析员"
 
@@ -730,7 +720,7 @@ msgid "Analyst must be specified."
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "任何"
 
@@ -742,7 +732,7 @@ msgstr ""
 msgid "Apply template"
 msgstr "应用模板"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr ""
 
@@ -760,15 +750,15 @@ msgstr ""
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "已分派到工作表"
 
@@ -786,27 +776,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "附加于"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "附件"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "附件关键词"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "附件选项"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "单一附件类型"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "多个附件类型"
 
@@ -816,25 +806,25 @@ msgstr "多个附件类型"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "不允许添加附件"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "要求添加附件"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "附件类型"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "多个附件"
 
@@ -846,7 +836,7 @@ msgstr ""
 msgid "Autofill"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr ""
 
@@ -863,27 +853,27 @@ msgstr ""
 msgid "Available templates"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "平均周转时间"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "平均较早"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "平均较晚"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "银行支行"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "银行名"
 
@@ -892,31 +882,31 @@ msgid "Basis"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "批"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "批ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "多批"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr ""
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr ""
 
@@ -924,7 +914,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr ""
 
@@ -932,7 +922,7 @@ msgstr ""
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr ""
 
@@ -940,63 +930,67 @@ msgstr ""
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "账单地址"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "空白"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "品牌"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "批发价(不含增值税)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "办公电话"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "由"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "抄送多个邮件"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "计算"
 
@@ -1004,8 +998,8 @@ msgstr "计算"
 msgid "Calculation Formula"
 msgstr "计算公式"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "临时场地计算"
@@ -1018,11 +1012,11 @@ msgstr "计算: ${calc_name}"
 msgid "Calculation: None"
 msgstr "计算: 没有"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "多个计算"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr ""
 
@@ -1034,12 +1028,12 @@ msgstr ""
 msgid "Calibration report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1053,9 +1047,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -1071,18 +1065,18 @@ msgstr ""
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr ""
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "容量"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "已捕获"
 
@@ -1091,7 +1085,7 @@ msgid "Cardinal"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "类别号码"
 
@@ -1099,17 +1093,17 @@ msgstr "类别号码"
 msgid "Categorise analysis services"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "类别"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "类别"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr ""
 
@@ -1122,31 +1116,31 @@ msgstr ""
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "如果该分析服务已包含在实验室认证分析计划中, 选中这个勾选框"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "如果此点的样品是混合物, 即由多个样品混合而成的,则选中这个勾选框, 比如将大坝表面的几个样品混合在一起作为该大坝的样品. 默认没有勾选, 表示直接采取的样品"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "如果这个容器已经保留则选中这个勾选框. 选中这个勾选框将不会进一步选择是否保留该容器中的各个样品."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "如果实验室已认证则选中这个勾选框"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "勾选本框以确认本次分析服务已使用单独的样品容器"
 
@@ -1154,7 +1148,7 @@ msgstr "勾选本框以确认本次分析服务已使用单独的样品容器"
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "如果你想使用单独的ID服务器则选中此处. 在每个Bika站点中样品前缀可以单独配置"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr ""
 
@@ -1170,19 +1164,19 @@ msgstr ""
 msgid "City"
 msgstr "城市"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "典型的"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr ""
 
@@ -1190,19 +1184,19 @@ msgstr ""
 msgid "Click to download"
 msgstr "点击下载"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "客户"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "客户编号"
 
@@ -1210,59 +1204,59 @@ msgstr "客户编号"
 msgid "Client Landing Page"
 msgstr ""
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "客户名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "客户订单"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "客户参阅"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "客户参阅"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "客户样品编号"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "提交请求前需要客户联系"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "多个客户"
 
@@ -1271,39 +1265,39 @@ msgstr "多个客户"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "已关闭"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr ""
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr ""
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr ""
 
@@ -1311,21 +1305,21 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "混合物"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "混合物等级%"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "配置该模板的样品个部分和保留样品. 分配样品各部分给模板上的分析实验室"
 
@@ -1334,13 +1328,13 @@ msgid "Confirm password"
 msgstr "确认密码"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "联系方式"
@@ -1349,8 +1343,8 @@ msgstr "联系方式"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "多个联系方式"
@@ -1359,48 +1353,48 @@ msgstr "多个联系方式"
 msgid "Contacts to CC"
 msgstr "抄送联系方式"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "容器"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "容器类型"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "多个容器类型"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "多个容器"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "内容类型"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "正文类型"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "对照"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr ""
 
@@ -1416,12 +1410,12 @@ msgstr ""
 msgid "Copy from"
 msgstr "拷贝自"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "计数"
 
@@ -1434,18 +1428,18 @@ msgstr "国家"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "已创建"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr ""
 
@@ -1453,7 +1447,7 @@ msgstr ""
 msgid "Created by:"
 msgstr "创建者: "
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1461,8 +1455,8 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr ""
 
@@ -1470,12 +1464,12 @@ msgstr ""
 msgid "Currency"
 msgstr "现金"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "当前"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr ""
 
@@ -1488,7 +1482,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1502,88 +1496,88 @@ msgstr "数据界面"
 msgid "Data Interface Options"
 msgstr "数据界面选项"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "日期"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "发送日期"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "处置日期"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "过期日期"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "导入日期"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "载入日期"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "打开日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "保留时间"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "发布日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "收到日期"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "请求日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "做样日期"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1599,7 +1593,7 @@ msgstr ""
 msgid "Date from which the instrument is under calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr ""
 
@@ -1617,7 +1611,7 @@ msgid "Date until the certificate is valid"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr ""
@@ -1626,11 +1620,11 @@ msgstr ""
 msgid "Date when the calibration certificate was granted"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "天数"
 
@@ -1642,17 +1636,17 @@ msgstr ""
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "默认"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr ""
 
@@ -1660,49 +1654,49 @@ msgstr ""
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "默认容器"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr ""
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "默认保留"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr ""
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "默认类别"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr ""
 
@@ -1711,11 +1705,11 @@ msgid "Default containers: ${container_list}"
 msgstr "默认的多个容器: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1739,11 +1733,11 @@ msgstr ""
 msgid "Default scientific notation format for results"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "默认价值"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr ""
 
@@ -1751,7 +1745,7 @@ msgstr ""
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr ""
 
@@ -1759,11 +1753,11 @@ msgstr ""
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
@@ -1771,16 +1765,16 @@ msgstr ""
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "度"
 
@@ -1788,9 +1782,9 @@ msgstr "度"
 msgid "Delete attachment"
 msgstr "删除附件"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "系"
 
@@ -1803,13 +1797,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "以来分析"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "为外行能看懂的语言描述方法. 该信息为客户可见."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "描述"
 
@@ -1817,7 +1811,7 @@ msgstr "描述"
 msgid "Description of the actions made during the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr ""
 
@@ -1825,19 +1819,19 @@ msgstr ""
 msgid "Description of the actions made during the validation"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr ""
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1845,7 +1839,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "折扣%"
 
@@ -1853,16 +1847,16 @@ msgstr "折扣%"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已发送"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "显示值"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr ""
 
@@ -1874,7 +1868,7 @@ msgstr ""
 msgid "Display individual sample partitions "
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "清除时间"
 
@@ -1883,8 +1877,8 @@ msgstr "清除时间"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已处置"
@@ -1893,54 +1887,54 @@ msgstr "已处置"
 msgid "District"
 msgstr "区"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "不活动"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr ""
 
@@ -1953,20 +1947,20 @@ msgstr "干燥"
 msgid "Dry matter analysis"
 msgstr "干燥物质分析"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "截止"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "截止期"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1975,20 +1969,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "重复"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "重复- "
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "重复变化%"
 
@@ -2000,35 +1994,35 @@ msgstr "重复分析质量控制"
 msgid "Duplicate analysis quality control graphs"
 msgstr "重复分析质量控制图"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "持续时间"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "如 SANAS, APLAC 等"
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "提前量"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "较早的"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "评估"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Email地址"
 
@@ -2036,7 +2030,7 @@ msgstr "Email地址"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Email标题行"
 
@@ -2056,14 +2050,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr ""
 
@@ -2075,16 +2069,16 @@ msgstr ""
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "输入折扣百分数值, 如7折就输30"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "输入百分数值, 如14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr ""
 
@@ -2092,15 +2086,15 @@ msgstr ""
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "输入百分数值, 如14.0. 这个百分数值将作为系统值使用,但对于单个项目可以重新定义."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "输入百分数值, 如33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "输入采样点的纬度. 度: 0-90, 分: 0-59, 秒: 0-59 以及北N/南S纬 "
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "输入采样点的经度. 度: 0-180, 分: 0-59, 秒: 0-59 以及东E/西W经"
 
@@ -2108,7 +2102,7 @@ msgstr "输入采样点的经度. 度: 0-180, 分: 0-59, 秒: 0-59 以及东E/�
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr ""
 
@@ -2116,45 +2110,45 @@ msgstr ""
 msgid "Entity"
 msgstr ""
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr ""
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "从结算中取出"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "单个期望结果"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr ""
 
@@ -2163,19 +2157,19 @@ msgstr ""
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "已过期"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "过期日期"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr ""
 
@@ -2183,44 +2177,40 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "传真"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "传真(办公)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "女/雌"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "场地"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "场地分析"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "场地保留"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "场地名"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "文件"
 
@@ -2228,19 +2218,19 @@ msgstr "文件"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr ""
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "文件名"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2260,16 +2250,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "名"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "公式"
 
@@ -2279,18 +2269,18 @@ msgstr "公式"
 msgid "From"
 msgstr "自"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "全名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "已预约时间的样品"
 
@@ -2300,7 +2290,7 @@ msgstr "已预约时间的样品"
 msgid "Generate report"
 msgstr ""
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "称谓, 如先生,女士, 博士"
 
@@ -2312,37 +2302,37 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "危险废弃物"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr ""
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "小时"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2351,8 +2341,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID服务器网址"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "Id服务器不可用"
 
@@ -2360,31 +2350,31 @@ msgstr "Id服务器不可用"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2396,7 +2386,7 @@ msgstr ""
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2404,27 +2394,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr ""
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr ""
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "如果已请求,在此选择分析的计算方法.计算方法可以在实验室信息管理系统设置中的计算项目下面配置"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr ""
 
@@ -2432,7 +2422,7 @@ msgstr ""
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr ""
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "如果该容器已经被预留, 则预留方法可以在此选择."
 
@@ -2445,7 +2435,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr ""
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "导入"
@@ -2454,7 +2444,7 @@ msgstr "导入"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "已导入"
@@ -2463,8 +2453,8 @@ msgstr "已导入"
 msgid "In-lab calibration procedure"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr ""
@@ -2473,7 +2463,7 @@ msgstr ""
 msgid "Include Previous Results From Batch"
 msgstr ""
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr ""
 
@@ -2481,7 +2471,7 @@ msgstr ""
 msgid "Include and display pricing information"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "包含描述"
 
@@ -2489,30 +2479,27 @@ msgstr "包含描述"
 msgid "Include year in ID prefix"
 msgstr "在ID前缀中包含年份"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr ""
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr ""
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "不确定的结果"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "指明对此分析是否要求文件附件,如显微镜照片等, 以及数据采集计算机的上传功能是否有效"
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr ""
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "起始修改"
 
@@ -2536,7 +2523,7 @@ msgstr ""
 msgid "InstallationDate"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
@@ -2549,17 +2536,17 @@ msgstr ""
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "仪器"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2572,16 +2559,16 @@ msgstr "仪器导入"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr ""
 
@@ -2589,19 +2576,19 @@ msgstr ""
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2645,9 +2632,9 @@ msgstr "仪器类型"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "多个仪器"
 
@@ -2671,7 +2658,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr ""
 
@@ -2687,24 +2674,21 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr ""
 
@@ -2712,43 +2696,43 @@ msgstr ""
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "发票不包括"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "项目不活"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "项目将包含在邮件标题栏中"
 
@@ -2758,7 +2742,7 @@ msgstr "项目将包含在邮件标题栏中"
 msgid "Job Title"
 msgstr ""
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "工作职位"
 
@@ -2766,12 +2750,12 @@ msgstr "工作职位"
 msgid "Key"
 msgstr "关键"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "关键词"
@@ -2780,47 +2764,47 @@ msgstr "关键词"
 msgid "Keywords"
 msgstr "多个关键词"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "实验室"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "实验室分析"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "实验室联系方式"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "实验室科系"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "实验室保存"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "实验室产品"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "实验室网址"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "实验室"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "实验室认证"
 
@@ -2840,13 +2824,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "上次更改"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "延迟"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "分析延迟"
@@ -2856,7 +2840,7 @@ msgstr "分析延迟"
 msgid "Late Analysis"
 msgstr "分析延迟"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "纬度"
 
@@ -2878,11 +2862,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "已链接样品"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2894,7 +2878,7 @@ msgstr ""
 msgid "Load Setup Data"
 msgstr "载入设置数据"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "在此载入描述该方法的文档"
 
@@ -2906,41 +2890,41 @@ msgstr ""
 msgid "Load the certificate document here"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "已加载"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr ""
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "记录"
@@ -2965,35 +2949,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "经度"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "批号"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr ""
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "邮寄地址"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr ""
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "男/雄"
 
@@ -3001,16 +2985,16 @@ msgstr "男/雄"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "经理"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "经理Email"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "经理电话"
 
@@ -3018,31 +3002,25 @@ msgstr "经理电话"
 msgid "Manual"
 msgstr ""
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr ""
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr ""
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "制造商"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr ""
 
@@ -3051,14 +3029,14 @@ msgstr ""
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "最大"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "最大时间"
 
@@ -3066,30 +3044,30 @@ msgstr "最大时间"
 msgid "Maximum columns per results email"
 msgstr "最大的列 - 按结果email"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "最大的样品可能的尺寸或体积"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "完成分析的最长允许时间. 该时间截止后会有一个延迟分析警告."
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "最大周转时间"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "会员折扣%"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "会员折扣可用"
 
@@ -3098,22 +3076,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "方法"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "方法文档"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr ""
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "方法说明"
 
@@ -3125,9 +3103,9 @@ msgstr "方法: ${method_name}"
 msgid "Method: None"
 msgstr "方法: 没有"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "多个方法"
 
@@ -3135,17 +3113,17 @@ msgstr "多个方法"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "方法包含在本实验室 ${accreditation_body} 认证计划中. 分析注释未认证."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr ""
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "最小"
 
@@ -3157,8 +3135,8 @@ msgstr "我的"
 msgid "Minimum 5 characters."
 msgstr "最少5个"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "最小体积"
 
@@ -3166,27 +3144,27 @@ msgstr "最小体积"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "质量控制统计计算的最小结果数目"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "分钟"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "手机"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "型号"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr ""
 
@@ -3200,7 +3178,7 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3212,13 +3190,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "名称"
 
@@ -3227,17 +3205,17 @@ msgstr "名称"
 msgid "New"
 msgstr "新文件"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "否"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3253,18 +3231,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "没有选择分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "你的请求没有符合的分析"
 
@@ -3276,23 +3254,23 @@ msgstr "没有添加分析"
 msgid "No analyses were added to this worksheet."
 msgstr "该工作表中没有添加分析."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "没有改变"
 
@@ -3300,7 +3278,7 @@ msgstr "没有改变"
 msgid "No control type specified"
 msgstr "没有指定对照类型"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3312,17 +3290,17 @@ msgstr "本服务没有指定默认容器"
 msgid "No default preservations specified for this service"
 msgstr "本服务没有指定默认保留"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "没有选择项目"
 
@@ -3330,7 +3308,7 @@ msgstr "没有选择项目"
 msgid "No items selected"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr ""
 
@@ -3340,16 +3318,16 @@ msgstr ""
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "没有选择参考样品"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr ""
 
@@ -3367,25 +3345,22 @@ msgstr "${contact_fullname}用户不存在且他/她不能登入. 请填写下�
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "没有"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "不允许"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr ""
 
@@ -3405,19 +3380,19 @@ msgstr ""
 msgid "Num columns"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3425,30 +3400,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "分析数目"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "分析数目周期超出范围"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "分析请求数量 - 按分析服务"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "分析请求数目 - 按样品类型"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "分析数目已周期性重测"
 
@@ -3456,15 +3431,15 @@ msgstr "分析数目已周期性重测"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "请求数目"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3473,31 +3448,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "样品数量"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr ""
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr ""
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "一旦保留, 样品必须在该时间周期内处置. 如果没有指明, 将使用该样品类型的时间周期."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3505,15 +3480,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr ""
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "打开"
@@ -3526,26 +3498,26 @@ msgstr ""
 msgid "Order"
 msgstr "订单"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "订单日期"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "订单ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "订单号码"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "多个订单"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr ""
 
@@ -3553,7 +3525,7 @@ msgstr ""
 msgid "Organization responsible of granting the calibration certificate"
 msgstr ""
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3565,8 +3537,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr ""
 
@@ -3578,16 +3550,13 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "一部分"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3608,8 +3577,8 @@ msgstr "密码"
 msgid "Password lifetime"
 msgstr "密码有效期"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "正在处理"
@@ -3634,31 +3603,31 @@ msgstr ""
 msgid "Period"
 msgstr "周期"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "已许可"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "许可误差%"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "电话"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "电话(办公)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "电话(家庭)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "电话(手机)"
 
@@ -3671,8 +3640,8 @@ msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "住址"
 
@@ -3680,7 +3649,7 @@ msgstr "住址"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3688,19 +3657,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "请上传认证机构授权你在你的网站和结果报告上使用的认证标识. 最大尺寸为175x175像素."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "捕获点"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3709,13 +3678,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "位置"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "邮寄地址"
 
@@ -3723,16 +3692,16 @@ msgstr "邮寄地址"
 msgid "Postal code"
 msgstr "邮编"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "已预留"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "小数精度"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3760,7 +3729,7 @@ msgstr ""
 msgid "Preferred scientific notation format for results"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "前缀"
 
@@ -3768,12 +3737,12 @@ msgstr "前缀"
 msgid "Prefixes"
 msgstr "人名前的称谓"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3785,17 +3754,17 @@ msgstr ""
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "储藏"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "保留类别"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3806,7 +3775,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "保留的样品"
 
@@ -3816,14 +3785,14 @@ msgstr "保留的样品"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "保留人"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr ""
 
@@ -3831,34 +3800,34 @@ msgstr ""
 msgid "Preventive maintenance procedure"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "价格"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "价格(不含增值税)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr ""
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "不含增值税的价格"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "价格列表:"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr ""
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3873,13 +3842,13 @@ msgstr ""
 msgid "Print date:"
 msgstr "打印日期"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr ""
 
@@ -3896,34 +3865,34 @@ msgstr "产能报告"
 msgid "Professional Open Source LIMS/LIS"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "概况"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "概况分析"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "关键概况"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "概况关键词"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "多个概况"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr ""
 
@@ -3931,7 +3900,7 @@ msgstr ""
 msgid "Public. Lag"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr ""
 
@@ -3946,21 +3915,21 @@ msgstr "发布偏好"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "已发布"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "未包含在发票中的已发布的分析"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr ""
 
@@ -3973,8 +3942,8 @@ msgid "QC Analyses"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr ""
 
@@ -3995,23 +3964,23 @@ msgstr "质量"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "范围最大值"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "范围最小值"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "特定范围"
 
@@ -4033,9 +4002,9 @@ msgstr "接收"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "已收到"
 
@@ -4043,11 +4012,11 @@ msgstr "已收到"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr ""
 
@@ -4056,31 +4025,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "参考"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "参考定义"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "参考多项定义"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "参考样品"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "参考样品"
 
@@ -4088,16 +4057,16 @@ msgstr "参考样品"
 msgid "Reference Supplier"
 msgstr "参考供应商"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "参考类型"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "参考分析质量控制"
@@ -4106,7 +4075,7 @@ msgstr "参考分析质量控制"
 msgid "Reference analysis quality control graphs"
 msgstr "参考分析质量控制图"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "参考分析质量控制图"
 
@@ -4114,21 +4083,21 @@ msgstr "参考分析质量控制图"
 msgid "Reference sample"
 msgstr "参考样品"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "样品参考值为0或'空白'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "参考定义代表用于质量控制测试的样品类型的参考定义"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr ""
 
@@ -4151,8 +4120,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4161,9 +4130,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "注释"
 
@@ -4171,7 +4140,7 @@ msgstr "注释"
 msgid "Remarks to take into account before calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr ""
 
@@ -4179,7 +4148,7 @@ msgstr ""
 msgid "Remarks to take into account before validation"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr ""
 
@@ -4188,8 +4157,8 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr ""
 
@@ -4198,7 +4167,7 @@ msgid "Repeated analyses"
 msgstr "重复分析"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "报告"
 
@@ -4212,14 +4181,14 @@ msgstr ""
 msgid "Report ID"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "报告类型"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "作为干燥物质报告"
 
@@ -4244,7 +4213,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "报告类型"
 
@@ -4252,7 +4221,7 @@ msgstr "报告类型"
 msgid "Report upload"
 msgstr ""
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "多个报告"
 
@@ -4261,15 +4230,15 @@ msgstr "多个报告"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "请求"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "请求ID"
 
@@ -4277,26 +4246,26 @@ msgstr "请求ID"
 msgid "Request new analyses"
 msgstr "请求新分析"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "已请求"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "多个请求"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "已请求"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "要求的体积"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr ""
 
@@ -4304,13 +4273,13 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "限制类别"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "结果"
 
@@ -4318,15 +4287,15 @@ msgstr "结果"
 msgid "Result Footer"
 msgstr "结果页脚"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "结果选项"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "结果值"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4344,11 +4313,11 @@ msgstr "结果超出范围"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr ""
 
@@ -4356,7 +4325,7 @@ msgstr ""
 msgid "Results attachments permitted"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr ""
 
@@ -4364,11 +4333,11 @@ msgstr ""
 msgid "Results interpretation"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "结果 - 按取样点"
@@ -4377,14 +4346,14 @@ msgstr "结果 - 按取样点"
 msgid "Results per samplepoint and analysis service"
 msgstr "结果 - 按取样点和分析服务"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "保留周期"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "已重新测试"
@@ -4403,11 +4372,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr ""
 
@@ -4423,12 +4392,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr ""
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "称呼"
 
@@ -4436,19 +4405,19 @@ msgstr "称呼"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "同上, 但设置为分析服务的默认值. 该设置可以在具体样品的配置上修改."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "样品"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr ""
 
@@ -4457,8 +4426,8 @@ msgid "Sample Due"
 msgstr "样品截止日"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "样品编号"
 
@@ -4470,12 +4439,12 @@ msgstr "样品编号位数"
 msgid "Sample ID Sequence Start"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr ""
 
@@ -4485,52 +4454,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "样品区块"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "单个样品点"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "多个样品点"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "样品类型"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "样品类型前缀"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr ""
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "多个样品类型"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr ""
 
@@ -4540,9 +4509,9 @@ msgstr ""
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "取样点"
 
@@ -4570,17 +4539,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "样品类型"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr ""
 
@@ -4590,30 +4559,30 @@ msgstr ""
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "取样人"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "多个样品"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "该类型的样品需要作为\"危险废弃物\"处理"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr ""
@@ -4622,62 +4591,62 @@ msgstr ""
 msgid "Samples received vs. samples reported"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "采样日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "取样频率"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4687,9 +4656,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "保存"
 
@@ -4702,17 +4671,17 @@ msgstr "保存注释"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr ""
 
@@ -4720,16 +4689,16 @@ msgstr ""
 msgid "Search"
 msgstr "搜索"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "秒"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4741,11 +4710,11 @@ msgstr ""
 msgid "Select AR Templates to include"
 msgstr ""
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "选择用户界面"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "为此分析服务选择一个默认保留. 如果保存取决于关于样品类型的组合, 请在下表中按样品指定保存类型"
 
@@ -4753,11 +4722,11 @@ msgstr "为此分析服务选择一个默认保留. 如果保存取决于关于�
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "选择一个终点位置和分析请求来重复."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "从'实验室联系'选项中可用的职员中选择一个管理员. 科系管理员们的名字将在含有他们所在科系的分析报告中列出."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr ""
 
@@ -4769,7 +4738,7 @@ msgstr "选项所有选项"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr ""
 
@@ -4781,11 +4750,11 @@ msgstr "选择分析员"
 msgid "Select existing file"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "选择是否从结算报告中将排除该分析"
 
@@ -4793,19 +4762,19 @@ msgstr "选择是否从结算报告中将排除该分析"
 msgid "Select if is an in-house calibration certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "选择是否添加描述"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4831,7 +4800,7 @@ msgstr ""
 msgid "Select the currency the site will use to display prices."
 msgstr "选择用于网站显示价格的货币种类."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4843,7 +4812,7 @@ msgstr ""
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "选择合适的仪器"
 
@@ -4851,7 +4820,7 @@ msgstr "选择合适的仪器"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4875,7 +4844,7 @@ msgstr "选此激活样品采集工作流程."
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "选择工作表中需要包含的分析"
 
@@ -4891,7 +4860,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4903,7 +4872,7 @@ msgstr ""
 msgid "Separate"
 msgstr "分隔"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr ""
 
@@ -4911,32 +4880,28 @@ msgstr ""
 msgid "Serial No"
 msgstr "序列号"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "服务"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "服务已包含在 ${accreditation_body_abbrev} 中"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "多个服务"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr ""
 
@@ -4944,31 +4909,31 @@ msgstr ""
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "按结果email设置最大分析请求数目. 有的用户喜欢每个email包含少一些的结果, email中列数过多对他们来说阅读困难"
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "设置实验室分析结果规格"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr ""
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "邮寄地址"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4984,7 +4949,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "用户视图中只能看到选中的类别"
 
@@ -4996,29 +4961,25 @@ msgstr ""
 msgid "Signature"
 msgstr "签名"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "尺寸"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr ""
 
@@ -5026,14 +4987,14 @@ msgstr ""
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr ""
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5041,41 +5002,41 @@ msgstr ""
 msgid "Specification"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指出工作表的大小,如相应仪器的样品盘大小. 然后按工作表位置选择分析'类型'. 选择质量控制样品的位置也需要选择使用参考样品. 如果选择了重复样品, 指明需要重复哪一个位置的样品."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "州"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "状态"
 
@@ -5083,33 +5044,33 @@ msgstr "状态"
 msgid "Sticker templates"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr ""
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "提交"
 
@@ -5117,37 +5078,34 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr ""
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "子项总计"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "供应商"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr ""
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr ""
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "姓"
 
@@ -5167,11 +5125,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr ""
 
@@ -5180,20 +5138,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr ""
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "为分析员准备的技术描述和说明"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "温度"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5211,35 +5169,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "实验室为用户请求分配了此ID"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "实验室为用户样品分配了此ID"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "实验室网址"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "适用的认证标准, 如 ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "分析包含于此配置中, 按类别分组"
 
@@ -5251,7 +5209,7 @@ msgstr "该分析用于检测干燥物质."
 msgid "The analyst or agent responsible of the calibration"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr ""
 
@@ -5259,12 +5217,12 @@ msgstr ""
 msgid "The analyst responsible of the validation"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "附件链接到分析请求和分析"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "该分析服务类别属于"
 
@@ -5272,19 +5230,19 @@ msgstr "该分析服务类别属于"
 msgid "The date the instrument was installed"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr ""
 
@@ -5296,7 +5254,7 @@ msgstr "输入折扣的百分数, 该折扣将用于标为'会员'的用户,通�
 msgid "The full URL: http://URL/path:port"
 msgstr "具体网址, 如: http://xxx.xxx.xxx/xxx:xxx"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取样高度或深度"
 
@@ -5313,24 +5271,24 @@ msgstr "仪器型号"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "该实验室未经认证, 或者尚未设置认证信息."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "实验室科系"
@@ -5347,27 +5305,27 @@ msgstr "样品ID数字位数为0的长度"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "分析请求ID的分析请求数目数字位数为0的长度"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "可采集类型的取样点列表. 如果没有样品类型被选择, 则所有取样点都将可以采集."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "此取样点处可以采集的样品类型列表. 如果没有选择样品类型, 则所有样品类型都可采集."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "该分析结果的单位, 如毫克/升, ppm, dB, mV等"
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
 
@@ -5391,7 +5349,7 @@ msgstr "密码有效天数. 如果输入0则表示永远有效"
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "样品有效天数, 过期的样品将不能分析. 该设置可以在样品类型设置中为具体样品类型重置."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5408,11 +5366,11 @@ msgstr "请求和分析的数量"
 msgid "The number of requests and analyses per client"
 msgstr "The number of requests and analyses per client"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "该类型非保留样品的可用于测试的有效期周期"
 
@@ -5429,19 +5387,19 @@ msgstr ""
 msgid "The person at the supplier who prepared the certificate"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "按样品的大客户折扣价"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "识别导入文件的独特配置关键词. 这个词必须唯一, 并且不能和临时场地计算（Calculation Interim fileld）ID抑一致"
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "认证机构向实验室发放的参考码"
 
@@ -5449,11 +5407,11 @@ msgstr "认证机构向实验室发放的参考码"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "在样品点取样时捕获到的场地分析的结果, 如取样河流的取样水温. 实验分析在实验室完成"
 
@@ -5461,7 +5419,7 @@ msgstr "在样品点取样时捕获到的场地分析的结果, 如取样河流�
 msgid "The room and location where the instrument is installed"
 msgstr ""
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr ""
 
@@ -5473,11 +5431,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "仪器唯一序列号"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr ""
 
@@ -5485,19 +5443,19 @@ msgstr ""
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "系统范围内的默认配置,表明是否要求,允许或禁止为分析请求添加附件."
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr ""
 
@@ -5509,7 +5467,7 @@ msgstr "分析周转时间"
 msgid "The turnaround times of analyses plotted over time"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr ""
 
@@ -5521,37 +5479,37 @@ msgstr "没有结果"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "由于计算未工作, 分析服务不能激活."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "由于从属于一个或多个计算, 该分析服务现在不能停止."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5563,7 +5521,7 @@ msgstr "本服务不需要单独分区"
 msgid "This service requires a separate container."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5571,13 +5529,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "该文本将添加到结果报告后."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "本值为所有发布的结果中最低值"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5591,63 +5545,63 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "标题"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "需要保留"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "需要取样"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "需要验证"
 
@@ -5659,13 +5613,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "总计"
 
@@ -5673,22 +5627,22 @@ msgstr "总计"
 msgid "Total Lag"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "总价"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "总分析"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "总价"
 
@@ -5700,11 +5654,11 @@ msgstr ""
 msgid "Traceability"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5712,61 +5666,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "类型"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr ""
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr ""
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "没有分派"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "不确定性"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "不确定值"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr ""
 
@@ -5774,13 +5722,13 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "单位"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr ""
 
@@ -5805,17 +5753,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5827,11 +5775,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上传一个用于打印分析报告的签名扫描件. 理想尺寸为250像素宽, 150像素高"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr ""
 
@@ -5839,7 +5787,7 @@ msgstr ""
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr ""
 
@@ -5851,13 +5799,13 @@ msgstr "使用外部ID服务器"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "用户"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "用户名"
@@ -5870,7 +5818,7 @@ msgstr ""
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr ""
@@ -5879,27 +5827,27 @@ msgstr ""
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "取样点太少时分析结果无意义. 请在质量控制统计处理前设置可接受的最小样品量."
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "增值税"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "增值税%"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "增值税额"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr ""
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "增值税数目"
 
@@ -5907,11 +5855,11 @@ msgstr "增值税数目"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "有效自"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr ""
 
@@ -5919,181 +5867,181 @@ msgstr ""
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr ""
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "验证失败: '${keyword}': 重复关键词"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "验证失败: '${title}': 该关键词已在计算 '${used_by}' 中使用"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "验证失败: '${title}': 该关键词已在服务 '${used_by}' 中使用"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "验证失败: '${title}': 重复的标题"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "验证失败: '${value}' 非唯一"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "验证失败: 方向必须是E（东）/W（西）"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "验证失败: 方向必须是N（北）/S（南）"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr ""
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr ""
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "验证失败: 关键词 '${keyword}' 无效"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr ""
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "验证失败: 百分误差值必须介于0到100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "验证失败: 百分误差值必须为数字"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "验证失败: 预保留容器必须选择保留."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr ""
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "验证失败: 结果必须是数字"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "验证失败: 要求选中如下类别: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "验证失败: 列标题 '${title}' 必须含有关键词 '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "验证失败: 度为180时, 分必须为0"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "验证失败: 度为180时, 秒必须为0"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "验证失败: 度为90时, 分必须为0"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "验证失败: 度为90时, 秒必须为0"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "验证失败: 度必须在0-180之间"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "验证失败: 度必须在0-90间"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "验证失败: 度必须是数字"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "验证失败: 关键词 '${keyword}' 必须含有列标题 '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "验证失败: 关键词包含无效字符"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "验证失败: 需要关键词"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "验证失败: 分必须在0-59之间"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "验证失败: 分必须是数字"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr ""
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr ""
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "验证失败: 秒必须在0-59之间"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "验证失败: 秒必须是数字"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "验证失败: 需要标题"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6101,7 +6049,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr ""
@@ -6112,12 +6060,12 @@ msgstr ""
 msgid "Value"
 msgstr "值"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "已验证"
@@ -6128,7 +6076,7 @@ msgstr "已验证"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "版本"
 
@@ -6138,11 +6086,11 @@ msgstr "版本"
 msgid "Volume"
 msgstr "体积"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "认证机构的网址"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr ""
 
@@ -6150,24 +6098,24 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr ""
@@ -6178,25 +6126,25 @@ msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "工作表"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "工作表布局"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "工作表模板"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "多个工作表"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr ""
 
@@ -6204,9 +6152,9 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "是"
 
@@ -6218,7 +6166,7 @@ msgstr ""
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr ""
 
@@ -6226,11 +6174,11 @@ msgstr ""
 msgid "You must select an instrument"
 msgstr "你必须选择一个仪器"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr ""
 
@@ -6246,15 +6194,15 @@ msgstr ""
 msgid "analysis requests selected"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr ""
 msgid "bika-frontpage-title"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr ""
 
@@ -6283,36 +6231,8 @@ msgstr ""
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
@@ -6324,7 +6244,7 @@ msgstr "失活"
 msgid "heading_arpriority"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6372,19 +6292,19 @@ msgstr ""
 msgid "new_version_available_title"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6392,19 +6312,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6423,19 +6343,8 @@ msgstr ""
 msgid "text_default_site_title"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6447,7 +6356,7 @@ msgstr ""
 msgid "to"
 msgstr "至"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6455,7 +6364,7 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr ""
 
@@ -6480,7 +6389,7 @@ msgstr ""
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6492,6 +6401,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/zh_CN/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh_CN/LC_MESSAGES/bika.po
@@ -18,7 +18,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/bikalabs/bika-lims/language/zh_CN/)\n"
@@ -36,49 +36,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr "联系人${contact_fullname} （全名）可以使用用户名${contact_username}登录入LIMS系统。联系人必须修改他们自己的登录密码。如果忘记密码，联系人可以在登录界面中请求新生成密码。"
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr "${items} 遗失保存着或者保存日期"
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} 等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "${items} 无效的"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "${items} 已成功建立"
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: 部分等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr "${item} 遗失保存着或者保存日期"
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} 等待接收."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "${item} 已成功建立"
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} 等待接收."
 
@@ -94,7 +94,7 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "%误差"
 
@@ -108,15 +108,15 @@ msgstr "% 已做"
 msgid "% Published"
 msgstr "% 已发表"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr "%s 没有 '%s' 列."
 
@@ -128,15 +128,15 @@ msgstr "&nbsp;"
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'典型的'表示按样品和分析服务板块导入的分析请求. 在多选分析服务时, 在'配置'中分析配置关键词"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(空白)"
@@ -149,7 +149,7 @@ msgstr "(对照)"
 msgid "(Duplicate)"
 msgstr "(重复样)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(有害废弃物)"
 
@@ -158,32 +158,26 @@ msgid "(Required)"
 msgstr "(要求的)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr "16x16像素的图标用于表示该列表的优先级"
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr "32x32像素的图标用于表示对象视图的优先级"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "< 小于"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -194,16 +188,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr "> 大于"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr "分析请求 ${ar_number}"
 
@@ -215,7 +209,7 @@ msgstr "分析请求附件选项"
 msgid "AR ID Padding"
 msgstr "分析请求编号长度"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "导入分析请求"
 
@@ -223,17 +217,17 @@ msgstr "导入分析请求"
 msgid "AR Import options"
 msgstr "分析请求导入选项"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "分析请求模板"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "供复检結果的分析请求"
 
@@ -241,54 +235,54 @@ msgstr "供复检結果的分析请求"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr "ARs: ${ars}"
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "帐户名"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "帐号"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "帐户类型"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "认证"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "认证方缩写"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "认证方网址链接"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "认证标志"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "认证编码"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "认证页面标题"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "已认证"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -302,21 +296,21 @@ msgstr "在指定时间内用户(或特定用户)所执行的动作"
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "活跃的"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "无线网络点对点传输模式"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -336,11 +330,7 @@ msgstr "添加对照参考"
 msgid "Add Duplicate"
 msgstr "添加重复样"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "添加模板"
 
@@ -348,16 +338,16 @@ msgstr "添加模板"
 msgid "Add a remarks field to all analyses"
 msgstr "添加备注字段到所有分析"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "新增/添加新"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "附加备注"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "地址"
@@ -370,26 +360,26 @@ msgstr "在ID前缀后面添加2位年"
 msgid "Administrative Reports"
 msgstr "管理员报告"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "${end_date} 之后"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "代理机构"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "所有的"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "所有已认证的分析服务均列于此."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "所有已分派分析"
 
@@ -401,7 +391,7 @@ msgstr "所有分析类型"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "允许实验室职员创建和编辑客户"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "允许手动检测输入限制"
 
@@ -409,15 +399,15 @@ msgstr "允许手动检测输入限制"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr "允许只为分配分析而访问工作表"
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "允许手动输入不确定的结果"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -425,11 +415,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "允许分析师手动替换结果输入视图的默认检测限制(LDL和UDL)"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "允许分析师手动替换默认的不确定值。"
 
@@ -437,48 +427,48 @@ msgstr "允许分析师手动替换默认的不确定值。"
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "替代计算方法"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "始终扩展客户端视图中选定的类别"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "数量"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "分析"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "在误差范围内的分析"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "范围外分析"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "分析 - 按分析服务"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "类型分析 - 按样品"
@@ -492,7 +482,7 @@ msgstr "分析 - 按服务"
 msgid "Analyses performed and published as % of total"
 msgstr "执行分析并按照占总的%形式发表"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "已执行分析占总的%"
 
@@ -505,27 +495,27 @@ msgstr "分析相关的报告"
 msgid "Analyses repeated"
 msgstr "重复的分析"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "分析结果在指定范围外"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "已重新分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "分析汇总-按部门"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "已重新测试的分析"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "分析"
 
@@ -533,52 +523,52 @@ msgstr "分析"
 msgid "Analysis Attachment Option"
 msgstr "分析附件选项"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "多个分析类别"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "单个分析类别"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "分析关键词"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "分析单个数据图表"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "分析多个数据图表"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "分析请求"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "分析请求编号"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "导入分析请求"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "分析请求优先级"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "分析请求规格"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -586,65 +576,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "分析请求"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "单个分析服务"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "多个分析服务"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "分析单个规格"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "分析多个规格"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "分析状态"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "分析类型"
@@ -653,46 +643,46 @@ msgstr "分析类型"
 msgid "Analysis category"
 msgstr "分析类别"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "分析请求 ${AR} 已成功创建."
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "分析请求 ${ARs} 已成功创建."
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "分析请求与分析"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "分析请求与分析 - 按客户"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "未结算的分析请求"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "误差范围内的分析结果"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "分析结果"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "${subject_parts}的分析结果"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "每个采样点和分析服务的分析结果"
 
@@ -700,12 +690,12 @@ msgstr "每个采样点和分析服务的分析结果"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "分析结果超出实验室或客户指定范围 - 注意这可能需要花费几分钟"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "分析服务"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "重置分析规格至实验室默认值"
 
@@ -721,17 +711,17 @@ msgstr "分析周转时间"
 msgid "Analysis turnaround time over time"
 msgstr "分析周转时间超时"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "分析周转时间"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "分析周转时间超时"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "分析员"
 
@@ -740,7 +730,7 @@ msgid "Analyst must be specified."
 msgstr "必须制定分析员"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "任何"
 
@@ -752,7 +742,7 @@ msgstr "应用"
 msgid "Apply template"
 msgstr "应用模板"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "应用广泛"
 
@@ -770,15 +760,15 @@ msgstr "资产编号"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "已分派到工作表"
 
@@ -796,27 +786,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "附加于"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "附件"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "附件关键词"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "附件选项"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "单一附件类型"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "多个附件类型"
 
@@ -826,25 +816,25 @@ msgstr "多个附件类型"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "不允许添加附件"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "要求添加附件"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "附件类型"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "多个附件"
 
@@ -856,7 +846,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "自动填充"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "自动导入"
 
@@ -873,27 +863,27 @@ msgstr "自动不干胶印刷"
 msgid "Available templates"
 msgstr "可用模板"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "平均周转时间"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "平均较早"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "平均较晚"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr "形成严重的状态: ${errmsg}"
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "银行支行"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "银行名"
 
@@ -902,31 +892,31 @@ msgid "Basis"
 msgstr "依据/基本"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "批"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "批ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "批标签"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "多批"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "持有"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "${start_date} 之前"
 
@@ -934,7 +924,7 @@ msgstr "${start_date} 之前"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "大图标"
 
@@ -942,7 +932,7 @@ msgstr "大图标"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS配置"
 
@@ -950,63 +940,67 @@ msgstr "Bika LIMS配置"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "账单地址"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "空白"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "空白QC分析"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "品牌"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "批发价(不含增值税)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "办公电话"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "由"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "抄送多个联络人"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "抄送多个邮件"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "从不确定性进行精密计算"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "计算"
 
@@ -1014,8 +1008,8 @@ msgstr "计算"
 msgid "Calculation Formula"
 msgstr "计算公式"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "临时场地计算"
@@ -1028,11 +1022,11 @@ msgstr "计算: ${calc_name}"
 msgid "Calculation: None"
 msgstr "计算: 没有"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "多个计算"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "校准"
 
@@ -1044,12 +1038,12 @@ msgstr "校准证书"
 msgid "Calibration report date"
 msgstr "校准报告日期"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "校准器"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1063,9 +1057,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -1081,18 +1075,18 @@ msgstr "不能停用的计算，因它現正被以下服务使用中: ${calc_ser
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "无法验证：由当前用户提交"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "容量"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "已捕获"
 
@@ -1101,7 +1095,7 @@ msgid "Cardinal"
 msgstr "主要的/基本的"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "类别号码"
 
@@ -1109,17 +1103,17 @@ msgstr "类别号码"
 msgid "Categorise analysis services"
 msgstr "归类分析服务"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "类别"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "类别"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "证书号码"
 
@@ -1132,31 +1126,31 @@ msgstr "证书编码"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "检查该方法是否已被认可"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "如果该分析服务已包含在实验室认证分析计划中, 选中这个勾选框"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "如果此点的样品是混合物, 即由多个样品混合而成的,则选中这个勾选框, 比如将大坝表面的几个样品混合在一起作为该大坝的样品. 默认没有勾选, 表示直接采取的样品"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "如果这个容器已经保留则选中这个勾选框. 选中这个勾选框将不会进一步选择是否保留该容器中的各个样品."
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "如果这是默认优先级，则勾选此框"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "如果实验室已认证则选中这个勾选框"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "勾选本框以确认本次分析服务已使用单独的样品容器"
 
@@ -1164,7 +1158,7 @@ msgstr "勾选本框以确认本次分析服务已使用单独的样品容器"
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "如果你想使用单独的ID服务器则选中此处. 在每个Bika站点中样品前缀可以单独配置"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "选择默认AR的规范值"
 
@@ -1180,19 +1174,19 @@ msgstr ""
 msgid "City"
 msgstr "城市"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "典型的"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "点击分析分类（阴影的背景）以查看每个类别的分析服务。输入最小值和最大值，以指示一个有效的结果范围。在这个范围之外的任何结果将引发报警。当针对最小值和最大值评估结果时，误差（%）字段允许考虑一个%的不确定性。一个超出范围但是仍然在%误差考虑范围内的结果，将引发一个不太严重的报警。"
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "点击分析分类（阴影的背景）以查看每个类别的分析服务。输入最小值和最大值，以指示一个有效的结果范围。在这个范围之外的任何结果将引发报警。当针对最小值和最大值评估结果时，误差（%）字段允许考虑一个%的不确定性。一个超出范围但是仍然在%误差考虑范围内的结果，将引发一个不太严重的报警。"
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "点击分析分类（阴影的背景）以查看每个类别的分析服务。输入最小值和最大值，以指示一个有效的结果范围。在这个范围之外的任何结果将引发报警。当针对最小值和最大值评估结果时，误差（%）字段允许考虑一个%的不确定性。一个超出范围但是仍然在%误差考虑范围内的结果，将引发一个不太严重的报警。"
 
@@ -1200,19 +1194,19 @@ msgstr "点击分析分类（阴影的背景）以查看每个类别的分析服
 msgid "Click to download"
 msgstr "点击下载"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "客户"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "客户批次ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "客户编号"
 
@@ -1220,59 +1214,59 @@ msgstr "客户编号"
 msgid "Client Landing Page"
 msgstr "客户登录页面"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "客户名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "客户订单"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "客户订单号"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "客户参阅"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "客户参阅"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "客户样品编号"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "客户样品ID"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "提交请求前需要客户联系"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "多个客户"
 
@@ -1281,39 +1275,39 @@ msgstr "多个客户"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "已关闭"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "位置代码"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "网站代码"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "货架代码"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "逗号 (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "评论"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "评论或结果解析"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "商业ID"
 
@@ -1321,21 +1315,21 @@ msgstr "商业ID"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "混合物"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "混合物等级%"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "配置该模板的样品个部分和保留样品. 分配样品各部分给模板上的分析实验室"
 
@@ -1344,13 +1338,13 @@ msgid "Confirm password"
 msgstr "确认密码"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "考虑"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "联系方式"
@@ -1359,8 +1353,8 @@ msgstr "联系方式"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "多个联系方式"
@@ -1369,48 +1363,48 @@ msgstr "多个联系方式"
 msgid "Contacts to CC"
 msgstr "抄送联系方式"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "容器"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "容器类型"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "多个容器类型"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "多个容器"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "内容类型"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "正文类型"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "对照"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "控制QC分析"
 
@@ -1426,12 +1420,12 @@ msgstr "拷贝分析服务"
 msgid "Copy from"
 msgstr "拷贝自"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "拷贝到新的"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "计数"
 
@@ -1444,18 +1438,18 @@ msgstr "国家"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "创建该类型的新样品"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "已创建"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "由创建"
 
@@ -1463,7 +1457,7 @@ msgstr "由创建"
 msgid "Created by:"
 msgstr "创建者: "
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1471,8 +1465,8 @@ msgstr ""
 msgid "Creator"
 msgstr "创建者"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "准则"
 
@@ -1480,12 +1474,12 @@ msgstr "准则"
 msgid "Currency"
 msgstr "现金"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "当前"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "自定义小数点标记"
 
@@ -1498,7 +1492,7 @@ msgstr "DL"
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1512,88 +1506,88 @@ msgstr "数据界面"
 msgid "Data Interface Options"
 msgstr "数据界面选项"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr "数据输入日记账"
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "日期"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "创建日期"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "发送日期"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "处置日期"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "过期日期"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "导入日期"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "载入日期"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "打开日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "保留时间"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "发布日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "收到日期"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "请求日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "做样日期"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1609,7 +1603,7 @@ msgstr "校准证书有效期的起始日期"
 msgid "Date from which the instrument is under calibration"
 msgstr "仪器校准的起始日期"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "该仪器正在维修中的起始日期"
 
@@ -1627,7 +1621,7 @@ msgid "Date until the certificate is valid"
 msgstr "直至证书有效期的日期"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "直到该仪器将不可用的日期"
@@ -1636,11 +1630,11 @@ msgstr "直到该仪器将不可用的日期"
 msgid "Date when the calibration certificate was granted"
 msgstr "校准证书被授予的日期"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "天数"
 
@@ -1652,17 +1646,17 @@ msgstr "取消激活，直到下一次校准测试"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "该客户报告中使用的小数点标记。"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "默认"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "默认AR规格"
 
@@ -1670,49 +1664,49 @@ msgstr "默认AR规格"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "默认计算方法"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "默认容器"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "默认容器类别"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "默认仪器"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "默认方法"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "默认保留"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "默认优先级？"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "选择的默认方法使用的默认计算方法。一个方法的计算方法可用通过该方法的编辑视图分配。"
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "默认类别"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "新样本划分使用的默认容器"
 
@@ -1721,11 +1715,11 @@ msgid "Default containers: ${container_list}"
 msgstr "默认的多个容器: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "默认小数点标记"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1749,11 +1743,11 @@ msgstr "报告的默认科学计数法格式"
 msgid "Default scientific notation format for results"
 msgstr "结果的默认科学计数法格式"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "默认值"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "默认AR规格说明"
 
@@ -1761,7 +1755,7 @@ msgstr "默认AR规格说明"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "定义方法的识别码。它必須是唯一的。"
 
@@ -1769,11 +1763,11 @@ msgstr "定义方法的识别码。它必須是唯一的。"
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "定义要用于此结果小数点后的位数。"
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "定义将值转换为指数符号时的精度。默认值是7。"
 
@@ -1781,16 +1775,16 @@ msgstr "定义将值转换为指数符号时的精度。默认值是7。"
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "度"
 
@@ -1798,9 +1792,9 @@ msgstr "度"
 msgid "Delete attachment"
 msgstr "删除附件"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "部门"
 
@@ -1813,13 +1807,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "以来分析"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "为外行能看懂的语言描述方法. 该信息为客户可见."
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "描述"
 
@@ -1827,7 +1821,7 @@ msgstr "描述"
 msgid "Description of the actions made during the calibration"
 msgstr "校准过程中所做的动作的描述"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "在维护过程中所做的动作的描述"
 
@@ -1835,19 +1829,19 @@ msgstr "在维护过程中所做的动作的描述"
 msgid "Description of the actions made during the validation"
 msgstr "在验证过程中所做的动作的描述"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "位置的描述"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "货架的描述"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "站点的描述"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1855,7 +1849,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "折扣%"
 
@@ -1863,16 +1857,16 @@ msgstr "折扣%"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已发送"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "显示值"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "显示检测限制选择器"
 
@@ -1884,7 +1878,7 @@ msgstr "显示Bika LIMS新版本的警告"
 msgid "Display individual sample partitions "
 msgstr "显示单个样本划分"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "清除时间"
 
@@ -1893,8 +1887,8 @@ msgstr "清除时间"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已处置"
@@ -1903,54 +1897,54 @@ msgstr "已处置"
 msgid "District"
 msgstr "区"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "除以零"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr "文档"
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "不活动"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "点 (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "从下跌"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "下至"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "下载"
 
@@ -1963,20 +1957,20 @@ msgstr "干燥"
 msgid "Dry matter analysis"
 msgstr "干燥物质分析"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "截止"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "截止期"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr "复制变量"
 
@@ -1985,20 +1979,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "重复"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "重复- "
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "重复的QC分析"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "重复变化%"
 
@@ -2010,35 +2004,35 @@ msgstr "重复分析质量控制"
 msgid "Duplicate analysis quality control graphs"
 msgstr "重复分析质量控制图"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "持续时间"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "如 SANAS, APLAC 等"
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "提前量"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "较早的"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "评估"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "Email"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "Email地址"
 
@@ -2046,7 +2040,7 @@ msgstr "Email地址"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "Email标题行"
 
@@ -2066,14 +2060,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "结束日期"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "增强"
 
@@ -2085,16 +2079,16 @@ msgstr "输入用户名，如'jsmith'。无空格或者特殊字符。用户名�
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "输入邮箱地址。万一密码丢失，这是必要的。我们尊重您的隐私，不会把邮箱地址给任何第三方或公开到任何其他地方。"
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "输入折扣百分数值, 如7折就输30"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "输入百分数值, 如14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "输入百分比值，如14.0 。这一比例仅在分析档案时应用，覆盖系统的增值稅(VAT)"
 
@@ -2102,15 +2096,15 @@ msgstr "输入百分比值，如14.0 。这一比例仅在分析档案时应用�
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "输入百分数值, 如14.0. 这个百分数值将作为系统值使用,但对于单个项目可以重新定义."
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "输入百分数值, 如33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "输入采样点的纬度. 度: 0-90, 分: 0-59, 秒: 0-59 以及北N/南S纬 "
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "输入采样点的经度. 度: 0-180, 分: 0-59, 秒: 0-59 以及东E/西W经"
 
@@ -2118,7 +2112,7 @@ msgstr "输入采样点的经度. 度: 0-180, 分: 0-59, 秒: 0-59 以及东E/�
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "输入要复制的分析服务的每一个细节。"
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "在这里输入你的实验室认证的服务细节。可提供以下字段：lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 
@@ -2126,45 +2120,45 @@ msgstr "在这里输入你的实验室认证的服务细节。可提供以下字
 msgid "Entity"
 msgstr "实体"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "从${request_id}发布的错误结果"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "从结算中取出"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "单个期望结果"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "期望值"
 
@@ -2173,19 +2167,19 @@ msgstr "期望值"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "已过期"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "过期日期"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "指数格式精度"
 
@@ -2193,44 +2187,40 @@ msgstr "指数格式精度"
 msgid "Exponential format threshold"
 msgstr "指数格式阈值"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "传真"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "传真(办公)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "女/雌"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "场地"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "场地分析"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "场地保留"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "场地名"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "文件"
 
@@ -2238,19 +2228,19 @@ msgstr "文件"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "如果这个选项启用，结果的文件附件，例如显微镜照片，将被包括在电子邮件一并发送给收件人"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "文件名"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2270,16 +2260,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "名"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "公式"
 
@@ -2289,18 +2279,18 @@ msgstr "公式"
 msgid "From"
 msgstr "自"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "由 ${start_date} 至 ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "全名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "已预约时间的样品"
 
@@ -2310,7 +2300,7 @@ msgstr "已预约时间的样品"
 msgid "Generate report"
 msgstr "生成报告"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "称谓, 如先生,女士, 博士"
 
@@ -2322,37 +2312,37 @@ msgstr "当列表很长时，在LIMS表格中通过类别对服务进行分组�
 msgid "Group by"
 msgstr "通过...分组"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "分组周期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "危险废弃物"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "隐藏"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "隐藏字段"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "小时"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr "IBN"
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2361,8 +2351,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID服务器网址"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "Id服务器不可用"
 
@@ -2370,31 +2360,31 @@ msgstr "Id服务器不可用"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "重要提示：不要使用\"Bika\"或\"BIKA\"作为实例名，这是一个保留的命名空间。如果你得到\"属性错误：适配器\"的\"网站错误\"，这是最有可能造成该错误的原因。"
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "如果一个样品在这个采样点周期性地被取，在这里输入频率，例如每周"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr ""
 
@@ -2406,7 +2396,7 @@ msgstr "如果勾选，该仪器将不可用，直到下一个有效的校准。
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2414,27 +2404,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "如果启用，分析的名称将用斜体表示。"
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "如果启用，此分析及其结果默认不显示在报告中。此设置能够被分析概要和或分析请求中覆盖"
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "如果没有输入标题值，将使用批次ID 。"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "如果需要，为与这个方法相关联的分析服务选择一个计算器。计算器可以在LIMS系统set-up的计算器项目下进行配置。"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "如果已请求,在此选择分析的计算方法.计算方法可以在实验室信息管理系统设置中的计算项目下面配置"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "此处输入的文本会替换服务列出时标题栏中的标题信息。允许进行HTML格式化。"
 
@@ -2442,7 +2432,7 @@ msgstr "此处输入的文本会替换服务列出时标题栏中的标题信息
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "如果在同一批次分析请求的服务中有一个服务之前已经有结果，他们将在报告中显示。"
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "如果该容器已经被预留, 则预留方法可以在此选择."
 
@@ -2455,7 +2445,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "如果不勾选，分析师将获得的访问所有工作表的权限。"
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "导入"
@@ -2464,7 +2454,7 @@ msgstr "导入"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "已导入"
@@ -2473,8 +2463,8 @@ msgstr "已导入"
 msgid "In-lab calibration procedure"
 msgstr "在实验室校准程序"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "处于非活动状态"
@@ -2483,7 +2473,7 @@ msgstr "处于非活动状态"
 msgid "Include Previous Results From Batch"
 msgstr "包括批次中以往的结果"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "包含该选中对象的所有分析请求。"
 
@@ -2491,7 +2481,7 @@ msgstr "包含该选中对象的所有分析请求。"
 msgid "Include and display pricing information"
 msgstr "包含和显示价格信息"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "包含描述"
 
@@ -2499,30 +2489,27 @@ msgstr "包含描述"
 msgid "Include year in ID prefix"
 msgstr "在ID前缀中包含年份"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "不正确IBAN号码：%s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "不正确NIB号码：%s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "不确定的结果"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "指明对此分析是否要求文件附件,如显微镜照片等, 以及数据采集计算机的上传功能是否有效"
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "继承自"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "初步修订"
 
@@ -2546,7 +2533,7 @@ msgstr "安装证书上传"
 msgid "InstallationDate"
 msgstr "安装日期"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "操作指南"
@@ -2559,17 +2546,17 @@ msgstr "用于化验员的实验室常规校准例程指南"
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "用于化验员的经常性的预防和维护例程指南"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "仪器"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "仪器校准"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2582,16 +2569,16 @@ msgstr "仪器导入"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "仪器维护"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "仪器的计划任务"
 
@@ -2599,19 +2586,19 @@ msgstr "仪器的计划任务"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "仪器类型"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "仪器验证"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2655,9 +2642,9 @@ msgstr "仪器类型"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "多个仪器"
 
@@ -2681,7 +2668,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "内部校准测试"
 
@@ -2697,24 +2684,21 @@ msgstr "插值"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "无效"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "无效的AR复检"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "发现无效通配符: ${wildcards}"
 
@@ -2722,43 +2706,43 @@ msgstr "发现无效通配符: ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "发票"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "发票日期"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "发票不包括"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "发票号码"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "发票批次无结束日期"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "发票批次无开始日期"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "发票批次无标题"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "项目处于非活动状态"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "项目将包含在邮件标题栏中"
 
@@ -2768,7 +2752,7 @@ msgstr "项目将包含在邮件标题栏中"
 msgid "Job Title"
 msgstr "工作职位"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "工作职位"
 
@@ -2776,12 +2760,12 @@ msgstr "工作职位"
 msgid "Key"
 msgstr "关键"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "关键的错误"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "关键词"
@@ -2790,47 +2774,47 @@ msgstr "关键词"
 msgid "Keywords"
 msgstr "多个关键词"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "实验室"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "实验室分析"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "实验室联系方式"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "实验室科系"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "实验室保存"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "实验室产品"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "实验室网址"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "标签"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "实验室"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "实验室认证"
 
@@ -2850,13 +2834,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "上次更改"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "延迟"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "分析延迟"
@@ -2866,7 +2850,7 @@ msgstr "分析延迟"
 msgid "Late Analysis"
 msgstr "分析延迟"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "纬度"
 
@@ -2888,11 +2872,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "已链接样品"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2904,7 +2888,7 @@ msgstr "列出日期范围内收到的所有样品"
 msgid "Load Setup Data"
 msgstr "载入设置数据"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "在此载入描述该方法的文档"
 
@@ -2916,41 +2900,41 @@ msgstr "从文件加载"
 msgid "Load the certificate document here"
 msgstr "在这里加载证书文档"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "已加载"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "地点代码"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "地点描述"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "地点名称"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "地点类型"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "保存样品的地点"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "取样地点"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "日志"
@@ -2975,35 +2959,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "经度"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "批号"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "检查下线(LDL)"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "邮寄地址"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "维护者"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "维护类型"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "男/雄"
 
@@ -3011,16 +2995,16 @@ msgstr "男/雄"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "经理"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "经理Email"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "经理电话"
 
@@ -3028,31 +3012,25 @@ msgstr "经理电话"
 msgid "Manual"
 msgstr "手动"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "手控入口"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "手动输入结果"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "制造商"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "多个制造商"
 
@@ -3061,14 +3039,14 @@ msgstr "多个制造商"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "最大"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "最大时间"
 
@@ -3076,30 +3054,30 @@ msgstr "最大时间"
 msgid "Maximum columns per results email"
 msgstr "最大的列 - 按结果email"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "最大的样品可能的尺寸或体积"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "完成分析的最长允许时间. 该时间截止后会有一个延迟分析警告."
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "最大周转时间"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "会员折扣%"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "会员折扣可用"
 
@@ -3108,22 +3086,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "方法"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "方法文档"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "方法ID"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "方法说明"
 
@@ -3135,9 +3113,9 @@ msgstr "方法: ${method_name}"
 msgid "Method: None"
 msgstr "方法: 没有"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "多个方法"
 
@@ -3145,17 +3123,17 @@ msgstr "多个方法"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "方法包含在本实验室 ${accreditation_body} 认证计划中. 分析注释未认证."
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "中间初始"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "中间名字"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "最小"
 
@@ -3167,8 +3145,8 @@ msgstr "我的"
 msgid "Minimum 5 characters."
 msgstr "最少5个"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "最小体积"
 
@@ -3176,27 +3154,27 @@ msgstr "最小体积"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "质量控制统计计算的最小结果数目"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "分钟"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "手机"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "型号"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "修改日期"
 
@@ -3210,7 +3188,7 @@ msgstr ""
 msgid "More"
 msgstr "更多"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3222,13 +3200,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr "NIB"
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "名称"
 
@@ -3237,17 +3215,17 @@ msgstr "名称"
 msgid "New"
 msgstr "新文件"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "否"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr "没有符合您查询的分析"
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3263,18 +3241,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "没有发现用户${user}的任何动作"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "没有选择分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "你的请求没有符合的分析"
 
@@ -3286,23 +3264,23 @@ msgstr "没有添加分析"
 msgid "No analyses were added to this worksheet."
 msgstr "该工作表中没有添加分析."
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "未选择分析"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "未选择分析服务"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "未选择分析服务"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "没有改变"
 
@@ -3310,7 +3288,7 @@ msgstr "没有改变"
 msgid "No control type specified"
 msgstr "没有指定对照类型"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3322,17 +3300,17 @@ msgstr "本服务没有指定默认容器"
 msgid "No default preservations specified for this service"
 msgstr "本服务没有指定默认保留"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "没有选择文件"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "没有历史行为匹配您的查询"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "没有项目被选择"
 
@@ -3340,7 +3318,7 @@ msgstr "没有项目被选择"
 msgid "No items selected"
 msgstr "没有选择项目"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "无新建立项目"
 
@@ -3350,16 +3328,16 @@ msgstr "无新建立项目"
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "没有选择参考样品"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "没有在请求中指定报告"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "没有样品匹配您的查询"
 
@@ -3377,25 +3355,22 @@ msgstr "${contact_fullname}用户不存在且他/她不能登入. 请填写下�
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "没有"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "不允许"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "不可用"
 
@@ -3415,19 +3390,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "列数"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "分析数"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "分析请求和分析数"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "每个客户的分析请求和分析数"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3435,30 +3410,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "分析数目"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "分析数目周期超出范围"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "分析请求数量 - 按分析服务"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "分析请求数目 - 按样品类型"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "分析数目已周期性重测"
 
@@ -3466,15 +3441,15 @@ msgstr "分析数目已周期性重测"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "每部门的分析请求和公布数量并表示为占所有已完成分析的百分比"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "请求数目"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3483,31 +3458,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "样品数量"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "数值表示排序对象的优先级"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "对象ID"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "一旦保留, 样品必须在该时间周期内处置. 如果没有指明, 将使用该样品类型的时间周期."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3515,15 +3490,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "只有实验室经理可以建立和管理工作表"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "只有空或零字段"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "打开"
@@ -3536,26 +3508,26 @@ msgstr ""
 msgid "Order"
 msgstr "订单"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "订单日期"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "订单ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "订单号码"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "多个订单"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "订单: ${orders}"
 
@@ -3563,7 +3535,7 @@ msgstr "订单: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "复杂授予校准证书的组织"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3575,8 +3547,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr "其它的生产能力报告"
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "过时的"
 
@@ -3588,16 +3560,13 @@ msgstr "输出格式"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "一部分"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3618,8 +3587,8 @@ msgstr "密码"
 msgid "Password lifetime"
 msgstr "密码有效期"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "正在处理"
@@ -3644,31 +3613,31 @@ msgstr "由... 执行"
 msgid "Period"
 msgstr "周期"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "已许可"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "许可误差%"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "电话"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "电话(办公)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "电话(家庭)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "电话(手机)"
 
@@ -3681,8 +3650,8 @@ msgid "Photo of the instrument"
 msgstr "仪器的图片"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "住址"
 
@@ -3690,7 +3659,7 @@ msgstr "住址"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr ""
 
@@ -3698,19 +3667,19 @@ msgstr ""
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr ""
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "请上传认证机构授权你在你的网站和结果报告上使用的认证标识. 最大尺寸为175x175像素."
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "捕获点"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3719,13 +3688,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "位置"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "邮寄地址"
 
@@ -3733,16 +3702,16 @@ msgstr "邮寄地址"
 msgid "Postal code"
 msgstr "邮编"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "已预留"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "小数精度"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr ""
 
@@ -3770,7 +3739,7 @@ msgstr "报告的首先科学计数法格式"
 msgid "Preferred scientific notation format for results"
 msgstr "结果的首先科学计数法格式"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "前缀"
 
@@ -3778,12 +3747,12 @@ msgstr "前缀"
 msgid "Prefixes"
 msgstr "人名前的称谓"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "附加费/津贴"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3795,17 +3764,17 @@ msgstr "由...准备"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "储藏"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "保留类别"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3816,7 +3785,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "保留的样品"
 
@@ -3826,14 +3795,14 @@ msgstr "保留的样品"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "保留人"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "预防"
 
@@ -3841,34 +3810,34 @@ msgstr "预防"
 msgid "Preventive maintenance procedure"
 msgstr "预防性维护程序"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "价格"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "价格(不含增值税)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "价格溢价百分比"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "不含增值税的价格"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "价目表:"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "价目表"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3883,13 +3852,13 @@ msgstr "打印"
 msgid "Print date:"
 msgstr "打印日期"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "优先级"
 
@@ -3906,34 +3875,34 @@ msgstr "产能报告"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "专业的开源LIMS/LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "概况"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "概况分析"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "关键概况"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "概况关键词"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "多个概况"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "形式发票（没有发票）"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "协议ID"
 
@@ -3941,7 +3910,7 @@ msgstr "协议ID"
 msgid "Public. Lag"
 msgstr "公共滞后"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "发布规格"
 
@@ -3956,21 +3925,21 @@ msgstr "发布偏好"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "已发布"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "未包含在发票中的已发布的分析"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "由...发布"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "已发布结果"
 
@@ -3983,8 +3952,8 @@ msgid "QC Analyses"
 msgstr "质量控制分析"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "质量控制(QC)样品ID"
 
@@ -4005,23 +3974,23 @@ msgstr "质量"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "范围注释"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "范围注释"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "范围最大值"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "范围最小值"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "特定范围"
 
@@ -4043,9 +4012,9 @@ msgstr "接收"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "已收到"
 
@@ -4053,11 +4022,11 @@ msgstr "已收到"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "收件人"
 
@@ -4066,31 +4035,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr ""
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "参考"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "参考分析"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "参考定义"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "参考多项定义"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "参考样品"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "参考样品"
 
@@ -4098,16 +4067,16 @@ msgstr "参考样品"
 msgid "Reference Supplier"
 msgstr "参考供应商"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "参考类型"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "参考值"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "参考分析质量控制"
@@ -4116,7 +4085,7 @@ msgstr "参考分析质量控制"
 msgid "Reference analysis quality control graphs"
 msgstr "参考分析质量控制图"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "参考分析质量控制图"
 
@@ -4124,21 +4093,21 @@ msgstr "参考分析质量控制图"
 msgid "Reference sample"
 msgstr "参考样品"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "样品参考值为0或'空白'"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "参考分析组ID"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "参考定义代表用于质量控制测试的样品类型的参考定义"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "参考: ${references}"
 
@@ -4161,8 +4130,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4171,9 +4140,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "备注"
 
@@ -4181,7 +4150,7 @@ msgstr "备注"
 msgid "Remarks to take into account before calibration"
 msgstr "在校准前要考虑的备注"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "在执行任务前要考虑的备注"
 
@@ -4189,7 +4158,7 @@ msgstr "在执行任务前要考虑的备注"
 msgid "Remarks to take into account before validation"
 msgstr "在验证之前考虑的备注"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "维护过程需要考虑的备注"
 
@@ -4198,8 +4167,8 @@ msgstr "维护过程需要考虑的备注"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "修复"
 
@@ -4208,7 +4177,7 @@ msgid "Repeated analyses"
 msgstr "重复分析"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "报告"
 
@@ -4222,14 +4191,14 @@ msgstr "报告日期"
 msgid "Report ID"
 msgstr "报告ID"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "报告类型"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "作为干燥物质报告"
 
@@ -4254,7 +4223,7 @@ msgstr ""
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr ""
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "报告类型"
 
@@ -4262,7 +4231,7 @@ msgstr "报告类型"
 msgid "Report upload"
 msgstr "报告上传"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "多个报告"
 
@@ -4271,15 +4240,15 @@ msgstr "多个报告"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "请求"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "请求ID"
 
@@ -4287,26 +4256,26 @@ msgstr "请求ID"
 msgid "Request new analyses"
 msgstr "请求新分析"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "已请求"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "多个请求"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "已请求"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "要求的体积"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "必填字段没有值: ${field_names}"
 
@@ -4314,13 +4283,13 @@ msgstr "必填字段没有值: ${field_names}"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "限制类别"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "结果"
 
@@ -4328,15 +4297,15 @@ msgstr "结果"
 msgid "Result Footer"
 msgstr "结果页脚"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "结果选项"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "结果值"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4354,11 +4323,11 @@ msgstr "结果超出范围"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "结果中显示的数值小数点后有效数字位数不少于这个值，同时使用科学计数法用\"e\"表示指数符号。精确度可以在个人分析服务中进行配置。"
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "结果解析"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "结果解析"
 
@@ -4366,7 +4335,7 @@ msgstr "结果解析"
 msgid "Results attachments permitted"
 msgstr "运行结果附件"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "结果被撤回"
 
@@ -4374,11 +4343,11 @@ msgstr "结果被撤回"
 msgid "Results interpretation"
 msgstr "结果解析"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "结果 - 按取样点"
@@ -4387,14 +4356,14 @@ msgstr "结果 - 按取样点"
 msgid "Results per samplepoint and analysis service"
 msgstr "结果 - 按取样点和分析服务"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "保留周期"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "已重新测试"
@@ -4413,11 +4382,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "撤销分析"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "撤销报告不可用"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "撤销"
 
@@ -4433,12 +4402,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "SWIFT代码"
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "称呼"
 
@@ -4446,19 +4415,19 @@ msgstr "称呼"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "同上, 但设置为分析服务的默认值. 该设置可以在具体样品的配置上修改."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "样品"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "样品状态"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "样品状态"
 
@@ -4467,8 +4436,8 @@ msgid "Sample Due"
 msgstr "样品截止日"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "样品编号"
 
@@ -4480,12 +4449,12 @@ msgstr "样品编号位数"
 msgid "Sample ID Sequence Start"
 msgstr "样品ID顺序启动"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "样品基体"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "样品基体"
 
@@ -4495,52 +4464,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "样品区块"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "单个样品点"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "多个样品点"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "样品类型"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "样品类型前缀"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "样品类型规格（客户端）"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "样品类型规格（实验室）"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "多个样品类型"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "样品状态"
 
@@ -4550,9 +4519,9 @@ msgstr "样品状态"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "取样点"
 
@@ -4580,17 +4549,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "样品相关报告"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "样品类型"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "样品基体"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "样品类型"
 
@@ -4600,30 +4569,30 @@ msgstr "样品类型"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "取样人"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "多个样品"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "该类型的样品需要作为\"危险废弃物\"处理"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "已收到样品和报告"
@@ -4632,62 +4601,62 @@ msgstr "已收到样品和报告"
 msgid "Samples received vs. samples reported"
 msgstr "已收到样品和样品报告"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "样品: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "采样日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "采样偏差"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "采样偏差"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "采样频率"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4697,9 +4666,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "保存"
 
@@ -4712,17 +4681,17 @@ msgstr "保存注释"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "计划任务"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "科学名称/学名"
 
@@ -4730,16 +4699,16 @@ msgstr "科学名称/学名"
 msgid "Search"
 msgstr "搜索"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "秒"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4751,11 +4720,11 @@ msgstr "如果希望在新的AR或者样本结果生成时标签自动打印，�
 msgid "Select AR Templates to include"
 msgstr "选择要包含的AR模板"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "选择用户界面"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "为此分析服务选择一个默认保留. 如果保存取决于关于样品类型的组合, 请在下表中按样品指定保存类型"
 
@@ -4763,11 +4732,11 @@ msgstr "为此分析服务选择一个默认保留. 如果保存取决于关于�
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "选择一个终点位置和分析请求来重复."
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "从'实验室联系'选项中可用的职员中选择一个管理员. 科系管理员们的名字将在含有他们所在科系的分析报告中列出."
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "选择一个样品来创建辅助AR"
 
@@ -4779,7 +4748,7 @@ msgstr "选项所有选项"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "选择包括在这个模板中的分析"
 
@@ -4791,11 +4760,11 @@ msgstr "选择分析员"
 msgid "Select existing file"
 msgstr "选择现有的文件"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "选择是否从结算报告中将排除该分析"
 
@@ -4803,19 +4772,19 @@ msgstr "选择是否从结算报告中将排除该分析"
 msgid "Select if is an in-house calibration certificate"
 msgstr "选择，如果这是一个内部校准证书"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "如果要使用的计算器是默认方法中设置的默认的计算器，则选中此项。如果不选中，可以手工选择计算器。"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "选择是否添加描述"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4841,7 +4810,7 @@ msgstr "选择该网站默认显示的国家"
 msgid "Select the currency the site will use to display prices."
 msgstr "选择用于网站显示价格的货币种类."
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr ""
 
@@ -4853,7 +4822,7 @@ msgstr "选择默认的登陆页面。这是用在客户端用户登录到系统
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "选择合适的仪器"
 
@@ -4861,7 +4830,7 @@ msgstr "选择合适的仪器"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4885,7 +4854,7 @@ msgstr "选此激活样品采集工作流程."
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "选择工作表中需要包含的分析"
 
@@ -4901,7 +4870,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "当自动不干胶印刷启用时选择要打印的标签"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4913,7 +4882,7 @@ msgstr "发送电子邮件"
 msgid "Separate"
 msgstr "分隔/分离"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "单独的容器"
 
@@ -4921,32 +4890,28 @@ msgstr "单独的容器"
 msgid "Serial No"
 msgstr "序列号"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "服务"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "服务已包含在 ${accreditation_body_abbrev} 中"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "多个服务"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "设置维护任务为关闭状态"
 
@@ -4954,31 +4919,31 @@ msgstr "设置维护任务为关闭状态"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "按结果email设置最大分析请求数目. 有的用户喜欢每个email包含少一些的结果, email中列数过多对他们来说阅读困难"
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "发布一个AR的结果前设置使用的规格"
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "设置实验室分析结果规格"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "货架码"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "货架的描述"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "货架标题"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "邮寄地址"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr "短标题"
 
@@ -4994,7 +4959,7 @@ msgstr "显示QC分析"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "用户视图中只能看到选中的类别"
 
@@ -5006,29 +4971,25 @@ msgstr ""
 msgid "Signature"
 msgstr "签名"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "站点编码"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "站点描述"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "站点标题"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "尺寸"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "小图标"
 
@@ -5036,14 +4997,14 @@ msgstr "小图标"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "一些分析使用过时的或未校准的仪器。结果不允许编辑"
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "排序关键字"
 
@@ -5051,41 +5012,41 @@ msgstr "排序关键字"
 msgid "Specification"
 msgstr "规格"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "规格"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指出工作表的大小,如相应仪器的样品盘大小. 然后按工作表位置选择分析'类型'. 选择质量控制样品的位置也需要选择使用参考样品. 如果选择了重复样品, 指明需要重复哪一个位置的样品."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "开始日期"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "州"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "状态"
 
@@ -5093,33 +5054,33 @@ msgstr "状态"
 msgid "Sticker templates"
 msgstr "贴纸模板"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "存储位置"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "存储位置"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "子组"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "多个子组"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "组视图中使用该关键字对子组进行排序"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "提交"
 
@@ -5127,37 +5088,34 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "为了继续，请提交有效的包含Bika设置记录Open XML（.xlsx）文件。"
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "子项总计"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "供应商"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "供应商"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "供货订单"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "姓"
 
@@ -5177,11 +5135,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "任务"
 
@@ -5190,20 +5148,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "任务类型"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "为分析员准备的技术描述和说明"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "温度"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5221,35 +5179,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "该模板的分析配置文件选择"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "实验室为用户请求分配了此ID"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "实验室为用户样品分配了此ID"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "实验室网址"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "检测下限是使用指定的测试方法所能够测量到的最小值。超过此最大值的结果会被标示为<LDL。"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "检测上限是使用指定的测试方法所能够测量到的最大值。超过此最大值的结果会被标示为>UDL。"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "适用的认证标准, 如 ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "分析包含于此配置中, 按类别分组"
 
@@ -5261,7 +5219,7 @@ msgstr "该分析用于检测干燥物质."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "负责校准的分析师或者机构"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "负责维护的分析师或者机构"
 
@@ -5269,12 +5227,12 @@ msgstr "负责维护的分析师或者机构"
 msgid "The analyst responsible of the validation"
 msgstr "负责验证的分析师"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "附件链接到分析请求和分析"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "该分析服务类别属于"
 
@@ -5282,19 +5240,19 @@ msgstr "该分析服务类别属于"
 msgid "The date the instrument was installed"
 msgstr "仪器安装的日期"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "在Bika配置中使用的小数点标记"
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "默认容器类型。新样本分区将被自动分配一个该类型的容器，除非它已被更详细的分析服务指定"
 
@@ -5306,7 +5264,7 @@ msgstr "输入折扣的百分数, 该折扣将用于标为'会员'的用户,通�
 msgid "The full URL: http://URL/path:port"
 msgstr "完整的URL，如: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取样高度或深度"
 
@@ -5323,24 +5281,24 @@ msgstr "仪器型号"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "该实验室未经认证, 或者尚未设置认证信息."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "实验室科系"
@@ -5357,27 +5315,27 @@ msgstr "样品ID数字位数为0的长度"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "分析请求ID的分析请求数目数字位数为0的长度"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "可采集类型的取样点列表. 如果没有样品类型被选择, 则所有取样点都将可以采集."
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "此取样点处可以采集的样品类型列表. 如果没有选择样品类型, 则所有样品类型都可采集."
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "该分析结果的单位, 如毫克/升, ppm, dB, mV等"
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "分析需要的最小样品量，如：10ml或者1kg。"
 
@@ -5401,7 +5359,7 @@ msgstr "密码有效天数. 如果输入0则表示永远有效"
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "样品有效天数, 过期的样品将不能分析. 该设置可以在样品类型设置中为具体样品类型重置."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5418,11 +5376,11 @@ msgstr "请求和分析的数量"
 msgid "The number of requests and analyses per client"
 msgstr "每个客户请求和分析的数量"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "在这一优先级用于计算分析价格的百分比"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "该类型非保留样品的可用于测试的有效期周期"
 
@@ -5439,19 +5397,19 @@ msgstr "供应商端执行任务的人"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "供应商端准备证书的人"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "按样品的大客户折扣价"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "用于会计的个人档案的商业ID。"
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "识别导入文件的独特配置关键词. 这个词必须唯一, 并且不能和临时场地计算（Calculation Interim fileld）ID抑一致"
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "认证机构向实验室发放的参考码"
 
@@ -5459,11 +5417,11 @@ msgstr "认证机构向实验室发放的参考码"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "使用这种方法，分析服务的结果可以进行手动设置"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "在样品点取样时捕获到的场地分析的结果, 如取样河流的取样水温. 实验分析在实验室完成"
 
@@ -5471,7 +5429,7 @@ msgstr "在样品点取样时捕获到的场地分析的结果, 如取样河流�
 msgid "The room and location where the instrument is installed"
 msgstr "仪器安装的房间和位置"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "选择的仪器支持该方法。使用仪器的编辑视图给特定的仪器分配方法"
 
@@ -5483,11 +5441,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "仪器唯一序列号"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "分析服务的协议ID"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "用于会计的服务的商业ID"
 
@@ -5495,19 +5453,19 @@ msgstr "用于会计的服务的商业ID"
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "系统范围内的默认配置,表明是否要求,允许或禁止为分析请求添加附件."
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr "分析的周转时间"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "分析的周转时间以时间画图"
 
@@ -5519,7 +5477,7 @@ msgstr "分析周转时间"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "分析的周转时间以时间画图"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "唯一关键字用作识别从大量AR(分析请求)导入文件中的分析服务和从仪器中导入的结果。它也被用作识别在用户所定义的结果计算方法中所依赖的分析服务。"
 
@@ -5531,37 +5489,37 @@ msgstr "没有结果"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "这些结果可以被报告为干物质"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "这些结果已被撤回，这里列出的目的是为方便追溯。请按照链接到复检"
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "该分析请求已因分析请求${retracted_request_id}的收回而自动启动。"
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "这些结果已被撤回，这里列出的目的只为方便追溯。复检：${retest_child_id}。"
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "由于计算未工作, 分析服务不能激活."
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "由于从属于一个或多个计算, 该分析服务现在不能停止."
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5573,7 +5531,7 @@ msgstr "本服务不需要单独分区"
 msgid "This service requires a separate container."
 msgstr "此服务需要一个单独的容器。"
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5581,13 +5539,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "该文本将添加到结果报告后."
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "本值为所有发布的结果中最低值"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5601,63 +5555,63 @@ msgstr "此工作表已被拒绝。替换工作表为${ws_id}"
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "提示：附加文件将不会加载除非他们在实例呈现。"
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "标题"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "位置的标题"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "货架的标题"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "站点的标题"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "至"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "需要保留"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "需要取样"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "将显示在结果报告每个分析类别部分下方。"
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "需要验证"
 
@@ -5669,13 +5623,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "总计"
 
@@ -5683,22 +5637,22 @@ msgstr "总计"
 msgid "Total Lag"
 msgstr "总延迟"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "总价"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "总分析"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "总数据点"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "总价"
 
@@ -5710,11 +5664,11 @@ msgstr "总计："
 msgid "Traceability"
 msgstr "可追溯性"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5722,61 +5676,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "打开该选项，如果你想使用样品划分工作"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "周转时间（h）"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "类型"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "类型错误"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "位置的类型"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "无法加载模板"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "无法发送邮件提醒实验室客户联系人（lab client contacts），分析请求已被收回：${error}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "没有分派"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "不确定性"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "不确定值"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "未定义"
 
@@ -5784,13 +5732,13 @@ msgstr "未定义"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "单位"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "未知IBAN国家%s"
 
@@ -5815,17 +5763,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "未公布"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "无法识别的文件格式 ${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "无法识别的文件格式 ${file_format}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5837,11 +5785,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上传一个用于打印分析报告的签名扫描件. 理想尺寸为250像素宽, 150像素高"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "检测上限（UDL）"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "使用分析简介价格"
 
@@ -5849,7 +5797,7 @@ msgstr "使用分析简介价格"
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "使用默认的计算"
 
@@ -5861,13 +5809,13 @@ msgstr "使用外部ID服务器"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "使用该字段传递任意参数到导出/导入模块"
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "用户"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "用户名"
@@ -5880,7 +5828,7 @@ msgstr "用户历史记录"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "用户历史记录"
@@ -5889,27 +5837,27 @@ msgstr "用户历史记录"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "取样点太少时分析结果无意义. 请在质量控制统计处理前设置可接受的最小样品量."
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "增值税"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "增值税%"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "增值税额"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "增值税合计"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "增值税数目"
 
@@ -5917,11 +5865,11 @@ msgstr "增值税数目"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "有效自"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "有效至"
 
@@ -5929,181 +5877,181 @@ msgstr "有效至"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "验证"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "验证失败: '${keyword}': 重复关键词"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "验证失败: '${title}': 该关键词已在计算 '${used_by}' 中使用"
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "验证失败: '${title}': 该关键词已在服务 '${used_by}' 中使用"
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "验证失败: '${title}': 重复的标题"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "验证失败: '${value}' 非唯一"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "验证失败: 方向必须是E（东）/W（西）"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "验证失败: 方向必须是N（北）/S（南）"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "验证失败: 误差率必须在0和100之间"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "验证失败: 误差值必须为0或大于0"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "验证失败: 误差值必须是数字"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "验证失败: 预期值必须介于最小和最大值"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "验证失败: 预期值必须是数字"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "验证失败: 关键词 '${keyword}' 无效"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "验证失败: 最大值必须必最小值大"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "验证失败: 最大值必须为数字"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "验证失败: 最小值必须为数字"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "验证失败: 百分误差值必须介于0到100"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "验证失败: 百分误差值必须为数字"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "验证失败: 预保留容器必须选择保留."
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "验证失败: 结果文本不能为空"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "验证失败: 结果必须是数字"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "验证失败: 要求选中如下类别: ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "验证失败: 值必须为数字"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "验证失败: 列标题 '${title}' 必须含有关键词 '${keyword}'"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "验证失败: 度为180时, 分必须为0"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "验证失败: 度为180时, 秒必须为0"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "验证失败: 度为90时, 分必须为0"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "验证失败: 度为90时, 秒必须为0"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "验证失败: 度必须在0-180之间"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "验证失败: 度必须在0-90间"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "验证失败: 度必须是数字"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "验证失败: 关键词 '${keyword}' 必须含有列标题 '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "验证失败: 关键词包含无效字符"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "验证失败: 需要关键词"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "验证失败: 分必须在0-59之间"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "验证失败: 分必须是数字"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "验证失败: 百分比值必须在0到100之间"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "验证失败: 百分比值必须为数字"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "验证失败: 秒必须在0-59之间"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "验证失败: 秒必须是数字"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "验证失败: 需要标题"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6111,7 +6059,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "验证报告的日期"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "验证器;"
@@ -6122,12 +6070,12 @@ msgstr "验证器;"
 msgid "Value"
 msgstr "值"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "可在此处输入的值将覆盖在计算临时字段指定的默认值。"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "已验证"
@@ -6138,7 +6086,7 @@ msgstr "已验证"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "版本"
 
@@ -6148,11 +6096,11 @@ msgstr "版本"
 msgid "Volume"
 msgstr "体积"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "认证机构的网址"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "网站"
 
@@ -6160,24 +6108,24 @@ msgstr "网站"
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "几周后过期"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "当它被设置，系统将采用分析型的价格且系统的增值税由分析指定的增值税覆盖"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "当在工作表有对同一样品进行分析的重复结果，差别超过这一比例将引发警报"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "临时经理不允许使用通配符: ${wildcards}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "工作完成"
@@ -6188,25 +6136,25 @@ msgstr "工作流"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "工作表"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "工作表布局"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "工作表模板"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "工作表"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "错误的IBAN账号长度%s: %s 用短的 %i"
 
@@ -6214,9 +6162,9 @@ msgstr "错误的IBAN账号长度%s: %s 用短的 %i"
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "是"
 
@@ -6228,7 +6176,7 @@ msgstr "您没有足够的权限管理工作表。"
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "您没有足够的权限查看工作表${worksheet_title}。"
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "您必须将此请求分配给客户"
 
@@ -6236,11 +6184,11 @@ msgstr "您必须将此请求分配给客户"
 msgid "You must select an instrument"
 msgstr "你必须选择一个仪器"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "你应该引入一个默认结果密钥"
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "动作"
 
@@ -6256,15 +6204,15 @@ msgstr "分析"
 msgid "analysis requests selected"
 msgstr "选择的分析请求"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "以及其他等等"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6287,7 +6235,7 @@ msgstr "bika-首页-描述"
 msgid "bika-frontpage-title"
 msgstr "bika-首页-标题"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "评论"
 
@@ -6295,37 +6243,9 @@ msgstr "评论"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "数据"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6336,7 +6256,7 @@ msgstr "失活"
 msgid "heading_arpriority"
 msgstr "标题_分析请求优先级"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6385,19 +6305,19 @@ msgstr "新版本可用说明"
 msgid "new_version_available_title"
 msgstr "新版本可用标题"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6405,19 +6325,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "重复每一个"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "重复周期"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6436,19 +6356,8 @@ msgstr "摘要内容列表"
 msgid "text_default_site_title"
 msgstr "默认网站标题文字"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6460,7 +6369,7 @@ msgstr "标题是必填字段"
 msgid "to"
 msgstr "至"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6468,7 +6377,7 @@ msgstr ""
 msgid "type"
 msgstr "类型"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "直到"
 
@@ -6494,7 +6403,7 @@ msgstr "值"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6506,6 +6415,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/bika.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Bika-LIMS\n"
-"POT-Creation-Date: 2017-05-26 15:46+0000\n"
+"POT-Creation-Date: 2017-07-02 12:53+0000\n"
 "PO-Revision-Date: 2017-05-26 15:41+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/bikalabs/bika-lims/language/zh_TW/)\n"
@@ -24,49 +24,49 @@ msgstr ""
 msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:240
+#: bika/lims/browser/analysisrequest/workflow.py:242
 msgid "${items} are missing Preserver or Date Preserved"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:110
+#: bika/lims/browser/client/workflow.py:115
 msgid "${items} are waiting for preservation."
 msgstr "${items} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:228
-#: bika/lims/browser/client/workflow.py:113
+#: bika/lims/browser/analysisrequest/workflow.py:230
+#: bika/lims/browser/client/workflow.py:118
 msgid "${items} are waiting to be received."
 msgstr "${items} 等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:561
+#: bika/lims/browser/analysisrequest/workflow.py:563
 msgid "${items} invalidated."
 msgstr "無效的"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:117
+#: bika/lims/controlpanel/bika_analysisservices.py:124
 msgid "${items} were successfully created."
 msgstr "已成功建立"
 
-#: bika/lims/browser/client/workflow.py:176
+#: bika/lims/browser/client/workflow.py:181
 msgid "${items}: partitions are waiting to be received."
 msgstr "${items}: 部分等待接收."
 
-#: bika/lims/browser/analysisrequest/workflow.py:244
+#: bika/lims/browser/analysisrequest/workflow.py:246
 msgid "${item} is missing Preserver or Preservation Date"
 msgstr ""
 
-#: bika/lims/browser/client/workflow.py:118
+#: bika/lims/browser/client/workflow.py:123
 msgid "${item} is waiting for preservation."
 msgstr "${item} 等待保留."
 
-#: bika/lims/browser/analysisrequest/workflow.py:232
-#: bika/lims/browser/client/workflow.py:121
+#: bika/lims/browser/analysisrequest/workflow.py:234
+#: bika/lims/browser/client/workflow.py:126
 msgid "${item} is waiting to be received."
 msgstr "${item} 等待接收."
 
-#: bika/lims/controlpanel/bika_analysisservices.py:121
+#: bika/lims/controlpanel/bika_analysisservices.py:128
 msgid "${item} was successfully created."
 msgstr "已成功建立"
 
-#: bika/lims/browser/client/workflow.py:179
+#: bika/lims/browser/client/workflow.py:184
 msgid "${item}: ${part} is waiting to be received."
 msgstr "${item}: ${part} 等待接收."
 
@@ -82,7 +82,7 @@ msgstr ""
 msgid "%"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:77
+#: bika/lims/content/analysisspec.py:79
 msgid "% Error"
 msgstr "%誤差"
 
@@ -96,15 +96,15 @@ msgstr "%已做"
 msgid "% Published"
 msgstr "%已發表"
 
-#: bika/lims/utils/workflow/schedulesampling.py:33
+#: bika/lims/utils/workflow/schedulesampling.py:35
 msgid "%s can't be transitioned."
 msgstr ""
 
-#: bika/lims/utils/analysisrequest.py:312
+#: bika/lims/utils/analysisrequest.py:315
 msgid "%s has been rejected"
 msgstr ""
 
-#: bika/lims/exportimport/setupdata/__init__.py:35
+#: bika/lims/exportimport/setupdata/__init__.py:37
 msgid "%s has no '%s' column."
 msgstr ""
 
@@ -116,15 +116,15 @@ msgstr ""
 msgid "'Classic' indicates importing analysis requests per sample and analysis service selection. With 'Profiles', analysis profile keywords are used to select multiple analysis services together"
 msgstr "'典型的'表示按样品和分析服务板块导入的分析请求. 在多选分析服务时, 在''配置'中分析配置关键词"
 
-#: bika/lims/browser/analysisrequest/workflow.py:700
+#: bika/lims/browser/analysisrequest/workflow.py:702
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:686
+#: bika/lims/browser/analysisrequest/workflow.py:688
 msgid "'Sampling date' and 'Define the Sampler for the scheduled sampling' must be completed and saved in order to schedule a sampling. Element: %s"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:190
+#: bika/lims/content/referencesample.py:192
 #: bika/lims/skins/bika/attachments.pt:205
 msgid "(Blank)"
 msgstr "(空白)"
@@ -137,7 +137,7 @@ msgstr "(對照)"
 msgid "(Duplicate)"
 msgstr "(重復)"
 
-#: bika/lims/content/referencesample.py:192
+#: bika/lims/content/referencesample.py:194
 msgid "(Hazardous)"
 msgstr "(有害廢物)"
 
@@ -146,32 +146,26 @@ msgid "(Required)"
 msgstr "(要求的)"
 
 #: bika/lims/browser/analyses.py:105
-#: bika/lims/browser/referencesample.py:121
+#: bika/lims/browser/referencesample.py:123
 #: bika/lims/browser/worksheet/views/analyses.py:46
 msgid "+-"
 msgstr "±"
 
-#: bika/lims/content/arpriority.py:33
+#: bika/lims/content/arpriority.py:35
 msgid "16x16 pixel icon used for the this priority in listings."
 msgstr ""
 
-#: bika/lims/content/arpriority.py:39
+#: bika/lims/content/arpriority.py:41
 msgid "32x32 pixel icon used for the this priority in object views."
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:53
-#: bika/lims/content/analysisspec.py:78
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/content/analysisspec.py:80
 msgid "< Min"
 msgstr "<小於"
 
 #: bika/lims/skins/bika/bika_widgets/rejectionwidget.pt:59
 msgid "<input type=\"checkbox\" class=\"rejectionwidget-checkbox-other rejectionwidget-field\" name=\"${DYNAMIC_CONTENT}\" id=\"${DYNAMIC_CONTENT}\" /> Other"
-msgstr ""
-
-msgid "<p>${service} requires the following services to be selected:</p><br/><p>${deps}</p><br/><p>Do you want to apply these selections now?</p>"
-msgstr ""
-
-msgid "<p>The following services depend on ${service}, and will be unselected if you continue:</p><br/><p>${deps}</p><br/><p>Do you want to remove these selections now?</p>"
 msgstr ""
 
 #: bika/lims/content/calculation.py:84
@@ -182,16 +176,16 @@ msgstr ""
 msgid "<span>x</span> <span class=\"formHelp\">x</span>"
 msgstr ""
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
-#: bika/lims/content/analysisspec.py:79
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:56
+#: bika/lims/content/analysisspec.py:81
 msgid "> Max"
 msgstr ">大於"
 
-#: bika/lims/content/samplinground.py:141
+#: bika/lims/content/samplinground.py:143
 msgid "A short name that describes the Round for it to be easily identified on forms and drop-down menus"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:99
+#: bika/lims/browser/analysisrequest/add.py:106
 msgid "AR ${ar_number}"
 msgstr ""
 
@@ -203,7 +197,7 @@ msgstr "分析請求附件選項"
 msgid "AR ID Padding"
 msgstr "分析請求编號長度"
 
-#: bika/lims/browser/arimports.py:45
+#: bika/lims/browser/arimports.py:47
 msgid "AR Import"
 msgstr "輸入分析請求"
 
@@ -211,17 +205,17 @@ msgstr "輸入分析請求"
 msgid "AR Import options"
 msgstr "分析請求輸入選項"
 
-#: bika/lims/browser/srtemplate/artemplates.py:38
+#: bika/lims/browser/srtemplate/artemplates.py:40
 msgid "AR Template Title"
 msgstr ""
 
-#: bika/lims/browser/client/views/artemplates.py:34
-#: bika/lims/browser/srtemplate/artemplates.py:33
+#: bika/lims/browser/client/views/artemplates.py:36
+#: bika/lims/browser/srtemplate/artemplates.py:35
 #: bika/lims/content/srtemplate.py:85
 msgid "AR Templates"
 msgstr "分析請來樣板"
 
-#: bika/lims/browser/analysisrequest/view.py:453
+#: bika/lims/browser/analysisrequest/view.py:455
 msgid "AR for retested results"
 msgstr "分析以供重測結果"
 
@@ -229,54 +223,54 @@ msgstr "分析以供重測結果"
 msgid "ARs"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/publish.py:1030
+#: bika/lims/browser/analysisrequest/publish.py:1032
 msgid "ARs: ${ars}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:78
+#: bika/lims/content/organisation.py:80
 msgid "Account Name"
 msgstr "帳户名稱"
 
-#: bika/lims/content/organisation.py:84
+#: bika/lims/content/organisation.py:86
 msgid "Account Number"
 msgstr "帳號"
 
-#: bika/lims/content/organisation.py:72
+#: bika/lims/content/organisation.py:74
 msgid "Account Type"
 msgstr "帳户類型"
 
-#: bika/lims/browser/accreditation.py:40
-#: bika/lims/content/laboratory.py:64
+#: bika/lims/browser/accreditation.py:39
+#: bika/lims/content/laboratory.py:66
 msgid "Accreditation"
 msgstr "認證"
 
-#: bika/lims/content/laboratory.py:48
+#: bika/lims/content/laboratory.py:50
 msgid "Accreditation Body Abbreviation"
 msgstr "認證方縮寫"
 
-#: bika/lims/content/laboratory.py:56
+#: bika/lims/content/laboratory.py:58
 msgid "Accreditation Body URL"
 msgstr "認證方網址連結"
 
-#: bika/lims/content/laboratory.py:79
+#: bika/lims/content/laboratory.py:81
 msgid "Accreditation Logo"
 msgstr "認證標籤"
 
-#: bika/lims/content/laboratory.py:72
+#: bika/lims/content/laboratory.py:74
 msgid "Accreditation Reference"
 msgstr "認證编碼"
 
-#: bika/lims/content/laboratory.py:92
+#: bika/lims/content/laboratory.py:94
 msgid "Accreditation page header"
 msgstr "認證數據包的開始部分"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:264
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:134
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:105
+#: bika/lims/browser/analysisrequest/manage_analyses.py:266
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:136
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:107
 msgid "Accredited"
 msgstr "已認證"
 
-#: bika/lims/browser/log.py:53
+#: bika/lims/browser/log.py:55
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:74
 #: bika/lims/browser/templates/analysisservice_popup.pt:290
 msgid "Action"
@@ -290,21 +284,21 @@ msgstr "在指定時間內用戶(或特定用戶)所進行之動作"
 msgid "Activate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:152
-#: bika/lims/browser/client/views/analysisprofiles.py:49
-#: bika/lims/browser/client/views/analysisspecs.py:55
+#: bika/lims/browser/analysisrequest/analysisrequests.py:154
+#: bika/lims/browser/client/views/analysisprofiles.py:51
+#: bika/lims/browser/client/views/analysisspecs.py:57
 msgid "Active"
 msgstr "活躍的"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:110
-#: bika/lims/browser/sample/printform.py:284
-#: bika/lims/browser/sample/view.py:105
+#: bika/lims/browser/analysisrequest/analysisrequests.py:112
+#: bika/lims/browser/sample/printform.py:286
+#: bika/lims/browser/sample/view.py:107
 msgid "Ad-Hoc"
 msgstr "無線網路點對點傳輸模式"
 
-#: bika/lims/browser/batchfolder.py:103
-#: bika/lims/browser/client/views/analysisprofiles.py:68
-#: bika/lims/browser/client/views/analysisrequests.py:44
+#: bika/lims/browser/batchfolder.py:105
+#: bika/lims/browser/client/views/analysisprofiles.py:70
+#: bika/lims/browser/client/views/analysisrequests.py:46
 msgid "Add"
 msgstr "添加"
 
@@ -324,11 +318,7 @@ msgstr "添加對照参考"
 msgid "Add Duplicate"
 msgstr "添加重復"
 
-# worksheet.js
-msgid "Add Remark"
-msgstr ""
-
-#: bika/lims/controlpanel/bika_artemplates.py:41
+#: bika/lims/controlpanel/bika_artemplates.py:43
 msgid "Add Template"
 msgstr "添加樣板"
 
@@ -336,16 +326,16 @@ msgstr "添加樣板"
 msgid "Add a remarks field to all analyses"
 msgstr "在所有分析加入添加備註欄"
 
-#: bika/lims/browser/batch/analysisrequests.py:34
-#: bika/lims/browser/samplinground/analysisrequests.py:270
+#: bika/lims/browser/batch/analysisrequests.py:36
+#: bika/lims/browser/samplinground/analysisrequests.py:272
 msgid "Add new"
 msgstr "新增/添加新"
 
-#: bika/lims/browser/analysisrequest/workflow.py:532
+#: bika/lims/browser/analysisrequest/workflow.py:534
 msgid "Additional remarks:"
 msgstr "附加備註"
 
-#: bika/lims/content/storagelocation.py:87
+#: bika/lims/content/storagelocation.py:89
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:122
 msgid "Address"
 msgstr "地址"
@@ -358,26 +348,26 @@ msgstr "在ID前綴後面添加2位年"
 msgid "Administrative Reports"
 msgstr "管理員報告"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:167
+#: bika/lims/browser/reports/selection_macros/__init__.py:169
 msgid "After ${end_date}"
 msgstr "之後"
 
-#: bika/lims/browser/instrument.py:537
+#: bika/lims/browser/instrument.py:539
 #: bika/lims/content/instrumentcertification.py:89
 msgid "Agency"
 msgstr "代理機構"
 
-#: bika/lims/browser/accreditation.py:81
+#: bika/lims/browser/accreditation.py:80
 #: bika/lims/browser/aggregatedanalyses.py:81
 #: bika/lims/browser/analyses.py:127
 msgid "All"
 msgstr "所有的"
 
-#: bika/lims/browser/accreditation.py:60
+#: bika/lims/browser/accreditation.py:59
 msgid "All Accredited analysis services are listed here."
 msgstr "所有已認證的分析服務均列于此."
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:787
+#: bika/lims/browser/analysisrequest/analysisrequests.py:789
 msgid "All analyses assigned"
 msgstr "所有已分派分析"
 
@@ -389,7 +379,7 @@ msgstr "所有分析類型"
 msgid "Allow Lab Clerks to create and edit clients"
 msgstr "容許實驗室書記去開設和修改客戶"
 
-#: bika/lims/content/analysisservice.py:361
+#: bika/lims/content/analysisservice.py:360
 msgid "Allow Manual Detection Limit input"
 msgstr "容許輸入手動偵查限制/極限"
 
@@ -397,15 +387,15 @@ msgstr "容許輸入手動偵查限制/極限"
 msgid "Allow access to worksheets only to assigned analysts"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:953
+#: bika/lims/content/analysisservice.py:952
 msgid "Allow manual uncertainty value input"
 msgstr "容許手動輸入不確定的結果"
 
-#: bika/lims/config.py:124
+#: bika/lims/config.py:123
 msgid "Allow same user to verify multiple times"
 msgstr ""
 
-#: bika/lims/config.py:125
+#: bika/lims/config.py:124
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
 
@@ -413,11 +403,11 @@ msgstr ""
 msgid "Allow self-verification of results"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:362
+#: bika/lims/content/analysisservice.py:361
 msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
 msgstr "允許分析師在頁面手動更改預設/默認檢出限（ LDL和UDL）的結果"
 
-#: bika/lims/content/analysisservice.py:954
+#: bika/lims/content/analysisservice.py:953
 msgid "Allow the analyst to manually replace the default uncertainty value."
 msgstr "允許分析師手動更改預設/默認不確定的數值"
 
@@ -425,48 +415,48 @@ msgstr "允許分析師手動更改預設/默認不確定的數值"
 msgid "Allow users to filter datas by department."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:674
+#: bika/lims/content/analysisservice.py:673
 msgid "Alternative Calculation"
 msgstr "另一計算方法"
 
-#: bika/lims/content/client.py:85
+#: bika/lims/content/client.py:87
 msgid "Always expand the selected categories in client views"
 msgstr "在客戶檢視版面, 永遠擴大所選的類別"
 
-#: bika/lims/browser/sample/printform.py:280
+#: bika/lims/browser/sample/printform.py:282
 msgid "Ambiental Conditions"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:76
 msgid "Amount"
 msgstr "數量"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:106
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt:57
-#: bika/lims/browser/dashboard.py:581
+#: bika/lims/browser/dashboard.py:583
 msgid "Analyses"
 msgstr "分析"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:305
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:307
 msgid "Analyses in error shoulder range"
 msgstr "分析在誤差範圍內肩的數據"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:31
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:235
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:301
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:33
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:237
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:303
 msgid "Analyses out of range"
 msgstr "範圍外分析"
 
 #: bika/lims/browser/aggregatedanalyses.py:48
-#: bika/lims/browser/dashboard.py:506
+#: bika/lims/browser/dashboard.py:508
 msgid "Analyses pending"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:34
+#: bika/lims/browser/reports/productivity_analysesperservice.py:36
 msgid "Analyses per analysis service"
 msgstr "按分析服務分析"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:34
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:36
 #: bika/lims/browser/reports/templates/productivity.pt:211
 msgid "Analyses per sample type"
 msgstr "按樣品類型分析"
@@ -480,7 +470,7 @@ msgstr "按服務分析"
 msgid "Analyses performed and published as % of total"
 msgstr "分析已進行的並公佈為總％"
 
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:195
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:197
 msgid "Analyses performed as % of total"
 msgstr "分析已進行的為總％"
 
@@ -493,27 +483,27 @@ msgstr "分析相關的報告"
 msgid "Analyses repeated"
 msgstr "分析重復的"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:32
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:34
 msgid "Analyses results out of specified range"
 msgstr "分析超出規定範圍結果"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:30
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:32
 msgid "Analyses retested"
 msgstr "已重新分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:205
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:207
 #: bika/lims/browser/reports/templates/productivity.pt:378
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:77
 msgid "Analyses summary per department"
 msgstr "分析每個部門的總結"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:31
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:33
 msgid "Analyses which have been retested"
 msgstr "分析那個是已重新測試"
 
 #: bika/lims/browser/analyses.py:69
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
-#: bika/lims/browser/late_analyses.py:44
+#: bika/lims/browser/late_analyses.py:46
 msgid "Analysis"
 msgstr "分析"
 
@@ -521,52 +511,52 @@ msgstr "分析"
 msgid "Analysis Attachment Option"
 msgstr "分析附件選項"
 
-#: bika/lims/controlpanel/bika_analysiscategories.py:22
+#: bika/lims/controlpanel/bika_analysiscategories.py:24
 msgid "Analysis Categories"
 msgstr "分析多個類别"
 
-#: bika/lims/content/analysisservice.py:775
+#: bika/lims/content/analysisservice.py:774
 msgid "Analysis Category"
 msgstr "分析單個類别"
 
-#: bika/lims/content/analysisservice.py:400
+#: bika/lims/content/analysisservice.py:399
 msgid "Analysis Keyword"
 msgstr "分析關鍵詞"
 
-#: bika/lims/content/analysisrequest.py:483
-#: bika/lims/content/artemplate.py:165
+#: bika/lims/content/analysisrequest.py:485
+#: bika/lims/content/artemplate.py:167
 msgid "Analysis Profile"
 msgstr "分析單個數據圖表"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:35
-#: bika/lims/content/analysisrequest.py:504
-#: bika/lims/controlpanel/bika_analysisprofiles.py:22
+#: bika/lims/browser/client/views/analysisprofiles.py:37
+#: bika/lims/content/analysisrequest.py:506
+#: bika/lims/controlpanel/bika_analysisprofiles.py:24
 msgid "Analysis Profiles"
 msgstr "分析多個數據圖表"
 
 #: bika/lims/browser/aggregatedanalyses.py:72
-#: bika/lims/browser/batch/batchbook.py:46
+#: bika/lims/browser/batch/batchbook.py:51
 #: bika/lims/browser/templates/analyses_retractedlist.pt:17
 msgid "Analysis Request"
 msgstr "分析請求"
 
-#: bika/lims/config.py:74
+#: bika/lims/config.py:73
 msgid "Analysis Request ID"
 msgstr "分析請求編號"
 
-#: bika/lims/browser/arimports.py:56
+#: bika/lims/browser/arimports.py:58
 msgid "Analysis Request Imports"
 msgstr "分析進口申請"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:44
+#: bika/lims/controlpanel/bika_arpriorities.py:46
 msgid "Analysis Request Priorities"
 msgstr "分析優先級請求"
 
-#: bika/lims/config.py:64
+#: bika/lims/config.py:63
 msgid "Analysis Request Specifications"
 msgstr "分析規格請求"
 
-#: bika/lims/content/samplinground.py:198
+#: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
 msgstr ""
 
@@ -574,65 +564,65 @@ msgstr ""
 msgid "Analysis Request rejection reporting form"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:61
-#: bika/lims/browser/dashboard.py:343
+#: bika/lims/browser/analysisrequest/analysisrequests.py:63
+#: bika/lims/browser/dashboard.py:345
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:69
 msgid "Analysis Requests"
 msgstr "分析請求"
 
-#: bika/lims/browser/dashboard.py:186
+#: bika/lims/browser/dashboard.py:188
 msgid "Analysis Requests to be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:286
+#: bika/lims/browser/dashboard.py:288
 msgid "Analysis Requests to be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:226
+#: bika/lims/browser/dashboard.py:228
 msgid "Analysis Requests to be received"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/dashboard.py:168
 msgid "Analysis Requests to be sampled"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/dashboard.py:268
 msgid "Analysis Requests to be verified"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:246
+#: bika/lims/browser/dashboard.py:248
 msgid "Analysis Requests with results pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:206
+#: bika/lims/browser/dashboard.py:208
 msgid "Analysis Requests with scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:95
-#: bika/lims/browser/fields/referenceresultsfield.py:26
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:44
+#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/fields/referenceresultsfield.py:28
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:46
 msgid "Analysis Service"
 msgstr "分析單個服務"
 
-#: bika/lims/config.py:44
-#: bika/lims/controlpanel/bika_analysisservices.py:147
+#: bika/lims/config.py:43
+#: bika/lims/controlpanel/bika_analysisservices.py:153
 msgid "Analysis Services"
 msgstr "分析多個服務"
 
-#: bika/lims/content/analysisrequest.py:738
+#: bika/lims/content/analysisrequest.py:740
 msgid "Analysis Specification"
 msgstr "分析單個規格"
 
-#: bika/lims/browser/client/views/analysisspecs.py:42
-#: bika/lims/controlpanel/bika_analysisspecs.py:35
+#: bika/lims/browser/client/views/analysisspecs.py:44
+#: bika/lims/controlpanel/bika_analysisspecs.py:37
 msgid "Analysis Specifications"
 msgstr "分析多個規格"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:44
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:46
 msgid "Analysis State"
 msgstr "分析狀態"
 
-#: bika/lims/content/worksheettemplate.py:29
+#: bika/lims/content/worksheettemplate.py:31
 #: bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt:58
 msgid "Analysis Type"
 msgstr "分析類型"
@@ -641,46 +631,46 @@ msgstr "分析類型"
 msgid "Analysis category"
 msgstr "分析類别"
 
-#: bika/lims/browser/analysisrequest/add.py:461
+#: bika/lims/browser/analysisrequest/add.py:468
 msgid "Analysis request ${AR} was successfully created."
 msgstr "分析請求 ${AR} 已成功建立"
 
-#: bika/lims/content/samplinground.py:154
+#: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/add.py:458
+#: bika/lims/browser/analysisrequest/add.py:465
 msgid "Analysis requests ${ARs} were successfully created."
 msgstr "分析請求 ${ARs} 已成功建立"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:51
+#: bika/lims/browser/reports/productivity_analysesperclient.py:53
 #: bika/lims/browser/reports/templates/productivity.pt:254
 msgid "Analysis requests and analyses"
 msgstr "分析請求和分析"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:54
+#: bika/lims/browser/reports/productivity_analysesperclient.py:56
 #: bika/lims/browser/reports/templates/productivity.pt:264
 msgid "Analysis requests and analyses per client"
 msgstr "分析請求與按客户分析 "
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:31
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:34
 #: bika/lims/browser/reports/templates/administration.pt:94
 msgid "Analysis requests not invoiced"
 msgstr "未結算的分析請求"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:234
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:236
 msgid "Analysis result within error range"
 msgstr "在誤差範圍内分析結果"
 
-#: bika/lims/browser/analysisrequest/publish.py:1051
+#: bika/lims/browser/analysisrequest/publish.py:1053
 msgid "Analysis results"
 msgstr "分析結果"
 
-#: bika/lims/browser/analysisrequest/publish.py:1046
+#: bika/lims/browser/analysisrequest/publish.py:1048
 msgid "Analysis results for ${subject_parts}"
 msgstr "${subject_parts}的分析結果"
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:60
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:62
 msgid "Analysis results for per sample point and analysis service"
 msgstr "每個採樣點和分析服務的分析結果"
 
@@ -688,12 +678,12 @@ msgstr "每個採樣點和分析服務的分析結果"
 msgid "Analysis results out of lab or client specified range Note that this may take several minutes"
 msgstr "分析結果超出實驗室或客户指定範圍 - 注意這可能需要花幾分鐘"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 #: bika/lims/browser/reports/selection_macros/select_analysisservice.pt:3
 msgid "Analysis service"
 msgstr "分析服務"
 
-#: bika/lims/browser/client/views/analysisspecs.py:115
+#: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
 msgstr "重置分析規格至實驗室默認值"
 
@@ -709,17 +699,17 @@ msgstr "分析周轉時間"
 msgid "Analysis turnaround time over time"
 msgstr "分析周轉時間超時"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:34
+#: bika/lims/browser/reports/productivity_analysestats.py:36
 msgid "Analysis turnaround times"
 msgstr "分析周轉時間"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:32
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
 msgid "Analysis turnaround times over time"
 msgstr "分析周轉時間超時"
 
 #: bika/lims/browser/analyses.py:83
-#: bika/lims/browser/batch/publish.py:98
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:53
+#: bika/lims/browser/batch/publish.py:100
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:55
 msgid "Analyst"
 msgstr "分析員"
 
@@ -728,7 +718,7 @@ msgid "Analyst must be specified."
 msgstr "必須指定分析師"
 
 #: bika/lims/browser/worksheet/templates/add_analyses.pt:60
-#: bika/lims/content/analysisservice.py:75
+#: bika/lims/content/analysisservice.py:74
 msgid "Any"
 msgstr "任何"
 
@@ -740,7 +730,7 @@ msgstr "應用"
 msgid "Apply template"
 msgstr "應用樣板"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:30
+#: bika/lims/browser/fields/interimfieldsfield.py:32
 msgid "Apply wide"
 msgstr "應用廣泛"
 
@@ -758,15 +748,15 @@ msgstr "資產編號"
 msgid "Assign"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:562
-#: bika/lims/browser/samplinground/analysisrequests.py:205
+#: bika/lims/browser/analysisrequest/analysisrequests.py:564
+#: bika/lims/browser/samplinground/analysisrequests.py:207
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "已分派"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:89
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:91
-#: bika/lims/browser/reports/productivity_analysesperservice.py:90
+#: bika/lims/browser/reports/productivity_analysesperclient.py:91
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:93
+#: bika/lims/browser/reports/productivity_analysesperservice.py:92
 msgid "Assigned to worksheet"
 msgstr "已分派到工作表"
 
@@ -784,27 +774,27 @@ msgstr ""
 msgid "Attach to"
 msgstr "附加于"
 
-#: bika/lims/content/attachment.py:31
-#: bika/lims/content/samplepoint.py:88
+#: bika/lims/content/attachment.py:33
+#: bika/lims/content/samplepoint.py:90
 #: bika/lims/skins/bika/attachments.pt:11
 msgid "Attachment"
 msgstr "附件"
 
-#: bika/lims/content/attachment.py:45
+#: bika/lims/content/attachment.py:47
 msgid "Attachment Keys"
 msgstr "附件關鍵詞"
 
-#: bika/lims/content/analysisservice.py:384
+#: bika/lims/content/analysisservice.py:383
 msgid "Attachment Option"
 msgstr "附件選項"
 
-#: bika/lims/browser/client/views/attachments.py:35
-#: bika/lims/content/attachment.py:39
-#: bika/lims/controlpanel/bika_attachmenttypes.py:41
+#: bika/lims/browser/client/views/attachments.py:37
+#: bika/lims/content/attachment.py:41
+#: bika/lims/controlpanel/bika_attachmenttypes.py:43
 msgid "Attachment Type"
 msgstr "單一附件類型"
 
-#: bika/lims/controlpanel/bika_attachmenttypes.py:34
+#: bika/lims/controlpanel/bika_attachmenttypes.py:36
 msgid "Attachment Types"
 msgstr "多個附件類型"
 
@@ -814,25 +804,25 @@ msgstr "多個附件類型"
 msgid "Attachment due"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:285
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:149
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:120
+#: bika/lims/browser/analysisrequest/manage_analyses.py:287
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:151
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:122
 msgid "Attachment not permitted"
 msgstr "不允許添加附件"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:278
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:144
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:115
+#: bika/lims/browser/analysisrequest/manage_analyses.py:280
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:146
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:117
 msgid "Attachment required"
 msgstr "要求添加附件"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/productivity_analysesattachments.py:70
 msgid "Attachment type"
 msgstr "附件類型"
 
 #: bika/lims/browser/analyses.py:113
-#: bika/lims/browser/client/views/attachments.py:29
-#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/client/views/attachments.py:31
+#: bika/lims/browser/client/views/samplepoints.py:47
 msgid "Attachments"
 msgstr "多個附件"
 
@@ -844,7 +834,7 @@ msgstr ""
 msgid "Autofill"
 msgstr "自動填充"
 
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:480
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:482
 msgid "Autoimport"
 msgstr "自動進口"
 
@@ -861,27 +851,27 @@ msgstr "自動貼紙印刷"
 msgid "Available templates"
 msgstr "可用樣板"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:160
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:162
 msgid "Average TAT"
 msgstr "平均周轉時間"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:142
+#: bika/lims/browser/reports/productivity_analysestats.py:144
 msgid "Average early"
 msgstr "平均較早"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:140
+#: bika/lims/browser/reports/productivity_analysestats.py:142
 msgid "Average late"
 msgstr "平均較晚"
 
-#: bika/lims/browser/analysisrequest/add.py:386
+#: bika/lims/browser/analysisrequest/add.py:393
 msgid "Badly formed state: ${errmsg}"
 msgstr ""
 
-#: bika/lims/content/organisation.py:96
+#: bika/lims/content/organisation.py:98
 msgid "Bank branch"
 msgstr "銀行分行"
 
-#: bika/lims/content/organisation.py:90
+#: bika/lims/content/organisation.py:92
 msgid "Bank name"
 msgstr "銀行名稱"
 
@@ -890,31 +880,31 @@ msgid "Basis"
 msgstr "根據/基礎"
 
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:92
-#: bika/lims/content/analysisrequest.py:321
-#: bika/lims/content/arimport.py:130
+#: bika/lims/content/analysisrequest.py:323
+#: bika/lims/content/arimport.py:132
 msgid "Batch"
 msgstr "批量"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:84
-#: bika/lims/browser/batchfolder.py:44
+#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/batchfolder.py:46
 #: bika/lims/browser/templates/batch_publish.pt:52
 msgid "Batch ID"
 msgstr "批量ID"
 
-#: bika/lims/content/batch.py:115
-#: bika/lims/controlpanel/bika_batchlabels.py:29
+#: bika/lims/content/batch.py:117
+#: bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr "批量標籤"
 
-#: bika/lims/browser/batchfolder.py:34
+#: bika/lims/browser/batchfolder.py:36
 msgid "Batches"
 msgstr "多批"
 
-#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/coordinatefield.py:31
 msgid "Bearing"
 msgstr "軸承"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:164
+#: bika/lims/browser/reports/selection_macros/__init__.py:166
 msgid "Before ${start_date}"
 msgstr "${start_date}之前"
 
@@ -922,7 +912,7 @@ msgstr "${start_date}之前"
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:38
+#: bika/lims/content/arpriority.py:40
 msgid "Big Icon"
 msgstr "大圖標"
 
@@ -930,7 +920,7 @@ msgstr "大圖標"
 msgid "Bika LIMS"
 msgstr ""
 
-#: bika/lims/monkey/controlpanel.py:17
+#: bika/lims/monkey/controlpanel.py:19
 msgid "Bika LIMS Configuration"
 msgstr "Bika LIMS配置"
 
@@ -938,63 +928,67 @@ msgstr "Bika LIMS配置"
 msgid "Bika LIMS front-page"
 msgstr ""
 
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:66
+#: bika/lims/config.py:87
+#: bika/lims/content/organisation.py:68
 msgid "Billing address"
 msgstr "賬單地址"
 
-#: bika/lims/browser/referencesample.py:428
+#: bika/lims/browser/referencesample.py:430
 #: bika/lims/browser/templates/referencesample_view.pt:21
-#: bika/lims/config.py:50
+#: bika/lims/config.py:49
 msgid "Blank"
 msgstr "空白"
 
-#: bika/lims/config.py:93
+#: bika/lims/config.py:92
 msgid "Blank QC analyses"
 msgstr "空白檢測分析"
 
-#: bika/lims/controlpanel/bika_instruments.py:50
+#: bika/lims/browser/client/workflow.py:108
+msgid "Both Sampler and Date Sampled are required"
+msgstr ""
+
+#: bika/lims/controlpanel/bika_instruments.py:52
 msgid "Brand"
 msgstr "品牌"
 
-#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/browser/clientfolder.py:50
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:41
-#: bika/lims/content/pricelist.py:36
+#: bika/lims/content/client.py:43
+#: bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr "已使用大宗折扣"
 
-#: bika/lims/content/analysisservice.py:798
+#: bika/lims/content/analysisservice.py:797
 msgid "Bulk price (excluding VAT)"
 msgstr "批發價(不含增值税)"
 
-#: bika/lims/browser/client/views/contacts.py:48
-#: bika/lims/browser/supplier.py:66
+#: bika/lims/browser/client/views/contacts.py:50
+#: bika/lims/browser/supplier.py:68
 msgid "Business Phone"
 msgstr "業務/辦公室電話"
 
-#: bika/lims/browser/reports/__init__.py:133
+#: bika/lims/browser/reports/__init__.py:135
 msgid "By"
 msgstr "由"
 
-#: bika/lims/content/analysisrequest.py:168
+#: bika/lims/content/analysisrequest.py:170
 msgid "CC Contacts"
 msgstr "抄送多個聯絡"
 
-#: bika/lims/content/analysisrequest.py:211
-#: bika/lims/content/client.py:56
+#: bika/lims/content/analysisrequest.py:213
+#: bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr "抄送多個電郵"
 
-#: bika/lims/content/analysisservice.py:927
+#: bika/lims/content/analysisservice.py:926
 msgid "Calculate Precision from Uncertainties"
 msgstr "從不確定的進行精密計算"
 
-#: bika/lims/browser/accreditation.py:76
-#: bika/lims/browser/widgets/serviceswidget.py:62
-#: bika/lims/content/method.py:109
+#: bika/lims/browser/accreditation.py:75
+#: bika/lims/browser/widgets/serviceswidget.py:64
+#: bika/lims/content/method.py:111
 msgid "Calculation"
 msgstr "計算"
 
@@ -1002,8 +996,8 @@ msgstr "計算"
 msgid "Calculation Formula"
 msgstr "計算公式"
 
-#: bika/lims/content/analysis.py:98
-#: bika/lims/content/analysisservice.py:705
+#: bika/lims/content/analysis.py:97
+#: bika/lims/content/analysisservice.py:704
 #: bika/lims/content/calculation.py:49
 msgid "Calculation Interim Fields"
 msgstr "計算臨時場"
@@ -1016,11 +1010,11 @@ msgstr "計算: ${calc_name}"
 msgid "Calculation: None"
 msgstr "計算: 没有"
 
-#: bika/lims/controlpanel/bika_calculations.py:34
+#: bika/lims/controlpanel/bika_calculations.py:36
 msgid "Calculations"
 msgstr "多個計算"
 
-#: bika/lims/content/instrumentscheduledtask.py:89
+#: bika/lims/content/instrumentscheduledtask.py:91
 msgid "Calibration"
 msgstr "校準"
 
@@ -1032,12 +1026,12 @@ msgstr "校準證書"
 msgid "Calibration report date"
 msgstr "校準報告日期"
 
-#: bika/lims/browser/instrument.py:162
+#: bika/lims/browser/instrument.py:164
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
 msgstr "校準器"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:271
+#: bika/lims/browser/analysisrequest/manage_analyses.py:273
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:137
 #: bika/lims/browser/templates/analysisservice_popup.pt:68
 msgid "Can be reported as dry matter"
@@ -1051,9 +1045,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:481
-#: bika/lims/browser/arimports.py:93
-#: bika/lims/browser/batchfolder.py:75
+#: bika/lims/browser/analysisrequest/analysisrequests.py:483
+#: bika/lims/browser/arimports.py:95
+#: bika/lims/browser/batchfolder.py:77
 msgid "Cancelled"
 msgstr "已取消"
 
@@ -1069,18 +1063,18 @@ msgstr "不能停用的計算，因它現正被以下服務使用中: ${calc_ser
 msgid "Cannot verify, submitted or verified by current user before"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:884
+#: bika/lims/browser/analysisrequest/analysisrequests.py:886
 msgid "Cannot verify: Submitted by current user"
 msgstr "無法驗證：由當前用戶提交"
 
-#: bika/lims/content/container.py:39
-#: bika/lims/controlpanel/bika_containers.py:50
+#: bika/lims/content/container.py:41
+#: bika/lims/controlpanel/bika_containers.py:52
 msgid "Capacity"
 msgstr "容量"
 
 #: bika/lims/browser/analyses.py:116
-#: bika/lims/browser/referencesample.py:120
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:134
+#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:136
 msgid "Captured"
 msgstr "已捕獲; 佔領"
 
@@ -1089,7 +1083,7 @@ msgid "Cardinal"
 msgstr "主要的/基本的"
 
 #: bika/lims/browser/templates/referencesample_view.pt:54
-#: bika/lims/content/referencesample.py:76
+#: bika/lims/content/referencesample.py:78
 msgid "Catalogue Number"
 msgstr "類别號碼"
 
@@ -1097,17 +1091,17 @@ msgstr "類别號碼"
 msgid "Categorise analysis services"
 msgstr "所屬分類分析服務"
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/referencesample.py:108
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
+#: bika/lims/browser/accreditation.py:68
+#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:106
 msgid "Category"
 msgstr "單個類别"
 
-#: bika/lims/content/analysiscategory.py:98
+#: bika/lims/content/analysiscategory.py:100
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr "類別不能被停用，因為它包含分析服務"
 
-#: bika/lims/browser/instrument.py:535
+#: bika/lims/browser/instrument.py:537
 msgid "Cert. Num"
 msgstr "證書號碼"
 
@@ -1120,31 +1114,31 @@ msgstr "證書編碼"
 msgid "Changes saved."
 msgstr ""
 
-#: bika/lims/content/method.py:124
+#: bika/lims/content/method.py:126
 msgid "Check if the method has been accredited"
 msgstr "檢查方法是否已被認可"
 
-#: bika/lims/content/analysisservice.py:741
+#: bika/lims/content/analysisservice.py:740
 msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
 msgstr "如果分析服務包含在認證分析實驗室的時間表, 勾選此複選框"
 
-#: bika/lims/content/samplepoint.py:79
+#: bika/lims/content/samplepoint.py:81
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
 msgstr "在這一點上採取的樣本是“複合” ，並從多個子樣品放在一起，例如從混合在一起大壩幾面樣品是大壩具有代表性的樣本，勾選此選項。默認的，不勾選，表示“搶”樣本"
 
-#: bika/lims/content/container.py:48
+#: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
 msgstr "勾選此選項，如這個容器已經過處理。這選擇會將這個樣本分區保存在這個容器中的工作流程縮短。"
 
-#: bika/lims/content/arpriority.py:45
+#: bika/lims/content/arpriority.py:47
 msgid "Check this box if this is the default priority"
 msgstr "勾選此選項，如這是默認優先"
 
-#: bika/lims/content/laboratory.py:41
+#: bika/lims/content/laboratory.py:43
 msgid "Check this box if your laboratory is accredited"
 msgstr "勾選此選項，如您的實驗室認可是"
 
-#: bika/lims/content/analysisservice.py:994
+#: bika/lims/content/analysisservice.py:993
 msgid "Check this box to ensure a separate sample container is used for this analysis service"
 msgstr "勾選此選項，以確保一個獨立的樣品容器用於此分析服務"
 
@@ -1152,7 +1146,7 @@ msgstr "勾選此選項，以確保一個獨立的樣品容器用於此分析服
 msgid "Check this if you want to use a separate ID server. Prefixes are configurable separately in each Bika site"
 msgstr "勾選此選項，如果你想使用獨立的ID侍服器進。前綴會在每個Bika綱站獨立處理"
 
-#: bika/lims/content/analysisrequest.py:739
+#: bika/lims/content/analysisrequest.py:741
 msgid "Choose default AR specification values"
 msgstr "選擇默認AR規範值"
 
@@ -1168,19 +1162,19 @@ msgstr ""
 msgid "City"
 msgstr "城市"
 
-#: bika/lims/config.py:69
+#: bika/lims/config.py:68
 msgid "Classic"
 msgstr "典型的"
 
-#: bika/lims/browser/referencesample.py:221
+#: bika/lims/browser/referencesample.py:223
 msgid "Click on Analysis Categories (against shaded background) to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "點擊分析分類（對陰影的背景），看看分析服務在每個類別。輸入的最小值和最大值，以指示一個有效的結果的範圍。在這個範圍之外的任何結果將發出警報。誤差（％）欄字段允許評估對最小和最大值的結果時要考慮的一個％的不確定性。一個結果出如果％誤差考慮在內的範圍內，但仍然在範圍內，將提高一個不太嚴重的警報。"
 
-#: bika/lims/content/referencedefinition.py:33
+#: bika/lims/content/referencedefinition.py:35
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
 msgstr "點擊分析分類（對陰影的背景，看看分析服務在每個類別中，輸入的最小值和最大值來表示一個有效的結果範圍內，任何結果超出這個範圍就會引發警報。誤差（％）欄內會允許％的不確定, 這被視為如果％誤差考慮評估針對最小值和最大值的結果時，一個結果超出範圍，但仍然在範圍內，將提高一個不太嚴重的警報。"
 
-#: bika/lims/content/analysisspec.py:84
+#: bika/lims/content/analysisspec.py:86
 msgid "Click on Analysis Categories (against shaded backgroundto see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert. If the result is below '< Min' the result will be shown as '< [min]'. The same applies for results above '> Max'"
 msgstr "點擊分析分類（對陰影的背景，看看分析服務在每個類別中，輸入的最小值和最大值來表示一個有效的結果範圍內，任何結果超出這個範圍就會引發警報。誤差（％）欄內會允許％的不確定, 這被視為如果％誤差考慮評估針對最小值和最大值的結果時，一個結果超出範圍，但仍然在範圍內，將引發一個不太嚴重的警告。但如果結果低於'<最小值', 那結果會顯示為'<[min]'。這同樣適用於上述結果'> 最大值'"
 
@@ -1188,19 +1182,19 @@ msgstr "點擊分析分類（對陰影的背景，看看分析服務在每個類
 msgid "Click to download"
 msgstr "點擊下載"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:86
+#: bika/lims/browser/analysisrequest/analysisrequests.py:88
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:78
-#: bika/lims/browser/arimports.py:61
+#: bika/lims/browser/arimports.py:63
 msgid "Client"
 msgstr "客户"
 
-#: bika/lims/content/batch.py:100
+#: bika/lims/content/batch.py:102
 msgid "Client Batch ID"
 msgstr "客戶批ID"
 
-#: bika/lims/browser/clientfolder.py:48
-#: bika/lims/content/arimport.py:85
-#: bika/lims/content/batch.py:91
+#: bika/lims/browser/clientfolder.py:49
+#: bika/lims/content/arimport.py:87
+#: bika/lims/content/batch.py:93
 msgid "Client ID"
 msgstr "客户編號"
 
@@ -1208,59 +1202,59 @@ msgstr "客户編號"
 msgid "Client Landing Page"
 msgstr "客戶登錄頁面"
 
-#: bika/lims/content/arimport.py:77
+#: bika/lims/content/arimport.py:79
 msgid "Client Name"
 msgstr "客户名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:75
 msgid "Client Order"
 msgstr "客户訂單"
 
-#: bika/lims/browser/batch/batchbook.py:60
-#: bika/lims/content/analysisrequest.py:913
-#: bika/lims/content/arimport.py:93
+#: bika/lims/browser/batch/batchbook.py:65
+#: bika/lims/content/analysisrequest.py:915
+#: bika/lims/content/arimport.py:95
 msgid "Client Order Number"
 msgstr "客户訂單號碼"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:88
-#: bika/lims/browser/sample/view.py:90
+#: bika/lims/browser/analysisrequest/analysisrequests.py:90
+#: bika/lims/browser/sample/view.py:92
 msgid "Client Ref"
 msgstr "客户參考/參閱"
 
-#: bika/lims/browser/sample/printform.py:281
-#: bika/lims/config.py:76
-#: bika/lims/content/analysisrequest.py:947
+#: bika/lims/browser/sample/printform.py:283
+#: bika/lims/config.py:75
+#: bika/lims/content/analysisrequest.py:949
 msgid "Client Reference"
 msgstr "客户參考/參閱"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:91
-#: bika/lims/browser/sample/view.py:93
-#: bika/lims/config.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:93
+#: bika/lims/browser/sample/view.py:95
+#: bika/lims/config.py:76
 msgid "Client SID"
 msgstr "客户樣品編號"
 
-#: bika/lims/browser/sample/printform.py:282
-#: bika/lims/content/analysisrequest.py:982
+#: bika/lims/browser/sample/printform.py:284
+#: bika/lims/content/analysisrequest.py:984
 msgid "Client Sample ID"
 msgstr "客户樣品編號"
 
-#: bika/lims/browser/client/views/samplingrounds.py:25
+#: bika/lims/browser/client/views/samplingrounds.py:27
 msgid "Client Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:211
+#: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisrequests.py:39
+#: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
 msgstr "提交请求前需要客户联系"
 
-#: bika/lims/content/samplinground.py:205
+#: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:34
+#: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
 msgstr "多個客户"
 
@@ -1269,39 +1263,39 @@ msgstr "多個客户"
 msgid "Close"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:65
-#: bika/lims/content/instrumentmaintenancetask.py:112
-#: bika/lims/controlpanel/bika_samplingrounds.py:63
+#: bika/lims/browser/batchfolder.py:67
+#: bika/lims/content/instrumentmaintenancetask.py:114
+#: bika/lims/controlpanel/bika_samplingrounds.py:65
 msgid "Closed"
 msgstr "已關閉"
 
-#: bika/lims/content/storagelocation.py:53
+#: bika/lims/content/storagelocation.py:55
 msgid "Code for the location"
 msgstr "位置代碼"
 
-#: bika/lims/content/storagelocation.py:35
+#: bika/lims/content/storagelocation.py:37
 msgid "Code for the site"
 msgstr "地點代碼"
 
-#: bika/lims/content/storagelocation.py:77
+#: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
 msgstr "貨架代碼"
 
-#: bika/lims/config.py:110
+#: bika/lims/config.py:109
 msgid "Comma (,)"
 msgstr "逗號 (,)"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:77
-#: bika/lims/content/analysiscategory.py:39
+#: bika/lims/content/analysiscategory.py:41
 msgid "Comments"
 msgstr "評論, 意見"
 
-#: bika/lims/content/analysisrequest.py:1621
+#: bika/lims/content/analysisrequest.py:1623
 msgid "Comments or results interpretation"
 msgstr "評論或解釋結果"
 
-#: bika/lims/content/analysisprofile.py:74
-#: bika/lims/content/analysisservice.py:1109
+#: bika/lims/content/analysisprofile.py:76
+#: bika/lims/content/analysisservice.py:1108
 msgid "Commercial ID"
 msgstr "商業ID"
 
@@ -1309,21 +1303,21 @@ msgstr "商業ID"
 msgid "Complete"
 msgstr ""
 
-#: bika/lims/browser/client/views/samplepoints.py:43
-#: bika/lims/browser/sample/printform.py:283
-#: bika/lims/content/analysisrequest.py:1200
+#: bika/lims/browser/client/views/samplepoints.py:45
+#: bika/lims/browser/sample/printform.py:285
+#: bika/lims/content/analysisrequest.py:1202
 msgid "Composite"
 msgstr "混合物"
 
-#: bika/lims/browser/srtemplate/artemplates.py:53
+#: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
 msgstr ""
 
-#: bika/lims/content/laboratory.py:31
+#: bika/lims/content/laboratory.py:33
 msgid "Confidence Level %"
 msgstr "混合物等级%"
 
-#: bika/lims/content/artemplate.py:133
+#: bika/lims/content/artemplate.py:135
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
 msgstr "配置该模板的样品个部分和保留样品. 分配样品各部分给模板上的分析实验室"
 
@@ -1332,13 +1326,13 @@ msgid "Confirm password"
 msgstr "確定密碼"
 
 #: bika/lims/content/instrumentcalibration.py:105
-#: bika/lims/content/instrumentmaintenancetask.py:78
-#: bika/lims/content/instrumentscheduledtask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:80
+#: bika/lims/content/instrumentscheduledtask.py:62
 msgid "Considerations"
 msgstr "考慮"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:94
-#: bika/lims/browser/late_analyses.py:49
+#: bika/lims/browser/analysisrequest/analysisrequests.py:96
+#: bika/lims/browser/late_analyses.py:51
 #: bika/lims/browser/reports/selection_macros/select_contact.pt:4
 msgid "Contact"
 msgstr "聯絡"
@@ -1347,8 +1341,8 @@ msgstr "聯絡"
 msgid "Contact is deactivated. User cannot be unlinked."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:40
-#: bika/lims/browser/supplier.py:61
+#: bika/lims/browser/client/views/contacts.py:42
+#: bika/lims/browser/supplier.py:63
 #: bika/lims/browser/templates/pricelist_email_form.pt:27
 msgid "Contacts"
 msgstr "多個聯絡"
@@ -1357,48 +1351,48 @@ msgstr "多個聯絡"
 msgid "Contacts to CC"
 msgstr "抄送聯絡"
 
-#: bika/lims/browser/sample/partitions.py:39
-#: bika/lims/browser/sample/printform.py:277
-#: bika/lims/browser/samplinground/printform.py:175
+#: bika/lims/browser/sample/partitions.py:41
+#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/samplinground/printform.py:177
 msgid "Container"
 msgstr "容器"
 
-#: bika/lims/browser/srtemplate/artemplates.py:58
+#: bika/lims/browser/srtemplate/artemplates.py:60
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:103
-#: bika/lims/content/container.py:32
-#: bika/lims/controlpanel/bika_containers.py:48
+#: bika/lims/content/analysisservice.py:102
+#: bika/lims/content/container.py:34
+#: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr "容器類型"
 
-#: bika/lims/controlpanel/bika_containertypes.py:34
+#: bika/lims/controlpanel/bika_containertypes.py:36
 msgid "Container Types"
 msgstr "容器類型"
 
-#: bika/lims/browser/srtemplate/artemplates.py:63
+#: bika/lims/browser/srtemplate/artemplates.py:65
 msgid "Container Volume"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:265
-#: bika/lims/controlpanel/bika_containers.py:34
+#: bika/lims/controlpanel/bika_containers.py:36
 msgid "Containers"
 msgstr "多個容器"
 
-#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/client/views/attachments.py:38
 msgid "Content Type"
 msgstr "內容類型"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:69
+#: bika/lims/browser/reports/productivity_analysesattachments.py:71
 msgid "Content type"
 msgstr "內容類型"
 
-#: bika/lims/config.py:51
+#: bika/lims/config.py:50
 msgid "Control"
 msgstr "對照"
 
-#: bika/lims/config.py:94
+#: bika/lims/config.py:93
 msgid "Control QC analyses"
 msgstr "控制質量控制分析"
 
@@ -1414,12 +1408,12 @@ msgstr "複製分析服務"
 msgid "Copy from"
 msgstr "從複製"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:907
-#: bika/lims/browser/batch/batchbook.py:107
+#: bika/lims/browser/analysisrequest/analysisrequests.py:909
+#: bika/lims/browser/batch/batchbook.py:112
 msgid "Copy to new"
 msgstr "複製到新的"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:137
+#: bika/lims/browser/reports/productivity_analysestats.py:139
 msgid "Count"
 msgstr "計數"
 
@@ -1432,18 +1426,18 @@ msgstr "國家"
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:671
-#: bika/lims/content/artemplate.py:69
+#: bika/lims/content/analysisrequest.py:673
+#: bika/lims/content/artemplate.py:71
 msgid "Create a new sample of this type"
 msgstr "創建這種類型的新樣品"
 
-#: bika/lims/browser/instrument.py:280
-#: bika/lims/browser/invoicebatch.py:31
-#: bika/lims/browser/reports/__init__.py:132
+#: bika/lims/browser/instrument.py:282
+#: bika/lims/browser/invoicebatch.py:33
+#: bika/lims/browser/reports/__init__.py:134
 msgid "Created"
 msgstr "已建立"
 
-#: bika/lims/browser/instrument.py:279
+#: bika/lims/browser/instrument.py:281
 msgid "Created by"
 msgstr "由建立"
 
@@ -1451,7 +1445,7 @@ msgstr "由建立"
 msgid "Created by:"
 msgstr "由建立:"
 
-#: bika/lims/content/arimport.py:291
+#: bika/lims/content/arimport.py:293
 msgid "Creating and initialising objects"
 msgstr ""
 
@@ -1459,8 +1453,8 @@ msgstr ""
 msgid "Creator"
 msgstr "建立者"
 
-#: bika/lims/browser/instrument.py:278
-#: bika/lims/content/instrumentscheduledtask.py:51
+#: bika/lims/browser/instrument.py:280
+#: bika/lims/content/instrumentscheduledtask.py:53
 msgid "Criteria"
 msgstr "標準"
 
@@ -1468,12 +1462,12 @@ msgstr "標準"
 msgid "Currency"
 msgstr "貨幣"
 
-#: bika/lims/browser/referencesample.py:350
+#: bika/lims/browser/referencesample.py:352
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Current"
 msgstr "當前"
 
-#: bika/lims/content/client.py:126
+#: bika/lims/content/client.py:128
 msgid "Custom decimal mark"
 msgstr "自定小數位標記"
 
@@ -1486,7 +1480,7 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:110
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:112
 #: bika/lims/browser/reports/templates/productivity.pt:99
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:38
 msgid "Daily samples received"
@@ -1500,88 +1494,88 @@ msgstr "數據接口"
 msgid "Data Interface Options"
 msgstr "數據接口選項"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:176
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:179
 #: bika/lims/browser/reports/templates/productivity.pt:482
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:69
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:47
-#: bika/lims/browser/batchfolder.py:46
-#: bika/lims/browser/instrument.py:538
+#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/batchfolder.py:48
+#: bika/lims/browser/instrument.py:540
 msgid "Date"
 msgstr "日期"
 
-#: bika/lims/browser/arimports.py:63
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:34
+#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:37
 msgid "Date Created"
 msgstr "建立日期"
 
-#: bika/lims/browser/supplyorderfolder.py:39
-#: bika/lims/content/supplyorder.py:79
+#: bika/lims/browser/supplyorderfolder.py:41
+#: bika/lims/content/supplyorder.py:81
 msgid "Date Dispatched"
 msgstr "發送日期"
 
-#: bika/lims/content/referencesample.py:133
-#: bika/lims/content/sample.py:554
+#: bika/lims/content/referencesample.py:135
+#: bika/lims/content/sample.py:557
 msgid "Date Disposed"
 msgstr "處置日期"
 
-#: bika/lims/content/referencesample.py:126
-#: bika/lims/content/sample.py:511
+#: bika/lims/content/referencesample.py:128
+#: bika/lims/content/sample.py:514
 msgid "Date Expired"
 msgstr "過期日期"
 
-#: bika/lims/browser/arimports.py:66
+#: bika/lims/browser/arimports.py:68
 msgid "Date Imported"
 msgstr "進口日期"
 
-#: bika/lims/browser/client/views/attachments.py:38
-#: bika/lims/content/attachment.py:52
+#: bika/lims/browser/client/views/attachments.py:40
+#: bika/lims/content/attachment.py:54
 msgid "Date Loaded"
 msgstr "載入日期"
 
-#: bika/lims/browser/referencesample.py:338
+#: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:95
 msgid "Date Opened"
 msgstr "打開日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:124
-#: bika/lims/browser/sample/partitions.py:55
-#: bika/lims/browser/sample/view.py:124
+#: bika/lims/browser/analysisrequest/analysisrequests.py:126
+#: bika/lims/browser/sample/partitions.py:57
+#: bika/lims/browser/sample/view.py:126
 msgid "Date Preserved"
 msgstr "醃製/處理時間"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:134
-#: bika/lims/content/analysis.py:122
-#: bika/lims/content/analysisrequest.py:1374
+#: bika/lims/browser/analysisrequest/analysisrequests.py:136
+#: bika/lims/content/analysis.py:121
+#: bika/lims/content/analysisrequest.py:1376
 msgid "Date Published"
 msgstr "發佈日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:131
-#: bika/lims/browser/late_analyses.py:50
-#: bika/lims/browser/referencesample.py:334
+#: bika/lims/browser/analysisrequest/analysisrequests.py:133
+#: bika/lims/browser/late_analyses.py:52
+#: bika/lims/browser/referencesample.py:336
 msgid "Date Received"
 msgstr "收到日期"
 
-#: bika/lims/browser/batch/publish.py:92
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:35
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:35
+#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:37
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:37
 msgid "Date Requested"
 msgstr "請求日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:115
-#: bika/lims/browser/referencesample.py:330
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:256
+#: bika/lims/browser/analysisrequest/analysisrequests.py:117
+#: bika/lims/browser/referencesample.py:332
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:258
 msgid "Date Sampled"
 msgstr "做樣板日期"
 
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/arimports.py:67
 msgid "Date Validated"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:122
 msgid "Date Verified"
 msgstr ""
 
@@ -1597,7 +1591,7 @@ msgstr "日期從校準證書有效"
 msgid "Date from which the instrument is under calibration"
 msgstr "日期從儀器校準"
 
-#: bika/lims/content/instrumentmaintenancetask.py:51
+#: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
 msgstr "日期從該儀器在維修"
 
@@ -1615,7 +1609,7 @@ msgid "Date until the certificate is valid"
 msgstr "日期直到證書有效期"
 
 #: bika/lims/content/instrumentcalibration.py:87
-#: bika/lims/content/instrumentmaintenancetask.py:61
+#: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:67
 msgid "Date until the instrument will not be available"
 msgstr "日期，直到儀器將無法使用"
@@ -1624,11 +1618,11 @@ msgstr "日期，直到儀器將無法使用"
 msgid "Date when the calibration certificate was granted"
 msgstr "校準證書授予日期"
 
-#: bika/lims/browser/sample/printform.py:275
+#: bika/lims/browser/sample/printform.py:277
 msgid "Date/Time Sampled"
 msgstr ""
 
-#: bika/lims/browser/fields/durationfield.py:22
+#: bika/lims/browser/fields/durationfield.py:24
 msgid "Days"
 msgstr "天數"
 
@@ -1640,17 +1634,17 @@ msgstr "取消激活，直到明年校準測試"
 msgid "Deactivate"
 msgstr ""
 
-#: bika/lims/content/client.py:127
+#: bika/lims/content/client.py:129
 msgid "Decimal mark to use in the reports from this Client."
 msgstr "小數標記從該客戶的報告中使用。"
 
-#: bika/lims/browser/invoicebatch.py:56
-#: bika/lims/controlpanel/bika_arpriorities.py:51
+#: bika/lims/browser/invoicebatch.py:58
+#: bika/lims/controlpanel/bika_arpriorities.py:53
 msgid "Default"
 msgstr "默認"
 
 #: bika/lims/content/bikasetup.py:364
-#: bika/lims/content/client.py:108
+#: bika/lims/content/client.py:110
 msgid "Default AR Specifications"
 msgstr "默認AR規格"
 
@@ -1658,49 +1652,49 @@ msgstr "默認AR規格"
 msgid "Default ARReport Template"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:641
+#: bika/lims/content/analysisservice.py:640
 msgid "Default Calculation"
 msgstr "默認計算"
 
-#: bika/lims/content/analysisrequest.py:1127
-#: bika/lims/content/analysisservice.py:1031
-#: bika/lims/controlpanel/bika_sampletypes.py:63
+#: bika/lims/content/analysisrequest.py:1129
+#: bika/lims/content/analysisservice.py:1030
+#: bika/lims/controlpanel/bika_sampletypes.py:65
 msgid "Default Container"
 msgstr "默認容器"
 
-#: bika/lims/content/sampletype.py:77
+#: bika/lims/content/sampletype.py:79
 msgid "Default Container Type"
 msgstr "默認容器類型"
 
-#: bika/lims/content/client.py:57
+#: bika/lims/content/client.py:59
 msgid "Default Emails to CC all published ARs for this client"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:511
+#: bika/lims/content/analysisservice.py:510
 msgid "Default Instrument"
 msgstr "默認儀器"
 
-#: bika/lims/content/analysisservice.py:596
+#: bika/lims/content/analysisservice.py:595
 msgid "Default Method"
 msgstr "默認方法"
 
-#: bika/lims/content/analysisservice.py:1010
+#: bika/lims/content/analysisservice.py:1009
 msgid "Default Preservation"
 msgstr "默認保存"
 
-#: bika/lims/content/arpriority.py:44
+#: bika/lims/content/arpriority.py:46
 msgid "Default Priority?"
 msgstr "默認優先"
 
-#: bika/lims/content/analysisservice.py:642
+#: bika/lims/content/analysisservice.py:641
 msgid "Default calculation to be used from the default Method selected. The Calculation for a method can be assigned in the Method edit view."
 msgstr "默認計算是從選定的默認方法使用。計算方法可從編輯視圖進行分配。"
 
-#: bika/lims/content/client.py:84
+#: bika/lims/content/client.py:86
 msgid "Default categories"
 msgstr "默認類別"
 
-#: bika/lims/content/analysisrequest.py:1128
+#: bika/lims/content/analysisrequest.py:1130
 msgid "Default container for new sample partitions"
 msgstr "對於新樣本的分區的默認容器"
 
@@ -1709,11 +1703,11 @@ msgid "Default containers: ${container_list}"
 msgstr "默認多個容器: ${container_list}"
 
 #: bika/lims/content/bikasetup.py:221
-#: bika/lims/content/client.py:117
+#: bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr "默認小數標記"
 
-#: bika/lims/utils/analysis.py:401
+#: bika/lims/utils/analysis.py:400
 msgid "Default instrument %s is not valid"
 msgstr ""
 
@@ -1737,11 +1731,11 @@ msgstr "默認情況下，報告中科學記數法格式"
 msgid "Default scientific notation format for results"
 msgstr "默認情況下，結果科學記數法格式"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:27
+#: bika/lims/browser/fields/interimfieldsfield.py:29
 msgid "Default value"
 msgstr "默認值"
 
-#: bika/lims/content/client.py:109
+#: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
 msgstr "默認AR規格說明"
 
@@ -1749,7 +1743,7 @@ msgstr "默認AR規格說明"
 msgid "Define a date range"
 msgstr ""
 
-#: bika/lims/content/method.py:32
+#: bika/lims/content/method.py:34
 msgid "Define an identifier code for the method. It must be unique."
 msgstr "定義方法的識別碼。它必須是唯一的。"
 
@@ -1757,11 +1751,11 @@ msgstr "定義方法的識別碼。它必須是唯一的。"
 msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:264
+#: bika/lims/content/analysisservice.py:263
 msgid "Define the number of decimals to be used for this result."
 msgstr "定義小數的數要用於該結果。"
 
-#: bika/lims/content/analysisservice.py:275
+#: bika/lims/content/analysisservice.py:274
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr "當轉換數值(values)去指數值(exponent notation)時, 要定義精碓度。默認值是7"
 
@@ -1769,16 +1763,16 @@ msgstr "當轉換數值(values)去指數值(exponent notation)時, 要定義精�
 msgid "Define the prefixes for the unique sequential IDs the system issues for objects. In the 'Padding' field, indicate with how many leading zeros the numbers must be padded. E.g. a prefix of WS for worksheets with padding of 4, will see them numbered from WS-0001 to WS-9999. Sequence Start indicates the number from which the next ID should start. This is set only if it is greater than existing id numbers. Note that the gap created by jumping IDs cannot be refilled. NB: Note that samples and analysis requests are prefixed with sample type abbreviations and are not configured in this table - their padding can be set in the specified fields below"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:605
-#: bika/lims/content/sample.py:283
+#: bika/lims/content/analysisrequest.py:607
+#: bika/lims/content/sample.py:285
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
-#: bika/lims/content/sample.py:310
+#: bika/lims/content/sample.py:312
 msgid "Define when the sampler has to take the samples"
 msgstr ""
 
-#: bika/lims/browser/fields/coordinatefield.py:26
+#: bika/lims/browser/fields/coordinatefield.py:28
 msgid "Degrees"
 msgstr "度"
 
@@ -1786,9 +1780,9 @@ msgstr "度"
 msgid "Delete attachment"
 msgstr "删除附件"
 
-#: bika/lims/browser/accreditation.py:70
+#: bika/lims/browser/accreditation.py:69
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:96
-#: bika/lims/content/analysiscategory.py:50
+#: bika/lims/content/analysiscategory.py:52
 msgid "Department"
 msgstr "系"
 
@@ -1801,13 +1795,13 @@ msgstr ""
 msgid "Dependent Analyses"
 msgstr "以來分析"
 
-#: bika/lims/content/method.py:131
+#: bika/lims/content/method.py:133
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr "以淺白方法描述。此信息特別為實驗室的客戶提供"
 
-#: bika/lims/adapters/identifiers.py:38
-#: bika/lims/browser/batchfolder.py:45
-#: bika/lims/browser/client/views/analysisprofiles.py:42
+#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/browser/batchfolder.py:47
+#: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr "描述"
 
@@ -1815,7 +1809,7 @@ msgstr "描述"
 msgid "Description of the actions made during the calibration"
 msgstr "說明/描述在校準期間的行動/情節"
 
-#: bika/lims/content/instrumentmaintenancetask.py:89
+#: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
 msgstr "說明/描述在維修過程中做出的行動/情節"
 
@@ -1823,19 +1817,19 @@ msgstr "說明/描述在維修過程中做出的行動/情節"
 msgid "Description of the actions made during the validation"
 msgstr "說明/描述在驗證期間的行動/情節"
 
-#: bika/lims/content/storagelocation.py:59
+#: bika/lims/content/storagelocation.py:61
 msgid "Description of the location"
 msgstr "地點說明/描述"
 
-#: bika/lims/content/storagelocation.py:83
+#: bika/lims/content/storagelocation.py:85
 msgid "Description of the shelf"
 msgstr "貨架說明/描述"
 
-#: bika/lims/content/storagelocation.py:41
+#: bika/lims/content/storagelocation.py:43
 msgid "Description of the site"
 msgstr "工地/現場的說明/描述"
 
-#: bika/lims/config.py:126
+#: bika/lims/config.py:125
 msgid "Disable multi-verification for the same user"
 msgstr ""
 
@@ -1843,7 +1837,7 @@ msgstr ""
 msgid "Disable the filtering by date"
 msgstr ""
 
-#: bika/lims/content/pricelist.py:41
+#: bika/lims/content/pricelist.py:43
 msgid "Discount %"
 msgstr "折扣%"
 
@@ -1851,16 +1845,16 @@ msgstr "折扣%"
 msgid "Dispatch"
 msgstr ""
 
-#: bika/lims/browser/supplyorderfolder.py:61
+#: bika/lims/browser/supplyorderfolder.py:63
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Dispatched"
 msgstr "已發送"
 
-#: bika/lims/content/analysisservice.py:968
+#: bika/lims/content/analysisservice.py:967
 msgid "Display Value"
 msgstr "顯示值"
 
-#: bika/lims/content/analysisservice.py:341
+#: bika/lims/content/analysisservice.py:340
 msgid "Display a Detection Limit selector"
 msgstr "顯示檢測限選擇"
 
@@ -1872,7 +1866,7 @@ msgstr "當有新版Bika LIMS推出時, 顯示警報"
 msgid "Display individual sample partitions "
 msgstr "顯示單個樣本分區"
 
-#: bika/lims/browser/sample/partitions.py:61
+#: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
 msgstr "清除時間"
 
@@ -1881,8 +1875,8 @@ msgstr "清除時間"
 msgid "Dispose"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:374
-#: bika/lims/browser/sample/view.py:260
+#: bika/lims/browser/referencesample.py:376
+#: bika/lims/browser/sample/view.py:262
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Disposed"
 msgstr "已處置"
@@ -1891,54 +1885,54 @@ msgstr "已處置"
 msgid "District"
 msgstr "區"
 
-#: bika/lims/browser/calcs.py:242
+#: bika/lims/browser/calcs.py:244
 msgid "Division by zero"
 msgstr "被零除"
 
-#: bika/lims/browser/instrument.py:541
-#: bika/lims/content/multifile.py:28
+#: bika/lims/browser/instrument.py:543
+#: bika/lims/content/multifile.py:30
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:42
-#: bika/lims/content/multifile.py:21
+#: bika/lims/browser/multifile.py:44
+#: bika/lims/content/multifile.py:23
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:45
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/multifile.py:47
+#: bika/lims/content/multifile.py:43
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:46
-#: bika/lims/content/multifile.py:49
+#: bika/lims/browser/multifile.py:48
+#: bika/lims/content/multifile.py:51
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/multifile.py:44
-#: bika/lims/content/multifile.py:35
+#: bika/lims/browser/multifile.py:46
+#: bika/lims/content/multifile.py:37
 msgid "Document Version"
 msgstr ""
 
-#: bika/lims/browser/client/views/analysisprofiles.py:54
-#: bika/lims/browser/client/views/analysisspecs.py:60
-#: bika/lims/browser/client/views/artemplates.py:51
+#: bika/lims/browser/client/views/analysisprofiles.py:56
+#: bika/lims/browser/client/views/analysisspecs.py:62
+#: bika/lims/browser/client/views/artemplates.py:53
 msgid "Dormant"
 msgstr "休眠"
 
-#: bika/lims/config.py:109
+#: bika/lims/config.py:108
 msgid "Dot (.)"
 msgstr "點 (.)"
 
-#: bika/lims/browser/instrument.py:62
+#: bika/lims/browser/instrument.py:64
 msgid "Down from"
 msgstr "從下跌"
 
-#: bika/lims/browser/instrument.py:63
+#: bika/lims/browser/instrument.py:65
 msgid "Down to"
 msgstr "向下/下調"
 
-#: bika/lims/browser/analysisrequest/published_results.py:108
+#: bika/lims/browser/analysisrequest/published_results.py:110
 msgid "Download"
 msgstr "下載"
 
@@ -1951,20 +1945,20 @@ msgstr "乾燥"
 msgid "Dry matter analysis"
 msgstr "乾物質分析"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:301
-#: bika/lims/browser/sample/view.py:186
-#: bika/lims/browser/samplinground/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:303
+#: bika/lims/browser/sample/view.py:188
+#: bika/lims/browser/samplinground/analysisrequests.py:84
 msgid "Due"
 msgstr "截止"
 
 #: bika/lims/browser/analyses.py:120
-#: bika/lims/browser/late_analyses.py:52
-#: bika/lims/browser/referencesample.py:122
+#: bika/lims/browser/late_analyses.py:54
+#: bika/lims/browser/referencesample.py:124
 msgid "Due Date"
 msgstr "截止期"
 
-#: bika/lims/browser/accreditation.py:75
-#: bika/lims/controlpanel/bika_analysisservices.py:204
+#: bika/lims/browser/accreditation.py:74
+#: bika/lims/controlpanel/bika_analysisservices.py:211
 msgid "Dup Var"
 msgstr ""
 
@@ -1973,20 +1967,20 @@ msgid "Dup of"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:233
-#: bika/lims/config.py:52
-#: bika/lims/controlpanel/bika_analysisservices.py:249
+#: bika/lims/config.py:51
+#: bika/lims/controlpanel/bika_analysisservices.py:260
 msgid "Duplicate"
 msgstr "重複"
 
-#: bika/lims/content/worksheettemplate.py:32
+#: bika/lims/content/worksheettemplate.py:34
 msgid "Duplicate Of"
 msgstr "複本"
 
-#: bika/lims/config.py:95
+#: bika/lims/config.py:94
 msgid "Duplicate QC analyses"
 msgstr "重複的質量控制分析"
 
-#: bika/lims/content/analysisservice.py:727
+#: bika/lims/content/analysisservice.py:726
 msgid "Duplicate Variation %"
 msgstr "複製變異％"
 
@@ -1998,35 +1992,35 @@ msgstr "重複分析質量控制"
 msgid "Duplicate analysis quality control graphs"
 msgstr "重复分析质量控制图"
 
-#: bika/lims/content/analysis.py:132
+#: bika/lims/content/analysis.py:131
 msgid "Duration"
 msgstr "為期"
 
-#: bika/lims/content/laboratory.py:49
+#: bika/lims/content/laboratory.py:51
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "如 SANAS, APLAC 等"
 
-#: bika/lims/content/analysis.py:137
+#: bika/lims/content/analysis.py:136
 msgid "Earliness"
 msgstr "提前"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:141
+#: bika/lims/browser/reports/productivity_analysestats.py:143
 msgid "Early"
 msgstr "較早的"
 
-#: bika/lims/content/samplepoint.py:44
+#: bika/lims/content/samplepoint.py:46
 msgid "Elevation"
 msgstr "評估"
 
 #: bika/lims/browser/templates/login_details.pt:87
-#: bika/lims/controlpanel/bika_suppliers.py:45
+#: bika/lims/controlpanel/bika_suppliers.py:47
 #: bika/lims/vocabularies/__init__.py:531
 msgid "Email"
 msgstr "電郵"
 
-#: bika/lims/browser/client/views/contacts.py:47
-#: bika/lims/browser/clientfolder.py:45
-#: bika/lims/browser/invoicebatch.py:35
+#: bika/lims/browser/client/views/contacts.py:49
+#: bika/lims/browser/clientfolder.py:46
+#: bika/lims/browser/invoicebatch.py:37
 msgid "Email Address"
 msgstr "電郵地址"
 
@@ -2034,7 +2028,7 @@ msgstr "電郵地址"
 msgid "Email notification on rejection"
 msgstr ""
 
-#: bika/lims/content/client.py:71
+#: bika/lims/content/client.py:73
 msgid "Email subject line"
 msgstr "電子郵件主題行"
 
@@ -2054,14 +2048,14 @@ msgstr ""
 msgid "Enable the rejection workflow"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:43
-#: bika/lims/browser/invoicefolder.py:36
-#: bika/lims/browser/pricelist.py:46
+#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr "結束日期"
 
-#: bika/lims/content/instrumentmaintenancetask.py:149
-#: bika/lims/content/instrumentscheduledtask.py:90
+#: bika/lims/content/instrumentmaintenancetask.py:151
+#: bika/lims/content/instrumentscheduledtask.py:92
 msgid "Enhancement"
 msgstr "增強"
 
@@ -2073,16 +2067,16 @@ msgstr "輸入的用戶名，如“jsmith ” 。無空格或特殊字符。用�
 msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "輸入電子郵件地址。萬一密碼丟失，這是必要的。我們尊重您的隱私，不會把郵件地址給任何第三方或任何其公開。"
 
-#: bika/lims/content/pricelist.py:42
+#: bika/lims/content/pricelist.py:44
 msgid "Enter discount percentage value"
 msgstr "輸入折扣百分比值"
 
-#: bika/lims/content/analysisservice.py:830
-#: bika/lims/content/labproduct.py:31
+#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/labproduct.py:33
 msgid "Enter percentage value eg. 14.0"
 msgstr "輸入百分比值，如。 14.0"
 
-#: bika/lims/content/analysisprofile.py:106
+#: bika/lims/content/analysisprofile.py:108
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
 msgstr "輸入百分比值，如。 14.0 。這一比例僅在分析檔案應用，覆蓋系統的增值稅"
 
@@ -2090,15 +2084,15 @@ msgstr "輸入百分比值，如。 14.0 。這一比例僅在分析檔案應用
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
 msgstr "輸入百分比值，如。 14.0 。此百分數應用於系統寬，但可超過寫入的物品"
 
-#: bika/lims/content/analysisrequest.py:1429
+#: bika/lims/content/analysisrequest.py:1431
 msgid "Enter percentage value eg. 33.0"
 msgstr "輸入百分比值，如。 33.0"
 
-#: bika/lims/content/samplepoint.py:31
+#: bika/lims/content/samplepoint.py:33
 msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
 msgstr "在0-90度輸入樣版點的緯度，分0-59 ， 0-59秒和N / S指標"
 
-#: bika/lims/content/samplepoint.py:38
+#: bika/lims/content/samplepoint.py:40
 msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
 msgstr "在0-180度輸入樣版點的經度，分0-59 ， 0-59秒和N / S指標"
 
@@ -2106,7 +2100,7 @@ msgstr "在0-180度輸入樣版點的經度，分0-59 ， 0-59秒和N / S指標"
 msgid "Enter the details of each of the analysis services you want to copy."
 msgstr "輸入每次你要複製的分析服務的細節。"
 
-#: bika/lims/content/laboratory.py:93
+#: bika/lims/content/laboratory.py:95
 msgid "Enter the details of your lab's service accreditations here.  The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
 msgstr "在這裡輸入您的實驗室服務認證資格的細節。以下字段： lab_is_accredited ， lab_name ， lab_country ，信心， accreditation_body_name ， accreditation_standard ， accreditation_reference <br/>"
 
@@ -2114,45 +2108,45 @@ msgstr "在這裡輸入您的實驗室服務認證資格的細節。以下字段
 msgid "Entity"
 msgstr "實體"
 
-#: bika/lims/content/sample.py:419
+#: bika/lims/content/sample.py:421
 msgid "Environmental Conditions"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1094
-#: bika/lims/content/samplinground.py:188
+#: bika/lims/content/analysisrequest.py:1096
+#: bika/lims/content/samplinground.py:190
 msgid "Environmental conditions"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:499
+#: bika/lims/browser/analysisrequest/workflow.py:501
 msgid "Erroneus result publication from ${request_id}"
 msgstr "從${request_id}公佈錯誤/不正確的結果"
 
-#: bika/lims/content/arimport.py:208
+#: bika/lims/content/arimport.py:210
 msgid "Errors"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:576
+#: bika/lims/browser/dashboard.py:578
 msgid "Evolution of Analyses"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:337
+#: bika/lims/browser/dashboard.py:339
 msgid "Evolution of Analysis Requests"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:450
+#: bika/lims/browser/dashboard.py:452
 msgid "Evolution of Worksheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:799
+#: bika/lims/browser/analysisrequest/analysisrequests.py:801
 msgid "Exclude from invoice"
 msgstr "從發票中排除"
 
-#: bika/lims/browser/fields/referenceresultsfield.py:27
-#: bika/lims/browser/widgets/referenceresultswidget.py:52
+#: bika/lims/browser/fields/referenceresultsfield.py:29
+#: bika/lims/browser/widgets/referenceresultswidget.py:54
 msgid "Expected Result"
 msgstr "預期結果"
 
-#: bika/lims/content/referencesample.py:146
+#: bika/lims/content/referencesample.py:148
 msgid "Expected Values"
 msgstr "預期值"
 
@@ -2161,19 +2155,19 @@ msgstr "預期值"
 msgid "Expire"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:362
-#: bika/lims/browser/sample/view.py:236
+#: bika/lims/browser/referencesample.py:364
+#: bika/lims/browser/sample/view.py:238
 #: bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
 msgid "Expired"
 msgstr "已過期"
 
-#: bika/lims/browser/referencesample.py:341
+#: bika/lims/browser/referencesample.py:343
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:108
 msgid "Expiry Date"
 msgstr "到期日"
 
-#: bika/lims/content/analysisservice.py:274
+#: bika/lims/content/analysisservice.py:273
 msgid "Exponential format precision"
 msgstr "指數格式的精度"
 
@@ -2181,44 +2175,40 @@ msgstr "指數格式的精度"
 msgid "Exponential format threshold"
 msgstr "指數格式門檻"
 
-#: Profile description in configure.zcml
-msgid "Extension profile for the Bika LIMS"
-msgstr ""
-
-#: bika/lims/browser/clientfolder.py:47
-#: bika/lims/browser/supplier.py:68
-#: bika/lims/content/organisation.py:41
+#: bika/lims/browser/clientfolder.py:48
+#: bika/lims/browser/supplier.py:70
+#: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr "傳真"
 
-#: bika/lims/content/person.py:80
+#: bika/lims/content/person.py:82
 msgid "Fax (business)"
 msgstr "傳真 (辦公室)"
 
-#: bika/lims/config.py:82
+#: bika/lims/config.py:81
 msgid "Female"
 msgstr "女"
 
 #: bika/lims/browser/worksheet/templates/results.pt:133
-#: bika/lims/config.py:34
+#: bika/lims/config.py:33
 msgid "Field"
 msgstr "領域/場地"
 
-#: bika/lims/config.py:29
+#: bika/lims/config.py:28
 msgid "Field Analyses"
 msgstr "實地分析"
 
-#: bika/lims/config.py:39
+#: bika/lims/config.py:38
 msgid "Field Preservation"
 msgstr "實地保護"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:26
+#: bika/lims/browser/fields/interimfieldsfield.py:28
 msgid "Field Title"
 msgstr "場地名"
 
-#: bika/lims/browser/analysisrequest/published_results.py:45
-#: bika/lims/browser/client/views/attachments.py:34
-#: bika/lims/browser/multifile.py:47
+#: bika/lims/browser/analysisrequest/published_results.py:47
+#: bika/lims/browser/client/views/attachments.py:36
+#: bika/lims/browser/multifile.py:49
 msgid "File"
 msgstr "文件"
 
@@ -2226,19 +2216,19 @@ msgstr "文件"
 msgid "File attachments to results, e.g. microscope photos, will be included in emails to recipients if this option is enabled"
 msgstr "文件已隨結果附上，例如顯微鏡照片，如果啟用該選項將被包含在電子郵件的收件人"
 
-#: bika/lims/content/multifile.py:29
+#: bika/lims/content/multifile.py:31
 msgid "File upload "
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/arimports.py:64
 msgid "Filename"
 msgstr "文件名"
 
-#: bika/lims/browser/multifile.py:38
+#: bika/lims/browser/multifile.py:40
 msgid "Files"
 msgstr ""
 
-#: bika/lims/browser/bika_listing.py:1335
+#: bika/lims/browser/bika_listing.py:1345
 msgid "Filter"
 msgstr ""
 
@@ -2258,16 +2248,16 @@ msgstr ""
 msgid "Filter template analyses by client"
 msgstr ""
 
-#: bika/lims/content/person.py:30
+#: bika/lims/content/person.py:32
 msgid "Firstname"
 msgstr "名"
 
-#: bika/lims/content/analysiscategory.py:64
-#: bika/lims/content/analysisservice.py:232
+#: bika/lims/content/analysiscategory.py:66
+#: bika/lims/content/analysisservice.py:231
 msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
 msgstr ""
 
-#: bika/lims/controlpanel/bika_calculations.py:48
+#: bika/lims/controlpanel/bika_calculations.py:50
 msgid "Formula"
 msgstr "公式"
 
@@ -2277,18 +2267,18 @@ msgstr "公式"
 msgid "From"
 msgstr "自/由"
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:161
+#: bika/lims/browser/reports/selection_macros/__init__.py:163
 msgid "From ${start_date} to ${end_date}"
 msgstr "由${start_date} 至 ${end_date}"
 
-#: bika/lims/browser/client/views/contacts.py:44
-#: bika/lims/browser/supplier.py:64
+#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/supplier.py:66
 #: bika/lims/browser/templates/login_details.pt:63
 msgid "Full Name"
 msgstr "全名"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:796
-#: bika/lims/browser/sample/view.py:384
+#: bika/lims/browser/analysisrequest/analysisrequests.py:798
+#: bika/lims/browser/sample/view.py:386
 msgid "Future dated sample"
 msgstr "已預約的樣本"
 
@@ -2298,7 +2288,7 @@ msgstr "已預約的樣本"
 msgid "Generate report"
 msgstr "建立報告"
 
-#: bika/lims/content/person.py:24
+#: bika/lims/content/person.py:26
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "問候/稱謂標題如：先生，太太，博士"
 
@@ -2310,37 +2300,37 @@ msgstr "通過在LIMS表類別組分析服務，幫助時，名單很長"
 msgid "Group by"
 msgstr "通過...分組"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:59
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:50
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:61
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:52
 msgid "Grouping period"
 msgstr "分組期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:802
+#: bika/lims/browser/analysisrequest/analysisrequests.py:804
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:135
-#: bika/lims/browser/referencesample.py:432
+#: bika/lims/browser/referencesample.py:434
 msgid "Hazardous"
 msgstr "有危險的"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:61
-#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:83
-#: bika/lims/browser/widgets/artemplateanalyseswidget.py:85
+#: bika/lims/browser/analysisrequest/manage_analyses.py:63
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:85
+#: bika/lims/browser/widgets/artemplateanalyseswidget.py:87
 msgid "Hidden"
 msgstr "隱藏的"
 
-#: bika/lims/browser/fields/interimfieldsfield.py:29
+#: bika/lims/browser/fields/interimfieldsfield.py:31
 msgid "Hidden Field"
 msgstr "隱藏域"
 
-#: bika/lims/browser/fields/durationfield.py:23
+#: bika/lims/browser/fields/durationfield.py:25
 msgid "Hours"
 msgstr "小時"
 
-#: bika/lims/content/supplier.py:54
+#: bika/lims/content/supplier.py:56
 msgid "IBN"
 msgstr ""
 
 #: bika/lims/browser/bika_listing.py:388
-#: bika/lims/browser/referencesample.py:106
+#: bika/lims/browser/referencesample.py:108
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:85
 msgid "ID"
 msgstr "ID"
@@ -2349,8 +2339,8 @@ msgstr "ID"
 msgid "ID Server URL"
 msgstr "ID侍服器URL"
 
-#: bika/lims/controlpanel/bika_idserver.py:63
-#: bika/lims/idserver.py:50
+#: bika/lims/controlpanel/bika_idserver.py:65
+#: bika/lims/idserver.py:52
 msgid "ID Server unavailable"
 msgstr "ID侍服器不可用"
 
@@ -2358,31 +2348,31 @@ msgstr "ID侍服器不可用"
 msgid "IMPORTANT: Don't use \"Bika\" or \"BIKA\" as the instance name, this is a reserved namespace. If you get \"Site Error\" citing \"AttributeError: adapters\", this is the most likely cause."
 msgstr "重要提示：不要使用“Bika”或“BIKA”作為實例名，這是一個保留的命名空間。如果你得到“綱站錯誤”調降至“屬性錯誤：適配器” ，這是最有可能的原因。"
 
-#: bika/lims/adapters/identifiers.py:37
+#: bika/lims/adapters/identifiers.py:44
 msgid "Identifier"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:36
+#: bika/lims/adapters/identifiers.py:43
 msgid "Identifier Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:25
+#: bika/lims/controlpanel/bika_identifiertypes.py:32
 msgid "Identifier Types"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
+#: bika/lims/adapters/identifiers.py:52
 msgid "Identifiers for this object"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:597
+#: bika/lims/content/analysisservice.py:596
 msgid "If 'Allow instrument entry of results' is selected, the method from the default instrument will be used. Otherwise, only the methods selected above will be displayed."
 msgstr "如果“允許結果的儀器條目'被選擇時，將使用從默認的儀器的方法。否則，將只顯示上述選擇的方法。"
 
-#: bika/lims/content/samplepoint.py:52
+#: bika/lims/content/samplepoint.py:54
 msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
 msgstr "如果樣品在此樣本點定期進行，在這裡輸入頻率，例如每週"
 
-#: bika/lims/content/analysisservice.py:342
+#: bika/lims/content/analysisservice.py:341
 msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
 msgstr "如選此項，選擇列表將顯示在錄入觀點分析結果字段旁邊。通過使用這種選擇，分析師將能夠設定值作為檢測限（LDL或UDL）而不是常規的結果"
 
@@ -2394,7 +2384,7 @@ msgstr "如果選中，直至進行下一個有效校準時, 儀器將不可用�
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1076
+#: bika/lims/content/analysisservice.py:1075
 msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
@@ -2402,27 +2392,27 @@ msgstr ""
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:242
+#: bika/lims/content/analysisservice.py:241
 msgid "If enabled, the name of the analysis will be written in italics."
 msgstr "如果啟用，分析的名稱將用斜體。"
 
-#: bika/lims/content/analysisservice.py:1061
+#: bika/lims/content/analysisservice.py:1060
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
 msgstr "如果啟用，此分析及其結果將不被默認顯示在報告中。此設置可以在分析資料和/或分析請求被撤銷"
 
-#: bika/lims/content/batch.py:198
+#: bika/lims/content/batch.py:200
 msgid "If no Title value is entered, the Batch ID will be used."
 msgstr "如果沒有輸入標題值，將使用批次ID 。"
 
-#: bika/lims/content/method.py:110
+#: bika/lims/content/method.py:112
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "如需要，幫分析服務計算方法, 而且會鏈接到該方法的計算。計算可以配置到計算項目下LIMS建立"
 
-#: bika/lims/content/analysisservice.py:675
+#: bika/lims/content/analysisservice.py:674
 msgid "If required, select a calculation for the analysis here. Calculations can be configured under the calculations item in the LIMS set-up"
 msgstr "如果已请求,在此选择分析的计算方法.计算方法可以在实验室信息管理系统设置中的计算项目下面配置"
 
-#: bika/lims/content/analysisservice.py:219
+#: bika/lims/content/analysisservice.py:218
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
 msgstr "如果這裡輸入的原文，當服務中的列標題中列出它被使用的標題代替。 HTML格式是允許的。"
 
@@ -2430,7 +2420,7 @@ msgstr "如果這裡輸入的原文，當服務中的列標題中列出它被使
 msgid "If there are previous results for a service in the same batch of Analysis Requests, they will be displayed in the report."
 msgstr "如果對於在同一批次分析請求的服務之前的結果，它們將在報告中顯示。"
 
-#: bika/lims/content/container.py:64
+#: bika/lims/content/container.py:66
 msgid "If this container is pre-preserved, then the preservation method could be selected here."
 msgstr "如果此容器被預先保留，則保存方法可以在此處選擇。"
 
@@ -2443,7 +2433,7 @@ msgid "If unchecked, analysts will have access to all worksheets."
 msgstr "如不選此項，分析師將有機會獲得所有工作表。"
 
 #: bika/lims/browser/templates/arimport_add.pt:26
-#: bika/lims/exportimport/dataimport.py:54
+#: bika/lims/exportimport/dataimport.py:56
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Import"
 msgstr "輸入"
@@ -2452,7 +2442,7 @@ msgstr "輸入"
 msgid "Import Analysis Request Data"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:82
+#: bika/lims/browser/arimports.py:84
 #: bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
 msgid "Imported"
 msgstr "已輸入"
@@ -2461,8 +2451,8 @@ msgstr "已輸入"
 msgid "In-lab calibration procedure"
 msgstr "在實驗室校準程序"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:72
-#: bika/lims/controlpanel/bika_subgroups.py:61
+#: bika/lims/controlpanel/bika_arpriorities.py:74
+#: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Inactive"
 msgstr "待用/不活躍的"
@@ -2471,7 +2461,7 @@ msgstr "待用/不活躍的"
 msgid "Include Previous Results From Batch"
 msgstr "包括以往一批的結果"
 
-#: bika/lims/content/batch.py:157
+#: bika/lims/content/batch.py:159
 msgid "Include all analysis requests belonging to the selected objects."
 msgstr "包括屬於所選擇對象的所有分析請求。"
 
@@ -2479,7 +2469,7 @@ msgstr "包括屬於所選擇對象的所有分析請求。"
 msgid "Include and display pricing information"
 msgstr "包括和顯示的價格信息"
 
-#: bika/lims/content/pricelist.py:48
+#: bika/lims/content/pricelist.py:50
 msgid "Include descriptions"
 msgstr "包含描述"
 
@@ -2487,30 +2477,27 @@ msgstr "包含描述"
 msgid "Include year in ID prefix"
 msgstr "在ID前缀中包含年份"
 
-#: bika/lims/validators.py:1006
+#: bika/lims/validators.py:1038
 msgid "Incorrect IBAN number: %s"
 msgstr "不正確的IBAN號碼: %s"
 
-#: bika/lims/validators.py:965
+#: bika/lims/validators.py:997
 msgid "Incorrect NIB number: %s"
 msgstr "不正確的NIB號碼: %s"
 
-#: bika/lims/browser/calcs.py:56
+#: bika/lims/browser/calcs.py:58
 msgid "Indeterminate result"
 msgstr "不確定結果"
 
-#: bika/lims/content/analysisservice.py:385
+#: bika/lims/content/analysisservice.py:384
 msgid "Indicates whether file attachments, e.g. microscope images, are required for this analysis and whether file upload function will be available for it on data capturing screens"
 msgstr "指示文件附件是否需要用於此分析和文件上傳功能是否將可用於它的數據捕獲屏幕，例如顯微鏡圖像"
 
-msgid "Info"
-msgstr ""
-
-#: bika/lims/content/batch.py:156
+#: bika/lims/content/batch.py:158
 msgid "Inherit From"
 msgstr "繼承"
 
-#: bika/lims/browser/fields/historyawarereferencefield.py:93
+#: bika/lims/browser/fields/historyawarereferencefield.py:95
 msgid "Initial revision"
 msgstr "初步修訂"
 
@@ -2534,7 +2521,7 @@ msgstr "安裝證書上傳"
 msgid "InstallationDate"
 msgstr "安裝日期"
 
-#: bika/lims/content/samplinground.py:193
+#: bika/lims/content/samplinground.py:195
 #: bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr "說明"
@@ -2547,17 +2534,17 @@ msgstr "實驗室用於分析的定期校準例行程序之說明/指令"
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
 msgstr "用於分析的定期預防性和維護程序之說明/指令"
 
-#: bika/lims/browser/accreditation.py:71
+#: bika/lims/browser/accreditation.py:70
 #: bika/lims/browser/analyses.py:79
-#: bika/lims/browser/referencesample.py:116
+#: bika/lims/browser/referencesample.py:118
 msgid "Instrument"
 msgstr "儀器"
 
-#: bika/lims/browser/instrument.py:154
+#: bika/lims/browser/instrument.py:156
 msgid "Instrument Calibrations"
 msgstr "儀器校準"
 
-#: bika/lims/browser/instrument.py:619
+#: bika/lims/browser/instrument.py:621
 msgid "Instrument Files"
 msgstr ""
 
@@ -2570,16 +2557,16 @@ msgstr "導入儀器"
 msgid "Instrument Location"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumentlocations.py:34
+#: bika/lims/controlpanel/bika_instrumentlocations.py:39
 #: bika/lims/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:54
+#: bika/lims/browser/instrument.py:56
 msgid "Instrument Maintenance"
 msgstr "儀器維修"
 
-#: bika/lims/browser/instrument.py:271
+#: bika/lims/browser/instrument.py:273
 msgid "Instrument Scheduled Tasks"
 msgstr "儀器已計劃的任務/工作"
 
@@ -2587,19 +2574,19 @@ msgstr "儀器已計劃的任務/工作"
 msgid "Instrument Type"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instrumenttypes.py:34
+#: bika/lims/controlpanel/bika_instrumenttypes.py:36
 msgid "Instrument Types"
 msgstr "儀器類型"
 
-#: bika/lims/browser/instrument.py:211
+#: bika/lims/browser/instrument.py:213
 msgid "Instrument Validations"
 msgstr "儀器驗證"
 
-#: bika/lims/content/analysisservice.py:441
+#: bika/lims/content/analysisservice.py:440
 msgid "Instrument assignment is allowed"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:419
+#: bika/lims/content/analysisservice.py:418
 msgid "Instrument assignment is not required"
 msgstr ""
 
@@ -2643,9 +2630,9 @@ msgstr "儀器類型"
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:470
-#: bika/lims/content/method.py:58
-#: bika/lims/controlpanel/bika_instruments.py:35
+#: bika/lims/content/analysisservice.py:469
+#: bika/lims/content/method.py:60
+#: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr "多個儀器"
 
@@ -2669,7 +2656,7 @@ msgstr ""
 msgid "Instruments' calibration certificates expired:"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:350
+#: bika/lims/browser/instrument.py:352
 msgid "Internal Calibration Tests"
 msgstr "內部校準測試"
 
@@ -2685,24 +2672,21 @@ msgstr "插值"
 msgid "Interval"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:526
-#: bika/lims/browser/samplinground/analysisrequests.py:188
+#: bika/lims/browser/analysisrequest/analysisrequests.py:528
+#: bika/lims/browser/samplinground/analysisrequests.py:190
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Invalid"
 msgstr "無效"
 
-#: bika/lims/browser/analysisrequest/view.py:463
+#: bika/lims/browser/analysisrequest/view.py:465
 msgid "Invalid AR retested"
 msgstr "無效的AR複檢"
 
-#: bika/lims/utils/analysis.py:400
+#: bika/lims/utils/analysis.py:399
 msgid "Invalid instruments are not displayed: %s"
 msgstr ""
 
-msgid "Invalid instruments are not shown: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/validators.py:368
+#: bika/lims/validators.py:401
 msgid "Invalid wildcards found: ${wildcards}"
 msgstr "發現無效通配符/萬用字元: ${wildcards}"
 
@@ -2710,43 +2694,43 @@ msgstr "發現無效通配符/萬用字元: ${wildcards}"
 msgid "Invalidate"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/invoice.py:36
+#: bika/lims/browser/analysisrequest/invoice.py:38
 msgid "Invoice"
 msgstr "發票"
 
-#: bika/lims/browser/invoicebatch.py:39
+#: bika/lims/browser/invoicebatch.py:41
 msgid "Invoice Date"
 msgstr "發票日期"
 
-#: bika/lims/content/analysisrequest.py:1266
+#: bika/lims/content/analysisrequest.py:1268
 msgid "Invoice Exclude"
 msgstr "發票排除/不包括"
 
-#: bika/lims/browser/invoicebatch.py:29
+#: bika/lims/browser/invoicebatch.py:31
 msgid "Invoice Number"
 msgstr "發票號碼"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2267
+#: bika/lims/exportimport/setupdata/__init__.py:2269
 msgid "InvoiceBatch has no End Date"
 msgstr "發票批沒有結束日期"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2264
+#: bika/lims/exportimport/setupdata/__init__.py:2266
 msgid "InvoiceBatch has no Start Date"
 msgstr "發票批沒有開始日期"
 
-#: bika/lims/exportimport/setupdata/__init__.py:2261
+#: bika/lims/exportimport/setupdata/__init__.py:2263
 msgid "InvoiceBatch has no Title"
 msgstr "發票批無標題"
 
-#: bika/lims/content/artemplate.py:88
+#: bika/lims/content/artemplate.py:90
 msgid "It's a composite sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:275
+#: bika/lims/browser/analysisrequest/workflow.py:277
 msgid "Item is inactive."
 msgstr "項目處於非活動狀態。"
 
-#: bika/lims/content/client.py:70
+#: bika/lims/content/client.py:72
 msgid "Items to be included in email subject lines"
 msgstr "项目将包含在邮件标题栏中"
 
@@ -2756,7 +2740,7 @@ msgstr "项目将包含在邮件标题栏中"
 msgid "Job Title"
 msgstr "職位名稱"
 
-#: bika/lims/content/person.py:97
+#: bika/lims/content/person.py:99
 msgid "Job title"
 msgstr "職位名稱"
 
@@ -2764,12 +2748,12 @@ msgstr "職位名稱"
 msgid "Key"
 msgstr "關鍵"
 
-#: bika/lims/browser/calcs.py:254
+#: bika/lims/browser/calcs.py:256
 msgid "Key Error"
 msgstr "關鍵的錯誤"
 
-#: bika/lims/browser/accreditation.py:68
-#: bika/lims/browser/fields/interimfieldsfield.py:25
+#: bika/lims/browser/accreditation.py:67
+#: bika/lims/browser/fields/interimfieldsfield.py:27
 #: bika/lims/browser/templates/analysisservice_popup.pt:164
 msgid "Keyword"
 msgstr "關鍵詞"
@@ -2778,47 +2762,47 @@ msgstr "關鍵詞"
 msgid "Keywords"
 msgstr "多個關鍵詞"
 
-#: bika/lims/browser/analysisrequest/view.py:237
-#: bika/lims/config.py:35
-#: bika/lims/content/analysisspec.py:135
+#: bika/lims/browser/analysisrequest/view.py:239
+#: bika/lims/config.py:34
+#: bika/lims/content/analysisspec.py:137
 msgid "Lab"
 msgstr "實驗室"
 
-#: bika/lims/config.py:30
+#: bika/lims/config.py:29
 msgid "Lab Analyses"
 msgstr "實驗室分析"
 
-#: bika/lims/controlpanel/bika_labcontacts.py:34
+#: bika/lims/controlpanel/bika_labcontacts.py:36
 msgid "Lab Contacts"
 msgstr "實驗室聯繫方式"
 
-#: bika/lims/controlpanel/bika_departments.py:35
+#: bika/lims/controlpanel/bika_departments.py:37
 msgid "Lab Departments"
 msgstr "實驗室部門"
 
-#: bika/lims/config.py:40
+#: bika/lims/config.py:39
 msgid "Lab Preservation"
 msgstr "實驗室保存"
 
-#: bika/lims/config.py:45
-#: bika/lims/controlpanel/bika_labproducts.py:35
+#: bika/lims/config.py:44
+#: bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr "實驗室產品"
 
-#: bika/lims/content/laboratory.py:24
+#: bika/lims/content/laboratory.py:26
 msgid "Lab URL"
 msgstr "實驗室網址"
 
-#: bika/lims/controlpanel/bika_batchlabels.py:38
+#: bika/lims/controlpanel/bika_batchlabels.py:40
 msgid "Label"
 msgstr "標籤"
 
-#: bika/lims/content/laboratory.py:122
-#: bika/lims/setuphandlers.py:115
+#: bika/lims/content/laboratory.py:129
+#: bika/lims/setuphandlers.py:116
 msgid "Laboratory"
 msgstr "實驗室"
 
-#: bika/lims/content/laboratory.py:40
+#: bika/lims/content/laboratory.py:42
 msgid "Laboratory Accredited"
 msgstr "實驗室認可的"
 
@@ -2838,13 +2822,13 @@ msgstr ""
 msgid "Last modified"
 msgstr "上次/對上一次更改"
 
-#: bika/lims/browser/late_analyses.py:54
-#: bika/lims/browser/reports/productivity_analysestats.py:139
+#: bika/lims/browser/late_analyses.py:56
+#: bika/lims/browser/reports/productivity_analysestats.py:141
 msgid "Late"
 msgstr "遲/最近"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:793
-#: bika/lims/browser/late_analyses.py:32
+#: bika/lims/browser/analysisrequest/analysisrequests.py:795
+#: bika/lims/browser/late_analyses.py:34
 #: bika/lims/skins/bika/portlet_late_analyses.pt:31
 msgid "Late Analyses"
 msgstr "後期分析/最近的分析"
@@ -2854,7 +2838,7 @@ msgstr "後期分析/最近的分析"
 msgid "Late Analysis"
 msgstr "後期分析/最近的分析"
 
-#: bika/lims/content/samplepoint.py:30
+#: bika/lims/content/samplepoint.py:32
 msgid "Latitude"
 msgstr "緯度"
 
@@ -2876,11 +2860,11 @@ msgstr ""
 msgid "Link an existing User"
 msgstr ""
 
-#: bika/lims/content/sample.py:115
+#: bika/lims/content/sample.py:117
 msgid "Linked Sample"
 msgstr "已鏈接樣品"
 
-#: bika/lims/controlpanel/bika_identifiertypes.py:28
+#: bika/lims/controlpanel/bika_identifiertypes.py:35
 msgid "List of types of identifiers for multiple identifier records"
 msgstr ""
 
@@ -2892,7 +2876,7 @@ msgstr "列出了日期範圍內收到所有樣品"
 msgid "Load Setup Data"
 msgstr "載入設置數據"
 
-#: bika/lims/content/method.py:48
+#: bika/lims/content/method.py:50
 msgid "Load documents describing the method here"
 msgstr "在此載入文件描述的方法"
 
@@ -2904,41 +2888,41 @@ msgstr "由文件載入"
 msgid "Load the certificate document here"
 msgstr "在這載入證明文件"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:60
+#: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
 msgstr "已載入"
 
-#: bika/lims/content/storagelocation.py:52
+#: bika/lims/content/storagelocation.py:54
 msgid "Location Code"
 msgstr "地點代碼"
 
-#: bika/lims/content/storagelocation.py:58
+#: bika/lims/content/storagelocation.py:60
 msgid "Location Description"
 msgstr "位置/地點描述"
 
-#: bika/lims/content/storagelocation.py:46
+#: bika/lims/content/storagelocation.py:48
 msgid "Location Title"
 msgstr "標題的位置"
 
-#: bika/lims/content/storagelocation.py:64
+#: bika/lims/content/storagelocation.py:66
 msgid "Location Type"
 msgstr "位置類型"
 
-#: bika/lims/content/analysisrequest.py:876
-#: bika/lims/content/sample.py:202
+#: bika/lims/content/analysisrequest.py:878
+#: bika/lims/content/sample.py:204
 msgid "Location where sample is kept"
 msgstr "保持樣品的位置/地點"
 
-#: bika/lims/content/analysisrequest.py:836
-#: bika/lims/content/artemplate.py:44
+#: bika/lims/content/analysisrequest.py:838
+#: bika/lims/content/artemplate.py:46
 msgid "Location where sample was taken"
 msgstr "取走樣品的位置/地點"
 
-#: bika/lims/content/multifile.py:42
+#: bika/lims/content/multifile.py:44
 msgid "Location where the document set is shelved"
 msgstr ""
 
-#: bika/lims/browser/log.py:46
+#: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:284
 msgid "Log"
 msgstr "日誌"
@@ -2963,35 +2947,35 @@ msgstr ""
 msgid "Login failed. Your Login is linked to multiple Contacts. Please contact the Lab for further information."
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:37
+#: bika/lims/content/samplepoint.py:39
 msgid "Longitude"
 msgstr "經度"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:59
-#: bika/lims/content/referencesample.py:82
+#: bika/lims/content/referencesample.py:84
 msgid "Lot Number"
 msgstr "批號"
 
-#: bika/lims/content/analysisservice.py:287
+#: bika/lims/content/analysisservice.py:286
 msgid "Lower Detection Limit (LDL)"
 msgstr "檢測下限（LDL）"
 
-#: bika/lims/config.py:87
+#: bika/lims/config.py:86
 msgid "Mailing address"
 msgstr "郵寄地址"
 
-#: bika/lims/browser/instrument.py:64
-#: bika/lims/content/instrumentmaintenancetask.py:68
+#: bika/lims/browser/instrument.py:66
+#: bika/lims/content/instrumentmaintenancetask.py:70
 msgid "Maintainer"
 msgstr "保養者"
 
 #. Default: "Type"
-#: bika/lims/content/instrumentmaintenancetask.py:40
+#: bika/lims/content/instrumentmaintenancetask.py:42
 msgid "Maintenance type"
 msgstr "保養類型"
 
-#: bika/lims/config.py:81
+#: bika/lims/config.py:80
 msgid "Male"
 msgstr "男"
 
@@ -2999,16 +2983,16 @@ msgstr "男"
 msgid "Manage linked User"
 msgstr ""
 
-#: bika/lims/content/department.py:28
-#: bika/lims/controlpanel/bika_departments.py:49
+#: bika/lims/content/department.py:30
+#: bika/lims/controlpanel/bika_departments.py:51
 msgid "Manager"
 msgstr "經理"
 
-#: bika/lims/controlpanel/bika_departments.py:55
+#: bika/lims/controlpanel/bika_departments.py:57
 msgid "Manager Email"
 msgstr "經理電郵"
 
-#: bika/lims/controlpanel/bika_departments.py:52
+#: bika/lims/controlpanel/bika_departments.py:54
 msgid "Manager Phone"
 msgstr "經理電話"
 
@@ -3016,31 +3000,25 @@ msgstr "經理電話"
 msgid "Manual"
 msgstr "說明書/手動"
 
-#: bika/lims/content/methods.py:52
+#: bika/lims/content/methods.py:54
 msgid "Manual entry"
 msgstr "手動輸入"
 
-#: bika/lims/content/method.py:82
+#: bika/lims/content/method.py:84
 msgid "Manual entry of results"
 msgstr "手動輸入結果"
 
-msgid "Manual entry of results for method ${methodname} is not allowed"
-msgstr ""
-
-#: bika/lims/utils/analysis.py:403
+#: bika/lims/utils/analysis.py:402
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
 msgstr ""
 
-msgid "Manual entry of results for method {methodname} is not allowed and no valid instruments found: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/referencesample.py:320
+#: bika/lims/browser/referencesample.py:322
 #: bika/lims/browser/templates/referencesample_sticker.pt:51
 #: bika/lims/browser/templates/referencesample_view.pt:49
 msgid "Manufacturer"
 msgstr "製造商"
 
-#: bika/lims/controlpanel/bika_manufacturers.py:34
+#: bika/lims/controlpanel/bika_manufacturers.py:36
 msgid "Manufacturers"
 msgstr "多個製造商"
 
@@ -3049,14 +3027,14 @@ msgstr "多個製造商"
 msgid "Margins (mm)"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:73
-#: bika/lims/browser/fields/referenceresultsfield.py:30
-#: bika/lims/browser/referencesample.py:243
+#: bika/lims/browser/analysisrequest/manage_analyses.py:75
+#: bika/lims/browser/fields/referenceresultsfield.py:32
+#: bika/lims/browser/referencesample.py:245
 msgid "Max"
 msgstr "最大"
 
-#: bika/lims/browser/accreditation.py:74
-#: bika/lims/controlpanel/bika_analysisservices.py:200
+#: bika/lims/browser/accreditation.py:73
+#: bika/lims/controlpanel/bika_analysisservices.py:207
 msgid "Max Time"
 msgstr "最大時間"
 
@@ -3064,30 +3042,30 @@ msgstr "最大時間"
 msgid "Maximum columns per results email"
 msgstr "每個結果的電子郵件最大列數"
 
-#: bika/lims/content/container.py:40
+#: bika/lims/content/container.py:42
 msgid "Maximum possible size or volume of samples."
 msgstr "最大可能的樣品尺碼或體積。"
 
-#: bika/lims/content/analysis.py:116
-#: bika/lims/content/analysisservice.py:717
+#: bika/lims/content/analysis.py:115
+#: bika/lims/content/analysisservice.py:716
 msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
 msgstr "允許完成分析的最長時間。當此期限結束而逾期分析，會發出警報"
 
-#: bika/lims/content/analysis.py:115
-#: bika/lims/content/analysisservice.py:716
+#: bika/lims/content/analysis.py:114
+#: bika/lims/content/analysisservice.py:715
 msgid "Maximum turn-around time"
 msgstr "最大周轉時間"
 
-#: bika/lims/browser/clientfolder.py:50
+#: bika/lims/browser/clientfolder.py:51
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1428
+#: bika/lims/content/analysisrequest.py:1430
 #: bika/lims/content/bikasetup.py:197
 msgid "Member discount %"
 msgstr "會員折扣%"
 
-#: bika/lims/content/client.py:48
+#: bika/lims/content/client.py:50
 msgid "Member discount applies"
 msgstr "會員可用折扣"
 
@@ -3096,22 +3074,22 @@ msgid "Member registered and linked to the current Contact."
 msgstr ""
 
 #: bika/lims/browser/analyses.py:75
-#: bika/lims/browser/batch/publish.py:96
-#: bika/lims/browser/referencesample.py:112
+#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/referencesample.py:114
 msgid "Method"
 msgstr "方法"
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:106
-#: bika/lims/content/method.py:47
+#: bika/lims/content/method.py:49
 msgid "Method Document"
 msgstr "方法文檔"
 
-#: bika/lims/content/method.py:31
+#: bika/lims/content/method.py:33
 msgid "Method ID"
 msgstr "方法ID"
 
 #. Default: "Instructions"
-#: bika/lims/content/method.py:40
+#: bika/lims/content/method.py:42
 msgid "Method Instructions"
 msgstr "方法說明"
 
@@ -3123,9 +3101,9 @@ msgstr "方法: ${method_name}"
 msgid "Method: None"
 msgstr "方法: 没有"
 
-#: bika/lims/content/analysisservice.py:555
+#: bika/lims/content/analysisservice.py:554
 #: bika/lims/content/instrument.py:137
-#: bika/lims/content/methods.py:34
+#: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr "多個方法"
 
@@ -3133,17 +3111,17 @@ msgstr "多個方法"
 msgid "Methods included in the ${accreditation_body} schedule of Accreditation for this Laboratory. Analysis remarks are not accredited"
 msgstr "方法包含在本實驗室 $ {認證機構} 認証計劃中,  分析註解未認証。"
 
-#: bika/lims/content/person.py:36
+#: bika/lims/content/person.py:38
 msgid "Middle initial"
 msgstr "中間初始"
 
-#: bika/lims/content/person.py:42
+#: bika/lims/content/person.py:44
 msgid "Middle name"
 msgstr "中間名字"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:72
-#: bika/lims/browser/fields/referenceresultsfield.py:29
-#: bika/lims/browser/referencesample.py:242
+#: bika/lims/browser/analysisrequest/manage_analyses.py:74
+#: bika/lims/browser/fields/referenceresultsfield.py:31
+#: bika/lims/browser/referencesample.py:244
 msgid "Min"
 msgstr "最小"
 
@@ -3155,8 +3133,8 @@ msgstr "我的"
 msgid "Minimum 5 characters."
 msgstr "最少5個"
 
-#: bika/lims/content/sampletype.py:66
-#: bika/lims/controlpanel/bika_sampletypes.py:57
+#: bika/lims/content/sampletype.py:68
+#: bika/lims/controlpanel/bika_sampletypes.py:59
 msgid "Minimum Volume"
 msgstr "最小體積"
 
@@ -3164,27 +3142,27 @@ msgstr "最小體積"
 msgid "Minimum number of results for QC stats calculations"
 msgstr "進行質量控制的統計計算結果的最小數量"
 
-#: bika/lims/browser/fields/coordinatefield.py:27
-#: bika/lims/browser/fields/durationfield.py:24
+#: bika/lims/browser/fields/coordinatefield.py:29
+#: bika/lims/browser/fields/durationfield.py:26
 msgid "Minutes"
 msgstr "紀要/分鐘"
 
-#: bika/lims/utils/workflow/schedulesampling.py:29
+#: bika/lims/utils/workflow/schedulesampling.py:31
 msgid "Missing scheduled sampling sampler or sampling date in %s."
 msgstr ""
 
-#: bika/lims/browser/client/views/contacts.py:49
-#: bika/lims/browser/supplier.py:67
-#: bika/lims/controlpanel/bika_labcontacts.py:52
+#: bika/lims/browser/client/views/contacts.py:51
+#: bika/lims/browser/supplier.py:69
+#: bika/lims/controlpanel/bika_labcontacts.py:54
 msgid "Mobile Phone"
 msgstr "手提電話"
 
 #: bika/lims/content/instrument.py:102
-#: bika/lims/controlpanel/bika_instruments.py:52
+#: bika/lims/controlpanel/bika_instruments.py:54
 msgid "Model"
 msgstr "型號"
 
-#: bika/lims/browser/reports/administration_usershistory.py:78
+#: bika/lims/browser/reports/administration_usershistory.py:80
 msgid "Modification date"
 msgstr "修改日期"
 
@@ -3198,7 +3176,7 @@ msgstr ""
 msgid "More"
 msgstr "更多"
 
-#: bika/lims/content/analysisservice.py:471
+#: bika/lims/content/analysisservice.py:470
 msgid "More than one instrument can be used in a test of this type of analysis. A selection list with the instruments selected here is populated in the results manage view for each test of this type of analysis. The available instruments in the selection list will change in accordance with the method selected by the user for that test in the manage results view. Although a method can have more than one instrument assigned, the selection list is only populated with the instruments that are both set here and allowed for the selected method."
 msgstr ""
 
@@ -3210,13 +3188,13 @@ msgstr ""
 msgid "Multi-verification required"
 msgstr ""
 
-#: bika/lims/content/supplier.py:44
+#: bika/lims/content/supplier.py:46
 msgid "NIB"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:44
-#: bika/lims/content/analysisrequest.py:151
-#: bika/lims/content/arimport.py:121
+#: bika/lims/browser/clientfolder.py:45
+#: bika/lims/content/analysisrequest.py:153
+#: bika/lims/content/arimport.py:123
 msgid "Name"
 msgstr "名稱"
 
@@ -3225,17 +3203,17 @@ msgstr "名稱"
 msgid "New"
 msgstr "新文件"
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "No"
 msgstr "否"
 
-#: bika/lims/browser/reports/productivity_dataentrydaybook.py:43
+#: bika/lims/browser/reports/productivity_dataentrydaybook.py:46
 msgid "No Analysis Requests matched your query"
 msgstr ""
 
-#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:38
+#: bika/lims/exportimport/instruments/eltra/cs/cs2000.py:40
 msgid "No Analysis Services defined"
 msgstr ""
 
@@ -3251,18 +3229,18 @@ msgstr ""
 msgid "No ReferenceDefinitions for Controls nor Blanks available.<br />To add a Control or Blank in this Worksheet Template, create a Reference Definition first."
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:167
+#: bika/lims/browser/reports/administration_usershistory.py:169
 msgid "No actions found for user ${user}"
 msgstr "未找到用戶$ {用戶}"
 
-#: bika/lims/browser/analysisrequest/workflow.py:124
+#: bika/lims/browser/analysisrequest/workflow.py:126
 #: bika/lims/browser/bika_listing.py:137
 msgid "No analyses have been selected"
 msgstr "沒有被選定的分析"
 
-#: bika/lims/browser/reports/productivity_analysesperdepartment.py:53
-#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:44
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:90
+#: bika/lims/browser/reports/productivity_analysesperdepartment.py:55
+#: bika/lims/browser/reports/productivity_analysesperformedpertotal.py:46
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:92
 msgid "No analyses matched your query"
 msgstr "沒有符合您查詢的分析"
 
@@ -3274,23 +3252,23 @@ msgstr "没有添加分析"
 msgid "No analyses were added to this worksheet."
 msgstr "沒有分析加入到這一工作。"
 
-#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:38
-#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:39
+#: bika/lims/exportimport/instruments/biodrop/ulite/ulite.py:40
+#: bika/lims/exportimport/instruments/lifetechnologies/qubit/qubit.py:41
 msgid "No analysis selected"
 msgstr "沒有選擇分析"
 
-#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:38
+#: bika/lims/exportimport/instruments/thermoscientific/multiskan/go.py:40
 msgid "No analysis service selected"
 msgstr "未有選擇分析服務"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:66
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:94
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:68
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:96
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:28
 msgid "No analysis services were selected."
 msgstr "未有選擇分析服務"
 
-#: bika/lims/browser/analysisrequest/workflow.py:236
-#: bika/lims/browser/client/workflow.py:125
+#: bika/lims/browser/analysisrequest/workflow.py:238
+#: bika/lims/browser/client/workflow.py:130
 msgid "No changes made."
 msgstr "沒有更改"
 
@@ -3298,7 +3276,7 @@ msgstr "沒有更改"
 msgid "No control type specified"
 msgstr "沒有指定控制型"
 
-#: bika/lims/controlpanel/bika_instruments.py:112
+#: bika/lims/controlpanel/bika_instruments.py:114
 msgid "No date set"
 msgstr ""
 
@@ -3310,17 +3288,17 @@ msgstr "此服務沒有指定默認容器"
 msgid "No default preservations specified for this service"
 msgstr "本服务没有指定默认保留"
 
-#: bika/lims/browser/arimports.py:200
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:34
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:51
+#: bika/lims/browser/arimports.py:202
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:36
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:53
 msgid "No file selected"
 msgstr "未有選擇文件"
 
-#: bika/lims/browser/reports/administration_usershistory.py:99
+#: bika/lims/browser/reports/administration_usershistory.py:101
 msgid "No historical actions matched your query"
 msgstr "沒有歷史行為符合您的查詢"
 
-#: bika/lims/browser/analysisrequest/workflow.py:102
+#: bika/lims/browser/analysisrequest/workflow.py:104
 msgid "No items have been selected"
 msgstr "沒有項目被選中"
 
@@ -3328,7 +3306,7 @@ msgstr "沒有項目被選中"
 msgid "No items selected"
 msgstr "沒有選擇的項目"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:125
+#: bika/lims/controlpanel/bika_analysisservices.py:132
 msgid "No new items were created."
 msgstr "無新項目建立"
 
@@ -3338,16 +3316,16 @@ msgstr "無新項目建立"
 msgid "No preservation required"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:55
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:57
 msgid "No reference sample was selected."
 msgstr "沒有參考樣本選擇"
 
-#: bika/lims/browser/reports/__init__.py:226
+#: bika/lims/browser/reports/__init__.py:228
 msgid "No report specified in request"
 msgstr "沒有在請求中指定的報告"
 
-#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:46
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:50
+#: bika/lims/browser/reports/productivity_dailysamplesreceived.py:48
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:52
 msgid "No samples matched your query"
 msgstr "沒有樣品符合您的查詢"
 
@@ -3365,25 +3343,22 @@ msgstr "沒有用戶存在${contact_fullname}, 而且他/她將無法登錄。�
 msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
 msgstr ""
 
-#: bika/lims/utils/analysis.py:402
+#: bika/lims/utils/analysis.py:401
 msgid "No valid instruments available: %s "
 msgstr ""
 
-msgid "No valid instruments found: ${invalid_list}"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:207
-#: bika/lims/content/analysisservice.py:1272
+#: bika/lims/content/analysisservice.py:1271
 #: bika/lims/content/bikasetup.py:93
 msgid "None"
 msgstr "没有"
 
-#: bika/lims/config.py:61
+#: bika/lims/config.py:60
 msgid "Not Permitted"
 msgstr "不允許"
 
-#: bika/lims/browser/analysisrequest/published_results.py:117
-#: bika/lims/browser/instrument.py:592
+#: bika/lims/browser/analysisrequest/published_results.py:119
+#: bika/lims/browser/instrument.py:594
 msgid "Not available"
 msgstr "不可用"
 
@@ -3403,19 +3378,19 @@ msgstr ""
 msgid "Num columns"
 msgstr "數列"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:142
+#: bika/lims/browser/analysisrequest/analysisrequests.py:144
 msgid "Number of Analyses"
 msgstr "分析數"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:52
+#: bika/lims/browser/reports/productivity_analysesperclient.py:54
 msgid "Number of Analysis requests and analyses"
 msgstr "分析請求和分析數"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:55
+#: bika/lims/browser/reports/productivity_analysesperclient.py:57
 msgid "Number of Analysis requests and analyses per client"
 msgstr "分析請求數和每個客戶端分析"
 
-#: bika/lims/content/samplinground.py:224
+#: bika/lims/content/samplinground.py:226
 msgid "Number of Containers"
 msgstr ""
 
@@ -3423,30 +3398,30 @@ msgstr ""
 msgid "Number of Positions"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:217
+#: bika/lims/content/samplinground.py:219
 msgid "Number of Sample Points"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:105
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/productivity_analysesperservice.py:95
+#: bika/lims/browser/reports/productivity_analysesperclient.py:107
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/productivity_analysesperservice.py:97
 msgid "Number of analyses"
 msgstr "分析數目"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:223
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:225
 msgid "Number of analyses out of range for period"
 msgstr "分析數超出範圍的時期"
 
-#: bika/lims/browser/reports/productivity_analysesperservice.py:35
+#: bika/lims/browser/reports/productivity_analysesperservice.py:37
 msgid "Number of analyses requested per analysis service"
 msgstr "分析請求數量 - 按分析服務"
 
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:35
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:37
 msgid "Number of analyses requested per sample type"
 msgstr "分析請求數目 - 按樣品類型"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:117
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:147
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:120
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:149
 msgid "Number of analyses retested for period"
 msgstr "這其間重測的分析數目"
 
@@ -3454,15 +3429,15 @@ msgstr "這其間重測的分析數目"
 msgid "Number of analysis requested and published per department and expresed as a percentage of all analyses performed"
 msgstr "每部門的分析數量請求和公佈都要以百分比進行分析表示"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:46
+#: bika/lims/controlpanel/bika_samplingrounds.py:48
 msgid "Number of containers"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:104
+#: bika/lims/browser/reports/productivity_analysesperclient.py:106
 msgid "Number of requests"
 msgstr "請求數目"
 
-#: bika/lims/content/analysisservice.py:1093
+#: bika/lims/content/analysisservice.py:1092
 #: bika/lims/content/bikasetup.py:421
 msgid "Number of required verifications"
 msgstr ""
@@ -3471,31 +3446,31 @@ msgstr ""
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1094
+#: bika/lims/content/analysisservice.py:1093
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
 msgstr ""
 
-#: bika/lims/content/arimport.py:68
+#: bika/lims/content/arimport.py:70
 msgid "Number of samples"
 msgstr "樣品數量"
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:44
+#: bika/lims/controlpanel/bika_samplingrounds.py:46
 msgid "Number of sampling points"
 msgstr ""
 
-#: bika/lims/content/arpriority.py:21
+#: bika/lims/content/arpriority.py:23
 msgid "Numeric value indicating the sort order of objects that are prioritised"
 msgstr "數值代表排序對象的順序優先級"
 
-#: bika/lims/content/batch.py:152
+#: bika/lims/content/batch.py:154
 msgid "Object ID"
 msgstr "物品ID"
 
-#: bika/lims/content/preservation.py:35
+#: bika/lims/content/preservation.py:37
 msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
 msgstr "一旦保留, 样品必须在该时间周期内处置. 如果没有指明, 将使用该样品类型的时间周期."
 
-#: bika/lims/utils/analysis.py:410
+#: bika/lims/utils/analysis.py:409
 msgid "Only instrument entry for this analysis is allowed, but there is no instrument assigned"
 msgstr ""
 
@@ -3503,15 +3478,12 @@ msgstr ""
 msgid "Only lab managers can create and manage worksheets"
 msgstr "只有實驗室經理可以建立和管理工作表"
 
-msgid "Only the analyses for which the selected instrument is allowed will be added automatically."
-msgstr ""
-
 #: bika/lims/browser/worksheet/templates/results.pt:151
 msgid "Only to empty or zero fields"
 msgstr "只有空或零域"
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:69
+#: bika/lims/browser/batchfolder.py:56
+#: bika/lims/browser/instrument.py:71
 #: bika/lims/browser/worksheet/views/folder.py:172
 msgid "Open"
 msgstr "打開"
@@ -3524,26 +3496,26 @@ msgstr ""
 msgid "Order"
 msgstr "訂單"
 
-#: bika/lims/browser/supplyorderfolder.py:38
+#: bika/lims/browser/supplyorderfolder.py:40
 #: bika/lims/browser/templates/supplyorder_view.pt:22
-#: bika/lims/content/supplyorder.py:66
+#: bika/lims/content/supplyorder.py:68
 msgid "Order Date"
 msgstr "訂單日期"
 
-#: bika/lims/config.py:75
+#: bika/lims/config.py:74
 msgid "Order ID"
 msgstr "訂單ID"
 
-#: bika/lims/browser/supplyorderfolder.py:37
-#: bika/lims/content/supplyorder.py:52
+#: bika/lims/browser/supplyorderfolder.py:39
+#: bika/lims/content/supplyorder.py:54
 msgid "Order Number"
 msgstr "訂單號碼"
 
-#: bika/lims/browser/supplyorderfolder.py:35
+#: bika/lims/browser/supplyorderfolder.py:37
 msgid "Orders"
 msgstr "多個訂單"
 
-#: bika/lims/browser/analysisrequest/publish.py:1034
+#: bika/lims/browser/analysisrequest/publish.py:1036
 msgid "Orders: ${orders}"
 msgstr "訂單: ${orders}"
 
@@ -3551,7 +3523,7 @@ msgstr "訂單: ${orders}"
 msgid "Organization responsible of granting the calibration certificate"
 msgstr "負責授予校準證書的組織"
 
-#: bika/lims/content/arimport.py:60
+#: bika/lims/content/arimport.py:62
 msgid "Original Filename"
 msgstr ""
 
@@ -3563,8 +3535,8 @@ msgstr ""
 msgid "Other productivity reports"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:603
-#: bika/lims/controlpanel/bika_instruments.py:117
+#: bika/lims/browser/instrument.py:605
+#: bika/lims/controlpanel/bika_instruments.py:119
 msgid "Out of date"
 msgstr "過時的"
 
@@ -3576,16 +3548,13 @@ msgstr "輸出格式"
 msgid "PDF"
 msgstr "PDF"
 
-msgid "Parent"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:72
-#: bika/lims/browser/analysisrequest/manage_analyses.py:70
-#: bika/lims/browser/sample/partitions.py:37
+#: bika/lims/browser/analysisrequest/manage_analyses.py:72
+#: bika/lims/browser/sample/partitions.py:39
 msgid "Partition"
 msgstr "一部分"
 
-#: bika/lims/browser/samplinground/analysisrequests.py:27
+#: bika/lims/browser/samplinground/analysisrequests.py:29
 msgid "Partition ID"
 msgstr ""
 
@@ -3606,8 +3575,8 @@ msgstr "密碼"
 msgid "Password lifetime"
 msgstr "密碼有效期"
 
-#: bika/lims/browser/arimports.py:71
-#: bika/lims/browser/supplyorderfolder.py:56
+#: bika/lims/browser/arimports.py:73
+#: bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr "有待/處理中"
@@ -3632,31 +3601,31 @@ msgstr "由... 執行"
 msgid "Period"
 msgstr "周期"
 
-#: bika/lims/config.py:60
+#: bika/lims/config.py:59
 msgid "Permitted"
 msgstr "已允許"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:74
-#: bika/lims/browser/fields/referenceresultsfield.py:28
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:52
+#: bika/lims/browser/analysisrequest/manage_analyses.py:76
+#: bika/lims/browser/fields/referenceresultsfield.py:30
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:54
 msgid "Permitted Error %"
 msgstr "許可誤差％"
 
-#: bika/lims/browser/clientfolder.py:46
-#: bika/lims/browser/invoicebatch.py:37
+#: bika/lims/browser/clientfolder.py:47
+#: bika/lims/browser/invoicebatch.py:39
 #: bika/lims/browser/templates/batch_publish.pt:68
 msgid "Phone"
 msgstr "電話"
 
-#: bika/lims/content/person.py:74
+#: bika/lims/content/person.py:76
 msgid "Phone (business)"
 msgstr "電話(辦公室)"
 
-#: bika/lims/content/person.py:86
+#: bika/lims/content/person.py:88
 msgid "Phone (home)"
 msgstr "電話(屋企)"
 
-#: bika/lims/content/person.py:92
+#: bika/lims/content/person.py:94
 msgid "Phone (mobile)"
 msgstr "電話(手提電話)"
 
@@ -3669,8 +3638,8 @@ msgid "Photo of the instrument"
 msgstr "儀器的照片"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:86
-#: bika/lims/config.py:86
-#: bika/lims/content/organisation.py:54
+#: bika/lims/config.py:85
+#: bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr "實際地址"
 
@@ -3678,7 +3647,7 @@ msgstr "實際地址"
 msgid "Please correct the indicated errors."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:980
+#: bika/lims/content/analysisservice.py:979
 msgid "Please list all options for the analysis result if you want to restrict it to specific options only, e.g. 'Positive', 'Negative' and 'Indeterminable'.  The option's result value must be a number"
 msgstr "請列出分析結果所有的選項，如果你想它只是限制在特定的選項，例如“積極” ， “負”和“不確定的” 。該選項的結果值必須是數字"
 
@@ -3686,19 +3655,19 @@ msgstr "請列出分析結果所有的選項，如果你想它只是限制在特
 msgid "Please select a User from the list"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1048
+#: bika/lims/content/analysisservice.py:1047
 msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
 msgstr "如默認保存方法不正確, 請按這裡每件樣品的分析服務類型來註明保存方法"
 
-#: bika/lims/content/laboratory.py:80
+#: bika/lims/content/laboratory.py:82
 msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr "請上傳認證機構授權你在你的網站和結果報告中使用的標誌。最大尺寸是175點¯x 175像素"
 
-#: bika/lims/content/analysisservice.py:755
+#: bika/lims/content/analysisservice.py:754
 msgid "Point of Capture"
 msgstr "捕獲點"
 
-#: bika/lims/content/identifiertype.py:40
+#: bika/lims/content/identifiertype.py:47
 msgid "Portal Types"
 msgstr ""
 
@@ -3707,13 +3676,13 @@ msgid "Pos"
 msgstr ""
 
 #: bika/lims/browser/worksheet/views/analyses.py:33
-#: bika/lims/browser/worksheet/views/analysisrequests.py:35
-#: bika/lims/content/worksheettemplate.py:28
+#: bika/lims/browser/worksheet/views/analysisrequests.py:34
+#: bika/lims/content/worksheettemplate.py:30
 msgid "Position"
 msgstr "位置"
 
-#: bika/lims/content/organisation.py:60
-#: bika/lims/content/person.py:114
+#: bika/lims/content/organisation.py:62
+#: bika/lims/content/person.py:116
 msgid "Postal address"
 msgstr "郵寄地址"
 
@@ -3721,16 +3690,16 @@ msgstr "郵寄地址"
 msgid "Postal code"
 msgstr "郵政編碼"
 
-#: bika/lims/content/container.py:47
-#: bika/lims/controlpanel/bika_containers.py:52
+#: bika/lims/content/container.py:49
+#: bika/lims/controlpanel/bika_containers.py:54
 msgid "Pre-preserved"
 msgstr "已預留"
 
-#: bika/lims/content/analysisservice.py:263
+#: bika/lims/content/analysisservice.py:262
 msgid "Precision as number of decimals"
 msgstr "小數位精度"
 
-#: bika/lims/content/analysisservice.py:928
+#: bika/lims/content/analysisservice.py:927
 msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
 msgstr "當數值不不確定時之小數位。小數點位置將通過從不確定數的零之後的第一個數字給出，在該位，在該位置，系統將四捨五入的不確定性和結果。例如，具有5.243的結果和0.22的不確定性，則系統將正確地為5.2 ±0.2顯示量。如果沒有不確定性範圍被設定為結果，系統將使用固定精度集。"
 
@@ -3758,7 +3727,7 @@ msgstr "報告首選科學記數法格式"
 msgid "Preferred scientific notation format for results"
 msgstr "結果首選科學記數法格式"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:55
+#: bika/lims/controlpanel/bika_sampletypes.py:57
 msgid "Prefix"
 msgstr "前缀"
 
@@ -3766,12 +3735,12 @@ msgstr "前缀"
 msgid "Prefixes"
 msgstr "人名前的稱謂"
 
-#: bika/lims/controlpanel/bika_arpriorities.py:50
+#: bika/lims/controlpanel/bika_arpriorities.py:52
 msgid "Premium"
 msgstr "附加費/津貼"
 
-#: bika/lims/content/analysisrequest.py:1535
-#: bika/lims/content/sample.py:337
+#: bika/lims/content/analysisrequest.py:1537
+#: bika/lims/content/sample.py:339
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -3783,17 +3752,17 @@ msgstr "由... 預備/準備"
 msgid "Prepublish"
 msgstr ""
 
-#: bika/lims/browser/sample/partitions.py:45
-#: bika/lims/browser/srtemplate/artemplates.py:68
-#: bika/lims/content/analysisservice.py:135
+#: bika/lims/browser/sample/partitions.py:47
+#: bika/lims/browser/srtemplate/artemplates.py:70
+#: bika/lims/content/analysisservice.py:134
 msgid "Preservation"
 msgstr "保存"
 
-#: bika/lims/content/preservation.py:29
+#: bika/lims/content/preservation.py:31
 msgid "Preservation Category"
 msgstr "保存類別"
 
-#: bika/lims/browser/srtemplate/artemplates.py:77
+#: bika/lims/browser/srtemplate/artemplates.py:79
 msgid "Preservation Method"
 msgstr ""
 
@@ -3804,7 +3773,7 @@ msgid "Preservation required"
 msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:264
-#: bika/lims/controlpanel/bika_preservations.py:34
+#: bika/lims/controlpanel/bika_preservations.py:36
 msgid "Preservations"
 msgstr "保存"
 
@@ -3814,14 +3783,14 @@ msgstr "保存"
 msgid "Preserve"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:129
-#: bika/lims/browser/sample/partitions.py:53
-#: bika/lims/browser/sample/view.py:128
+#: bika/lims/browser/analysisrequest/analysisrequests.py:131
+#: bika/lims/browser/sample/partitions.py:55
+#: bika/lims/browser/sample/view.py:130
 msgid "Preserver"
 msgstr "保存人/保護劑/防腐劑"
 
-#: bika/lims/content/instrumentmaintenancetask.py:147
-#: bika/lims/content/instrumentscheduledtask.py:91
+#: bika/lims/content/instrumentmaintenancetask.py:149
+#: bika/lims/content/instrumentscheduledtask.py:93
 msgid "Preventive"
 msgstr "預防"
 
@@ -3829,34 +3798,34 @@ msgstr "預防"
 msgid "Preventive maintenance procedure"
 msgstr "預防性保養程序"
 
-#: bika/lims/browser/accreditation.py:73
-#: bika/lims/browser/analysisrequest/manage_analyses.py:64
+#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/analysisrequest/manage_analyses.py:66
 #: bika/lims/browser/templates/analysisservice_popup.pt:166
 msgid "Price"
 msgstr "價錢"
 
-#: bika/lims/content/analysisprofile.py:95
-#: bika/lims/content/analysisservice.py:788
+#: bika/lims/content/analysisprofile.py:97
+#: bika/lims/content/analysisservice.py:787
 msgid "Price (excluding VAT)"
 msgstr "價錢(不含增值税)"
 
-#: bika/lims/content/arpriority.py:26
+#: bika/lims/content/arpriority.py:28
 msgid "Price Premium Percentage"
 msgstr "溢價百分比"
 
-#: bika/lims/content/labproduct.py:37
+#: bika/lims/content/labproduct.py:39
 msgid "Price excluding VAT"
 msgstr "不含增值税價錢"
 
-#: bika/lims/content/pricelist.py:30
+#: bika/lims/content/pricelist.py:32
 msgid "Pricelist for"
 msgstr "價目表為:"
 
-#: bika/lims/browser/pricelist.py:32
+#: bika/lims/browser/pricelist.py:34
 msgid "Pricelists"
 msgstr "價格表"
 
-#: bika/lims/content/arimport.py:113
+#: bika/lims/content/arimport.py:115
 msgid "Primary Contact"
 msgstr ""
 
@@ -3871,13 +3840,13 @@ msgstr "打印"
 msgid "Print date:"
 msgstr "打印日期"
 
-#: bika/lims/browser/sample/view.py:51
+#: bika/lims/browser/sample/view.py:53
 msgid "Print sample sheets"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:106
-#: bika/lims/browser/analysisrequest/manage_analyses.py:66
-#: bika/lims/browser/sample/analyses.py:29
+#: bika/lims/browser/analysisrequest/analysisrequests.py:108
+#: bika/lims/browser/analysisrequest/manage_analyses.py:68
+#: bika/lims/browser/sample/analyses.py:30
 msgid "Priority"
 msgstr "優先"
 
@@ -3894,34 +3863,34 @@ msgstr "生產力報告"
 msgid "Professional Open Source LIMS/LIS"
 msgstr "專業開源LIMS / LIS"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:141
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:93
 #: bika/lims/browser/reports/selection_macros/select_profile.pt:4
 msgid "Profile"
 msgstr "數據圖表/簡要介紹"
 
-#: bika/lims/content/analysisprofile.py:43
+#: bika/lims/content/analysisprofile.py:45
 msgid "Profile Analyses"
 msgstr "檔案/數據分析"
 
-#: bika/lims/browser/client/views/analysisprofiles.py:44
-#: bika/lims/controlpanel/bika_analysisprofiles.py:35
+#: bika/lims/browser/client/views/analysisprofiles.py:46
+#: bika/lims/controlpanel/bika_analysisprofiles.py:37
 msgid "Profile Key"
 msgstr "簡介重點"
 
-#: bika/lims/content/analysisprofile.py:30
+#: bika/lims/content/analysisprofile.py:32
 msgid "Profile Keyword"
 msgstr "數據圖表/簡要介紹關鍵字"
 
-#: bika/lims/config.py:70
+#: bika/lims/config.py:69
 msgid "Profiles"
 msgstr "多個數據圖表/簡要介紹"
 
-#: bika/lims/browser/analysisrequest/invoice.py:51
+#: bika/lims/browser/analysisrequest/invoice.py:53
 msgid "Proforma (Not yet invoiced)"
 msgstr "備考（尚未開票）"
 
-#: bika/lims/content/analysisservice.py:1120
+#: bika/lims/content/analysisservice.py:1119
 msgid "Protocol ID"
 msgstr "協議/草案ID"
 
@@ -3929,7 +3898,7 @@ msgstr "協議/草案ID"
 msgid "Public. Lag"
 msgstr "公共滯後"
 
-#: bika/lims/content/analysisrequest.py:797
+#: bika/lims/content/analysisrequest.py:799
 msgid "Publication Specification"
 msgstr "出版規範"
 
@@ -3944,21 +3913,21 @@ msgstr "出版偏好"
 msgid "Publish"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:447
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:49
-#: bika/lims/browser/reports/productivity_analysesperservice.py:66
+#: bika/lims/browser/analysisrequest/analysisrequests.py:449
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:52
+#: bika/lims/browser/reports/productivity_analysesperservice.py:68
 msgid "Published"
 msgstr "已發佈"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:32
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:35
 msgid "Published Analysis Requests which have not been invoiced"
 msgstr "已公佈未有發票的分析請求"
 
-#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/analysisrequest/published_results.py:50
 msgid "Published By"
 msgstr "由...出版"
 
-#: bika/lims/browser/analysisrequest/published_results.py:43
+#: bika/lims/browser/analysisrequest/published_results.py:45
 msgid "Published results"
 msgstr "發佈結果"
 
@@ -3971,8 +3940,8 @@ msgid "QC Analyses"
 msgstr "質量分析"
 
 #: bika/lims/browser/analyses.py:907
-#: bika/lims/browser/instrument.py:389
-#: bika/lims/browser/referencesample.py:107
+#: bika/lims/browser/instrument.py:391
+#: bika/lims/browser/referencesample.py:109
 msgid "QC Sample ID"
 msgstr "質量控制樣品ID"
 
@@ -3993,23 +3962,23 @@ msgstr "質量"
 msgid "Quarterly"
 msgstr ""
 
-#: bika/lims/content/analysisspec.py:80
+#: bika/lims/content/analysisspec.py:82
 msgid "Range Comment"
 msgstr "範圍註釋"
 
-#: bika/lims/browser/widgets/analysisspecificationwidget.py:55
+#: bika/lims/browser/widgets/analysisspecificationwidget.py:57
 msgid "Range comment"
 msgstr "範圍註釋"
 
-#: bika/lims/content/analysisservice.py:891
+#: bika/lims/content/analysisservice.py:890
 msgid "Range max"
 msgstr "範圍最大值"
 
-#: bika/lims/content/analysisservice.py:890
+#: bika/lims/content/analysisservice.py:889
 msgid "Range min"
 msgstr "範圍最小值"
 
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:48
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:50
 msgid "Range spec"
 msgstr "範圍規範"
 
@@ -4031,9 +4000,9 @@ msgstr "接收"
 msgid "Receive sample"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:340
-#: bika/lims/browser/reports/productivity_analysestats.py:60
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:77
+#: bika/lims/browser/analysisrequest/analysisrequests.py:342
+#: bika/lims/browser/reports/productivity_analysestats.py:62
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:79
 msgid "Received"
 msgstr "已收到"
 
@@ -4041,11 +4010,11 @@ msgstr "已收到"
 msgid "Recept. Lag"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:224
+#: bika/lims/browser/dashboard.py:226
 msgid "Reception pending"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/published_results.py:49
+#: bika/lims/browser/analysisrequest/published_results.py:51
 msgid "Recipients"
 msgstr "收件人"
 
@@ -4054,31 +4023,31 @@ msgid "Refer to <a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIM
 msgstr "請參閱<a target=\"_blank\" href=\"https://github.com/bikalabs/Bika-LIMS/wiki/Creating-new-report-templates\">建立新的報告模板</a>從Bika LIMS wiki文檔，以獲得更多或添加自己的報告模板。"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
-#: bika/lims/content/worksheettemplate.py:30
+#: bika/lims/content/worksheettemplate.py:32
 msgid "Reference"
 msgstr "参考"
 
-#: bika/lims/browser/referencesample.py:59
+#: bika/lims/browser/referencesample.py:61
 msgid "Reference Analyses"
 msgstr "參考分析"
 
-#: bika/lims/browser/referencesample.py:325
+#: bika/lims/browser/referencesample.py:327
 #: bika/lims/browser/templates/referencesample_view.pt:64
 #: bika/lims/browser/worksheet/views/referencesamples.py:41
 msgid "Reference Definition"
 msgstr "參考定義"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:35
+#: bika/lims/controlpanel/bika_referencedefinitions.py:37
 msgid "Reference Definitions"
 msgstr "參考多個定義"
 
-#: bika/lims/browser/instrument.py:391
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:60
+#: bika/lims/browser/instrument.py:393
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:62
 #: bika/lims/browser/reports/selection_macros/select_reference_sample.pt:5
 msgid "Reference Sample"
 msgstr "参考樣品"
 
-#: bika/lims/browser/referencesample.py:296
+#: bika/lims/browser/referencesample.py:298
 msgid "Reference Samples"
 msgstr "参考多個樣品"
 
@@ -4086,16 +4055,16 @@ msgstr "参考多個樣品"
 msgid "Reference Supplier"
 msgstr "参考供應商"
 
-#: bika/lims/content/referenceanalysis.py:43
+#: bika/lims/content/referenceanalysis.py:42
 msgid "Reference Type"
 msgstr "參考類型"
 
-#: bika/lims/browser/referencesample.py:220
-#: bika/lims/content/referencedefinition.py:32
+#: bika/lims/browser/referencesample.py:222
+#: bika/lims/content/referencedefinition.py:34
 msgid "Reference Values"
 msgstr "參考值"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:41
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:43
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:57
 msgid "Reference analysis QC"
 msgstr "參考分析質量控制"
@@ -4104,7 +4073,7 @@ msgstr "參考分析質量控制"
 msgid "Reference analysis quality control graphs"
 msgstr "參考分析質量控制圖"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:42
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:44
 msgid "Reference analysis quality control graphs "
 msgstr "參考分析質量控制圖"
 
@@ -4112,21 +4081,21 @@ msgstr "參考分析質量控制圖"
 msgid "Reference sample"
 msgstr "参考樣品"
 
-#: bika/lims/content/referencedefinition.py:50
-#: bika/lims/content/referencesample.py:51
+#: bika/lims/content/referencedefinition.py:52
+#: bika/lims/content/referencesample.py:53
 msgid "Reference sample values are zero or 'blank'"
 msgstr "參考樣品的值是零或“空白”"
 
-#: bika/lims/content/duplicateanalysis.py:125
-#: bika/lims/content/referenceanalysis.py:123
+#: bika/lims/content/duplicateanalysis.py:127
+#: bika/lims/content/referenceanalysis.py:122
 msgid "ReferenceAnalysesGroupID"
 msgstr "參考分析組ID"
 
-#: bika/lims/controlpanel/bika_referencedefinitions.py:36
+#: bika/lims/controlpanel/bika_referencedefinitions.py:38
 msgid "ReferenceDefinition represents a Reference Definition or sample type used for quality control testing"
 msgstr "參考定義表示用於質量控制測試一個函數定義或樣品類型"
 
-#: bika/lims/browser/analysisrequest/publish.py:1038
+#: bika/lims/browser/analysisrequest/publish.py:1040
 msgid "Refs: ${references}"
 msgstr "參考: ${references}"
 
@@ -4149,8 +4118,8 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:652
-#: bika/lims/browser/sample/view.py:310
+#: bika/lims/browser/analysisrequest/analysisrequests.py:654
+#: bika/lims/browser/sample/view.py:312
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Rejected"
 msgstr ""
@@ -4159,9 +4128,9 @@ msgstr ""
 msgid "Relative percentage difference, ${variation_here} %, is out of valid range (${variation} %))"
 msgstr "相對百分比差異, ${variation_here} %, 超出有效範圍(${variation} %))"
 
-#: bika/lims/browser/batch/publish.py:112
-#: bika/lims/content/analysisprofile.py:54
-#: bika/lims/content/analysisrequest.py:1410
+#: bika/lims/browser/batch/publish.py:114
+#: bika/lims/content/analysisprofile.py:56
+#: bika/lims/content/analysisrequest.py:1412
 msgid "Remarks"
 msgstr "備註"
 
@@ -4169,7 +4138,7 @@ msgstr "備註"
 msgid "Remarks to take into account before calibration"
 msgstr "備註已考慮到校準前"
 
-#: bika/lims/content/instrumentscheduledtask.py:61
+#: bika/lims/content/instrumentscheduledtask.py:63
 msgid "Remarks to take into account before performing the task"
 msgstr "備註已考慮到在執行任務前，"
 
@@ -4177,7 +4146,7 @@ msgstr "備註已考慮到在執行任務前，"
 msgid "Remarks to take into account before validation"
 msgstr "備註考慮到之前的驗證"
 
-#: bika/lims/content/instrumentmaintenancetask.py:79
+#: bika/lims/content/instrumentmaintenancetask.py:81
 msgid "Remarks to take into account for maintenance process"
 msgstr "備註已考慮到保養過程"
 
@@ -4186,8 +4155,8 @@ msgstr "備註已考慮到保養過程"
 msgid "Remove"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:148
-#: bika/lims/content/instrumentscheduledtask.py:92
+#: bika/lims/content/instrumentmaintenancetask.py:150
+#: bika/lims/content/instrumentscheduledtask.py:94
 msgid "Repair"
 msgstr "修理/維修"
 
@@ -4196,7 +4165,7 @@ msgid "Repeated analyses"
 msgstr "重複分析"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:23
-#: bika/lims/content/report.py:24
+#: bika/lims/content/report.py:26
 msgid "Report"
 msgstr "報告"
 
@@ -4210,14 +4179,14 @@ msgstr "報告日期"
 msgid "Report ID"
 msgstr "報告ID"
 
-#: bika/lims/browser/reports/__init__.py:150
-#: bika/lims/content/report.py:29
+#: bika/lims/browser/reports/__init__.py:152
+#: bika/lims/content/report.py:31
 msgid "Report Type"
 msgstr "報告類型"
 
-#: bika/lims/content/analysisrequest.py:1233
-#: bika/lims/content/analysisservice.py:373
-#: bika/lims/content/artemplate.py:94
+#: bika/lims/content/analysisrequest.py:1235
+#: bika/lims/content/analysisservice.py:372
+#: bika/lims/content/artemplate.py:96
 msgid "Report as Dry Matter"
 msgstr "乾物質報告"
 
@@ -4242,7 +4211,7 @@ msgstr "在一段時間內接收到的樣本數量和結果報告, 它們兩者�
 msgid "Report tables of Analysis Requests and totals submitted between a period of time"
 msgstr "一段時間內的請求分析和總提交收數目的報告表"
 
-#: bika/lims/content/report.py:30
+#: bika/lims/content/report.py:32
 msgid "Report type"
 msgstr "報告類型"
 
@@ -4250,7 +4219,7 @@ msgstr "報告類型"
 msgid "Report upload"
 msgstr "報告上傳"
 
-#: bika/lims/browser/reports/__init__.py:115
+#: bika/lims/browser/reports/__init__.py:117
 msgid "Reports"
 msgstr "多個報告"
 
@@ -4259,15 +4228,15 @@ msgstr "多個報告"
 msgid "Republish"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:69
-#: bika/lims/browser/reports/productivity_analysesattachments.py:66
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:101
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:72
+#: bika/lims/browser/reports/productivity_analysesattachments.py:68
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
 msgid "Request"
 msgstr "請求"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:71
-#: bika/lims/browser/batch/publish.py:91
-#: bika/lims/browser/client/views/attachments.py:33
+#: bika/lims/browser/analysisrequest/analysisrequests.py:73
+#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/client/views/attachments.py:35
 msgid "Request ID"
 msgstr "請求ID"
 
@@ -4275,26 +4244,26 @@ msgstr "請求ID"
 msgid "Request new analyses"
 msgstr "新分析的請求"
 
-#: bika/lims/browser/reports/productivity_analysesperclient.py:63
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:61
-#: bika/lims/browser/reports/productivity_analysesperservice.py:59
+#: bika/lims/browser/reports/productivity_analysesperclient.py:65
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:63
+#: bika/lims/browser/reports/productivity_analysesperservice.py:61
 msgid "Requested"
 msgstr "已請求"
 
-#: bika/lims/browser/sample/view.py:87
+#: bika/lims/browser/sample/view.py:89
 msgid "Requests"
 msgstr "多个请求"
 
 #: bika/lims/browser/templates/login_details.pt:227
-#: bika/lims/config.py:59
+#: bika/lims/config.py:58
 msgid "Required"
 msgstr "已请求"
 
-#: bika/lims/content/analysisservice.py:137
+#: bika/lims/content/analysisservice.py:136
 msgid "Required Volume"
 msgstr "要求的体积"
 
-#: bika/lims/browser/analysisrequest/add.py:425
+#: bika/lims/browser/analysisrequest/add.py:432
 msgid "Required fields have no values: ${field_names}"
 msgstr "必填字欄沒有值"
 
@@ -4302,13 +4271,13 @@ msgstr "必填字欄沒有值"
 msgid "Reset"
 msgstr ""
 
-#: bika/lims/content/client.py:99
+#: bika/lims/content/client.py:101
 msgid "Restrict categories"
 msgstr "限制類"
 
 #: bika/lims/browser/analyses.py:94
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:71
-#: bika/lims/browser/batch/publish.py:97
+#: bika/lims/browser/batch/publish.py:99
 msgid "Result"
 msgstr "結果"
 
@@ -4316,15 +4285,15 @@ msgstr "結果"
 msgid "Result Footer"
 msgstr "結果頁腳"
 
-#: bika/lims/content/analysisservice.py:979
+#: bika/lims/content/analysisservice.py:978
 msgid "Result Options"
 msgstr "結果選項"
 
-#: bika/lims/content/analysisservice.py:967
+#: bika/lims/content/analysisservice.py:966
 msgid "Result Value"
 msgstr "結果值"
 
-#: bika/lims/browser/analysisrequest/workflow.py:309
+#: bika/lims/browser/analysisrequest/workflow.py:311
 msgid "Result for ${analysis} could not be saved because it was already submitted by another user."
 msgstr ""
 
@@ -4342,11 +4311,11 @@ msgstr "結果超出範圍"
 msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
 msgstr "結果值最少的顯著位數會以科學記數法以字母“E”來表示。精度可以在個別分析服務來配置"
 
-#: bika/lims/content/analysisrequest.py:1634
+#: bika/lims/content/analysisrequest.py:1636
 msgid "Results Interpreation"
 msgstr "結果闡明"
 
-#: bika/lims/content/analysisrequest.py:1622
+#: bika/lims/content/analysisrequest.py:1624
 msgid "Results Interpretation"
 msgstr "結果闡明"
 
@@ -4354,7 +4323,7 @@ msgstr "結果闡明"
 msgid "Results attachments permitted"
 msgstr "允許結果附件"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:790
+#: bika/lims/browser/analysisrequest/analysisrequests.py:792
 msgid "Results have been withdrawn"
 msgstr "結果被撤回"
 
@@ -4362,11 +4331,11 @@ msgstr "結果被撤回"
 msgid "Results interpretation"
 msgstr "結果闡明"
 
-#: bika/lims/browser/dashboard.py:244
+#: bika/lims/browser/dashboard.py:246
 msgid "Results pending"
 msgstr ""
 
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:59
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:61
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:47
 msgid "Results per sample point"
 msgstr "結果按每個採樣點"
@@ -4375,14 +4344,14 @@ msgstr "結果按每個採樣點"
 msgid "Results per samplepoint and analysis service"
 msgstr "結果按每個採樣點和分析服務"
 
-#: bika/lims/content/preservation.py:34
-#: bika/lims/content/sampletype.py:33
-#: bika/lims/controlpanel/bika_sampletypes.py:59
+#: bika/lims/content/preservation.py:36
+#: bika/lims/content/sampletype.py:35
+#: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr "保留期"
 
 #: bika/lims/browser/analyses.py:109
-#: bika/lims/browser/referencesample.py:125
+#: bika/lims/browser/referencesample.py:127
 #: bika/lims/browser/worksheet/views/analyses.py:48
 msgid "Retested"
 msgstr "已複檢"
@@ -4401,11 +4370,11 @@ msgstr ""
 msgid "Retracted analyses"
 msgstr "撤回分析"
 
-#: bika/lims/browser/instrument.py:447
+#: bika/lims/browser/instrument.py:449
 msgid "Retraction report unavailable"
 msgstr "撤回報告不可用"
 
-#: bika/lims/browser/instrument.py:439
+#: bika/lims/browser/instrument.py:441
 msgid "Retractions"
 msgstr "撤回"
 
@@ -4421,12 +4390,12 @@ msgstr ""
 msgid "SMTP server disconnected. User creation aborted."
 msgstr ""
 
-#: bika/lims/content/supplier.py:64
+#: bika/lims/content/supplier.py:66
 msgid "SWIFT code."
 msgstr "SWIFT代碼"
 
 #. Default: "Title"
-#: bika/lims/content/person.py:22
+#: bika/lims/content/person.py:24
 msgid "Salutation"
 msgstr "問候/招呼"
 
@@ -4434,19 +4403,19 @@ msgstr "問候/招呼"
 msgid "Same as the above, but sets the default on analysis services. This setting can be set per individual analysis on its own configuration"
 msgstr "與上述相同，但在設定分析服務的默認設置。此設置可以為每個單獨的分析設置自己的配置"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:82
+#: bika/lims/browser/analysisrequest/analysisrequests.py:84
 #: bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt:93
-#: bika/lims/browser/samplinground/analysisrequests.py:35
+#: bika/lims/browser/samplinground/analysisrequests.py:37
 msgid "Sample"
 msgstr "樣品"
 
-#: bika/lims/content/sample.py:392
-#: bika/lims/controlpanel/bika_sampleconditions.py:40
+#: bika/lims/content/sample.py:394
+#: bika/lims/controlpanel/bika_sampleconditions.py:42
 msgid "Sample Condition"
 msgstr "樣品條件/狀態"
 
-#: bika/lims/browser/sample/printform.py:285
-#: bika/lims/controlpanel/bika_sampleconditions.py:30
+#: bika/lims/browser/sample/printform.py:287
+#: bika/lims/controlpanel/bika_sampleconditions.py:32
 msgid "Sample Conditions"
 msgstr "樣品條件/狀態"
 
@@ -4455,8 +4424,8 @@ msgid "Sample Due"
 msgstr "樣品到期日"
 
 #: bika/lims/browser/reports/templates/productivity_dailysamplesreceived.pt:54
-#: bika/lims/browser/sample/printform.py:272
-#: bika/lims/browser/sample/view.py:77
+#: bika/lims/browser/sample/printform.py:274
+#: bika/lims/browser/sample/view.py:79
 msgid "Sample ID"
 msgstr "樣品編號"
 
@@ -4468,12 +4437,12 @@ msgstr "樣品ID填充"
 msgid "Sample ID Sequence Start"
 msgstr "樣品編號順序啟動"
 
-#: bika/lims/controlpanel/bika_samplematrices.py:30
+#: bika/lims/controlpanel/bika_samplematrices.py:32
 msgid "Sample Matrices"
 msgstr "樣品基體"
 
-#: bika/lims/content/sampletype.py:54
-#: bika/lims/controlpanel/bika_samplematrices.py:40
+#: bika/lims/content/sampletype.py:56
+#: bika/lims/controlpanel/bika_samplematrices.py:42
 msgid "Sample Matrix"
 msgstr "樣品基體"
 
@@ -4483,52 +4452,52 @@ msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:59
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt:76
-#: bika/lims/browser/sample/partitions.py:24
+#: bika/lims/browser/sample/partitions.py:26
 msgid "Sample Partitions"
 msgstr "樣本分區"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:99
-#: bika/lims/browser/batch/batchbook.py:56
-#: bika/lims/browser/batch/publish.py:94
+#: bika/lims/browser/analysisrequest/analysisrequests.py:101
+#: bika/lims/browser/batch/batchbook.py:61
+#: bika/lims/browser/batch/publish.py:96
 msgid "Sample Point"
 msgstr "採樣點"
 
-#: bika/lims/browser/client/views/samplepoints.py:33
-#: bika/lims/content/sampletype.py:92
-#: bika/lims/controlpanel/bika_samplepoints.py:40
+#: bika/lims/browser/client/views/samplepoints.py:35
+#: bika/lims/content/sampletype.py:94
+#: bika/lims/controlpanel/bika_samplepoints.py:42
 msgid "Sample Points"
 msgstr "多個採樣點"
 
-#: bika/lims/content/analysisrequest.py:704
-#: bika/lims/content/sample.py:612
+#: bika/lims/content/analysisrequest.py:706
+#: bika/lims/content/sample.py:615
 msgid "Sample Rejection"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:96
-#: bika/lims/browser/batch/batchbook.py:52
-#: bika/lims/browser/batch/publish.py:93
+#: bika/lims/browser/analysisrequest/analysisrequests.py:98
+#: bika/lims/browser/batch/batchbook.py:57
+#: bika/lims/browser/batch/publish.py:95
 msgid "Sample Type"
 msgstr "樣品類型"
 
-#: bika/lims/content/sampletype.py:60
+#: bika/lims/content/sampletype.py:62
 msgid "Sample Type Prefix"
 msgstr "样品类型前缀"
 
-#: bika/lims/config.py:66
+#: bika/lims/config.py:65
 msgid "Sample Type Specifications (Client)"
 msgstr "樣品類型規格（客戶）"
 
-#: bika/lims/config.py:65
+#: bika/lims/config.py:64
 msgid "Sample Type Specifications (Lab)"
 msgstr "樣品類型規格（實驗室）"
 
-#: bika/lims/browser/client/views/samplepoints.py:42
+#: bika/lims/browser/client/views/samplepoints.py:44
 #: bika/lims/browser/templates/analysisservice_popup.pt:255
 #: bika/lims/browser/worksheet/views/folder.py:105
 msgid "Sample Types"
 msgstr "多個樣本類型"
 
-#: bika/lims/content/analysisrequest.py:1058
+#: bika/lims/content/analysisrequest.py:1060
 msgid "Sample condition"
 msgstr "樣品條件/狀態"
 
@@ -4538,9 +4507,9 @@ msgstr "樣品條件/狀態"
 msgid "Sample due"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:71
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:103
-#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:92
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:74
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:105
+#: bika/lims/browser/reports/qualitycontrol_analysesrepeated.py:94
 msgid "Sample point"
 msgstr "採樣點"
 
@@ -4568,17 +4537,17 @@ msgstr ""
 msgid "Sample related reports"
 msgstr "樣品相關報告"
 
-#: bika/lims/browser/reports/administration_arsnotinvoiced.py:70
-#: bika/lims/browser/reports/productivity_analysespersampletype.py:97
-#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:102
+#: bika/lims/browser/reports/administration_arsnotinvoiced.py:73
+#: bika/lims/browser/reports/productivity_analysespersampletype.py:99
+#: bika/lims/browser/reports/qualitycontrol_analysesoutofrange.py:104
 msgid "Sample type"
 msgstr "樣本類型"
 
-#: bika/lims/controlpanel/bika_sampletypes.py:61
+#: bika/lims/controlpanel/bika_sampletypes.py:63
 msgid "SampleMatrix"
 msgstr "樣品基體"
 
-#: bika/lims/content/analysisrequest.py:771
+#: bika/lims/content/analysisrequest.py:773
 msgid "SampleType"
 msgstr "樣本類型"
 
@@ -4588,30 +4557,30 @@ msgstr "樣本類型"
 msgid "Sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:122
-#: bika/lims/browser/sample/view.py:117
-#: bika/lims/browser/srtemplate/artemplates.py:73
+#: bika/lims/browser/analysisrequest/analysisrequests.py:124
+#: bika/lims/browser/sample/view.py:119
+#: bika/lims/browser/srtemplate/artemplates.py:75
 msgid "Sampler"
 msgstr "樣品檢查員"
 
-#: bika/lims/browser/sample/view.py:120
-#: bika/lims/content/analysisrequest.py:608
-#: bika/lims/content/sample.py:286
+#: bika/lims/browser/sample/view.py:122
+#: bika/lims/content/analysisrequest.py:610
+#: bika/lims/content/sample.py:288
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/sample/view.py:69
-#: bika/lims/content/arimport.py:183
+#: bika/lims/browser/sample/view.py:71
+#: bika/lims/content/arimport.py:185
 msgid "Samples"
 msgstr "多个样品"
 
-#: bika/lims/content/referencedefinition.py:58
-#: bika/lims/content/referencesample.py:59
-#: bika/lims/content/sampletype.py:43
+#: bika/lims/content/referencedefinition.py:60
+#: bika/lims/content/referencesample.py:61
+#: bika/lims/content/sampletype.py:45
 msgid "Samples of this type should be treated as hazardous"
 msgstr "這種類型的樣品應被視為危險物處理"
 
-#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:137
+#: bika/lims/browser/reports/productivity_samplereceivedvsreported.py:139
 #: bika/lims/browser/reports/templates/productivity_samplereceivedvsreported.pt:18
 msgid "Samples received vs. reported"
 msgstr "已收到的樣品與報告"
@@ -4620,62 +4589,62 @@ msgstr "已收到的樣品與報告"
 msgid "Samples received vs. samples reported"
 msgstr "已收到的樣品與樣品報告"
 
-#: bika/lims/browser/analysisrequest/publish.py:1042
+#: bika/lims/browser/analysisrequest/publish.py:1044
 msgid "Samples: ${samples}"
 msgstr "樣品: ${samples}"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:112
-#: bika/lims/browser/sample/view.py:107
-#: bika/lims/browser/samplinground/printform.py:173
+#: bika/lims/browser/analysisrequest/analysisrequests.py:114
+#: bika/lims/browser/sample/view.py:109
+#: bika/lims/browser/samplinground/printform.py:175
 msgid "Sampling Date"
 msgstr "採樣日期"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:104
-#: bika/lims/browser/sample/view.py:103
-#: bika/lims/content/analysisrequest.py:1018
+#: bika/lims/browser/analysisrequest/analysisrequests.py:106
+#: bika/lims/browser/sample/view.py:105
+#: bika/lims/content/analysisrequest.py:1020
 msgid "Sampling Deviation"
 msgstr "取樣偏差"
 
-#: bika/lims/controlpanel/bika_samplingdeviations.py:30
+#: bika/lims/controlpanel/bika_samplingdeviations.py:32
 msgid "Sampling Deviations"
 msgstr "取樣偏差"
 
-#: bika/lims/browser/client/views/samplepoints.py:44
-#: bika/lims/content/samplepoint.py:51
+#: bika/lims/browser/client/views/samplepoints.py:46
+#: bika/lims/content/samplepoint.py:53
 #: bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr "採樣頻率"
 
-#: bika/lims/browser/sample/printform.py:274
-#: bika/lims/browser/samplinground/printform.py:172
+#: bika/lims/browser/sample/printform.py:276
+#: bika/lims/browser/samplinground/printform.py:174
 msgid "Sampling Point"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:359
+#: bika/lims/content/analysisrequest.py:361
 msgid "Sampling Round"
 msgstr ""
 
-#: bika/lims/browser/samplinground/analysisrequests.py:31
+#: bika/lims/browser/samplinground/analysisrequests.py:33
 msgid "Sampling Round Template"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_srtemplates.py:36
+#: bika/lims/controlpanel/bika_srtemplates.py:38
 msgid "Sampling Round Templates"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_samplingrounds.py:34
+#: bika/lims/controlpanel/bika_samplingrounds.py:36
 msgid "Sampling Rounds"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:153
+#: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:181
+#: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:174
+#: bika/lims/content/samplinground.py:176
 msgid "Sampling frequency"
 msgstr ""
 
@@ -4685,9 +4654,9 @@ msgstr ""
 msgid "Sampling workflow"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:98
+#: bika/lims/browser/analysisrequest/manage_analyses.py:100
 #: bika/lims/browser/analysisrequest/templates/ar_add.pt:125
-#: bika/lims/browser/sample/partitions.py:84
+#: bika/lims/browser/sample/partitions.py:86
 msgid "Save"
 msgstr "保存"
 
@@ -4700,17 +4669,17 @@ msgstr "保存備註"
 msgid "Schedule sampling"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:266
-#: bika/lims/browser/dashboard.py:204
+#: bika/lims/browser/analysisrequest/analysisrequests.py:268
+#: bika/lims/browser/dashboard.py:206
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Scheduled sampling"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:275
+#: bika/lims/browser/instrument.py:277
 msgid "Scheduled task"
 msgstr "計劃任務"
 
-#: bika/lims/content/analysisservice.py:241
+#: bika/lims/content/analysisservice.py:240
 msgid "Scientific name"
 msgstr "科學名稱/學名"
 
@@ -4718,16 +4687,16 @@ msgstr "科學名稱/學名"
 msgid "Search"
 msgstr "搜索"
 
-#: bika/lims/browser/fields/coordinatefield.py:28
+#: bika/lims/browser/fields/coordinatefield.py:30
 msgid "Seconds"
 msgstr "秒"
 
-#: bika/lims/browser/sample/partitions.py:41
-#: bika/lims/browser/samplinground/analysisrequests.py:29
+#: bika/lims/browser/sample/partitions.py:43
+#: bika/lims/browser/samplinground/analysisrequests.py:31
 msgid "Security Seal Intact"
 msgstr ""
 
-#: bika/lims/content/container.py:72
+#: bika/lims/content/container.py:74
 msgid "Security Seal Intact Y/N"
 msgstr ""
 
@@ -4739,11 +4708,11 @@ msgstr "如果你想當建立新的ARs或樣品記錄時, 貼紙會自動打印,
 msgid "Select AR Templates to include"
 msgstr "選擇包括AR模板"
 
-#: bika/lims/exportimport/dataimport.py:55
+#: bika/lims/exportimport/dataimport.py:57
 msgid "Select a data interface"
 msgstr "選擇一個數據接口"
 
-#: bika/lims/content/analysisservice.py:1011
+#: bika/lims/content/analysisservice.py:1010
 msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
 msgstr "為此分析服務選擇默認保存。如果保存取決於樣品類型組合，指定下表中每個樣品類型保存"
 
@@ -4751,11 +4720,11 @@ msgstr "為此分析服務選擇默認保存。如果保存取決於樣品類型
 msgid "Select a destinaton position and the AR to duplicate."
 msgstr "選擇目標位置和複製AR "
 
-#: bika/lims/content/department.py:29
+#: bika/lims/content/department.py:31
 msgid "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
 msgstr "從“實驗室聯絡”選項中可用的職員中選擇一個管理員, 部門經理的名字將在他們的部門分析報告列出"
 
-#: bika/lims/content/analysisrequest.py:283
+#: bika/lims/content/analysisrequest.py:285
 msgid "Select a sample to create a secondary AR"
 msgstr "選擇一個樣本來建立一個輔助AR"
 
@@ -4767,7 +4736,7 @@ msgstr "選擇所有項目"
 msgid "Select an Export interface for this instrument."
 msgstr ""
 
-#: bika/lims/content/artemplate.py:184
+#: bika/lims/content/artemplate.py:186
 msgid "Select analyses to include in this template"
 msgstr "選擇所有包含這個模板的分析"
 
@@ -4779,11 +4748,11 @@ msgstr "選擇分析員"
 msgid "Select existing file"
 msgstr "選擇現有文件"
 
-#: bika/lims/adapters/identifiers.py:46
+#: bika/lims/adapters/identifiers.py:53
 msgid "Select identifiers by which this object can be referenced."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1267
+#: bika/lims/content/analysisrequest.py:1269
 msgid "Select if analyses to be excluded from invoice"
 msgstr "選擇分析是否從發票報告排除該分析"
 
@@ -4791,19 +4760,19 @@ msgstr "選擇分析是否從發票報告排除該分析"
 msgid "Select if is an in-house calibration certificate"
 msgstr "選擇這是否是一個內部校準證書"
 
-#: bika/lims/content/analysisservice.py:615
+#: bika/lims/content/analysisservice.py:614
 msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
 msgstr "如這個將使用的計算情式是默認設置的計算方法。如果沒有選擇，計算可手動選擇"
 
-#: bika/lims/content/pricelist.py:49
+#: bika/lims/content/pricelist.py:51
 msgid "Select if the descriptions should be included"
 msgstr "選擇是否應包括描述"
 
-#: bika/lims/content/analysisservice.py:442
+#: bika/lims/content/analysisservice.py:441
 msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:420
+#: bika/lims/content/analysisservice.py:419
 msgid "Select if the results for tests of this type of analysis can be set manually. If selected, the user will be able to set a result for a test of this type of analysis in manage results view without the need of selecting an instrument, even though the method selected for the test has instruments assigned."
 msgstr ""
 
@@ -4829,7 +4798,7 @@ msgstr "選擇一個國家, 該國的網站將默認顯示"
 msgid "Select the currency the site will use to display prices."
 msgstr "選擇網站將用於顯示價格的幣種。"
 
-#: bika/lims/content/analysisservice.py:1032
+#: bika/lims/content/analysisservice.py:1031
 msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
 msgstr "選擇默認的容器被用於此分析服務。如果要使用的容器取決於樣品類型與保存的組合，指定在下面的示例類型表的容器"
 
@@ -4841,7 +4810,7 @@ msgstr "選擇默認的登錄頁面。這是當一個客戶機用戶登錄到系
 msgid "Select the filter to apply"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:66
+#: bika/lims/content/worksheettemplate.py:68
 msgid "Select the preferred instrument"
 msgstr "選擇首選的儀器"
 
@@ -4849,7 +4818,7 @@ msgstr "選擇首選的儀器"
 msgid "Select the template which will be used, by default, when publishing ARs."
 msgstr ""
 
-#: bika/lims/content/identifiertype.py:41
+#: bika/lims/content/identifiertype.py:48
 msgid "Select the types that this ID is used to identify."
 msgstr ""
 
@@ -4873,7 +4842,7 @@ msgstr "選擇啟用樣本採集工作流程。"
 msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
 
-#: bika/lims/content/worksheettemplate.py:52
+#: bika/lims/content/worksheettemplate.py:54
 msgid "Select which Analyses should be included on the Worksheet"
 msgstr "選擇工作表中要包含的分析"
 
@@ -4889,7 +4858,7 @@ msgstr ""
 msgid "Select which sticker to print when automatic sticker printing is enabled"
 msgstr "當選擇啟用自動貼紙印刷時, 要打印那貼紙"
 
-#: bika/lims/content/analysisservice.py:1075
+#: bika/lims/content/analysisservice.py:1074
 msgid "Self-verification of results"
 msgstr ""
 
@@ -4901,7 +4870,7 @@ msgstr "發電子郵件"
 msgid "Separate"
 msgstr "分離/分間"
 
-#: bika/lims/content/analysisservice.py:134
+#: bika/lims/content/analysisservice.py:133
 msgid "Separate Container"
 msgstr "單獨的容器"
 
@@ -4909,32 +4878,28 @@ msgstr "單獨的容器"
 msgid "Serial No"
 msgstr "序列號"
 
-#: bika/lims/browser/accreditation.py:67
-#: bika/lims/browser/analysisrequest/manage_analyses.py:58
-#: bika/lims/browser/referencesample.py:109
+#: bika/lims/browser/accreditation.py:66
+#: bika/lims/browser/analysisrequest/manage_analyses.py:60
+#: bika/lims/browser/referencesample.py:111
 msgid "Service"
 msgstr "服務"
-
-# ../browser/js/analysisrequest.js
-msgid "Service dependencies"
-msgstr ""
 
 #: bika/lims/browser/templates/analysisservice_popup.pt:59
 msgid "Service is included in the ${accreditation_body_abbrev}"
 msgstr "服務包括在 ${accreditation_body_abbrev} "
 
-#: bika/lims/browser/reports/selection_macros/__init__.py:71
+#: bika/lims/browser/reports/selection_macros/__init__.py:73
 #: bika/lims/browser/worksheet/views/folder.py:102
 #: bika/lims/browser/worksheet/views/referencesamples.py:40
 msgid "Services"
 msgstr "多個服務"
 
-#: bika/lims/content/analysisrequest.py:705
-#: bika/lims/content/sample.py:613
+#: bika/lims/content/analysisrequest.py:707
+#: bika/lims/content/sample.py:616
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
-#: bika/lims/content/instrumentmaintenancetask.py:113
+#: bika/lims/content/instrumentmaintenancetask.py:115
 msgid "Set the maintenance task as closed."
 msgstr "當關閉時, 設置維護/保護任務。"
 
@@ -4942,31 +4907,31 @@ msgstr "當關閉時, 設置維護/保護任務。"
 msgid "Set the maximum number of analysis requests per results email. Too many columns per email are difficult to read for some clients who prefer fewer results per email"
 msgstr "按結果在電郵設置最大分析請求數目. 有的用户喜歡每個電郵包含少一些的結果, 電郵中列數過過多對他们來說閱讀困難 "
 
-#: bika/lims/content/analysisrequest.py:798
+#: bika/lims/content/analysisrequest.py:800
 msgid "Set the specification to be used before publishing an AR."
 msgstr "設置發布一個AR之前所使用的規範。"
 
-#: bika/lims/controlpanel/bika_analysisspecs.py:36
+#: bika/lims/controlpanel/bika_analysisspecs.py:38
 msgid "Set up the laboratory analysis service results specifications"
 msgstr "建立實驗室分析結果服務規範"
 
-#: bika/lims/content/storagelocation.py:76
+#: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
 msgstr "貨架碼"
 
-#: bika/lims/content/storagelocation.py:82
+#: bika/lims/content/storagelocation.py:84
 msgid "Shelf Description"
 msgstr "貨架說明"
 
-#: bika/lims/content/storagelocation.py:70
+#: bika/lims/content/storagelocation.py:72
 msgid "Shelf Title"
 msgstr "貨架標題"
 
-#: bika/lims/config.py:89
+#: bika/lims/config.py:88
 msgid "Shipping address"
 msgstr "郵寄地址"
 
-#: bika/lims/content/analysisservice.py:218
+#: bika/lims/content/analysisservice.py:217
 msgid "Short title"
 msgstr ""
 
@@ -4982,7 +4947,7 @@ msgstr "展示質量控制分析"
 msgid "Show more"
 msgstr ""
 
-#: bika/lims/content/client.py:100
+#: bika/lims/content/client.py:102
 msgid "Show only selected categories in client views"
 msgstr "用户视图中只能看到选中的类别"
 
@@ -4994,29 +4959,25 @@ msgstr ""
 msgid "Signature"
 msgstr "簽名"
 
-#: bika/lims/content/storagelocation.py:34
+#: bika/lims/content/storagelocation.py:36
 msgid "Site Code"
 msgstr "地點代碼"
 
-#: bika/lims/content/storagelocation.py:40
+#: bika/lims/content/storagelocation.py:42
 msgid "Site Description"
 msgstr "網站/地點說明"
 
-#: bika/lims/content/storagelocation.py:28
+#: bika/lims/content/storagelocation.py:30
 msgid "Site Title"
 msgstr "網站標題"
 
-#: bika/lims/browser/analysisrequest/published_results.py:46
-#: bika/lims/browser/client/views/attachments.py:37
-#: bika/lims/browser/reports/__init__.py:131
+#: bika/lims/browser/analysisrequest/published_results.py:48
+#: bika/lims/browser/client/views/attachments.py:39
+#: bika/lims/browser/reports/__init__.py:133
 msgid "Size"
 msgstr "尺寸"
 
-# ../browser/js/attachments.js
-msgid "Slot"
-msgstr ""
-
-#: bika/lims/content/arpriority.py:32
+#: bika/lims/content/arpriority.py:34
 msgid "Small Icon"
 msgstr "小圖標"
 
@@ -5024,14 +4985,14 @@ msgstr "小圖標"
 msgid "Small sticker"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/manage_results.py:90
+#: bika/lims/browser/analysisrequest/manage_results.py:92
 #: bika/lims/browser/worksheet/views/results.py:212
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
 msgstr "有分析使用了過期或未經校準的儀器。結果版不允許"
 
-#: bika/lims/content/analysiscategory.py:63
-#: bika/lims/content/analysisservice.py:231
-#: bika/lims/content/arpriority.py:20
+#: bika/lims/content/analysiscategory.py:65
+#: bika/lims/content/analysisservice.py:230
+#: bika/lims/content/arpriority.py:22
 msgid "Sort Key"
 msgstr "排序關鍵字"
 
@@ -5039,41 +5000,41 @@ msgstr "排序關鍵字"
 msgid "Specification"
 msgstr "規範"
 
-#: bika/lims/content/analysisspec.py:83
+#: bika/lims/content/analysisspec.py:85
 msgid "Specifications"
 msgstr "多個規範"
 
-#: bika/lims/content/worksheettemplate.py:35
+#: bika/lims/content/worksheettemplate.py:37
 msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
 msgstr "指出工作表的大小,如相應儀器的樣品盤大小, 就按工作表位置選擇分析'類型'. 選擇質量控制樣品的位置也需要選擇使用参考樣品. 如果選擇了重複樣品, 指明需要重複哪一個位置的樣品."
 
-#: bika/lims/content/analysisservice.py:901
+#: bika/lims/content/analysisservice.py:900
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr "在所給的範圍內指定不確定性的數值，例如於與0的最小和最大的10的範圍內，其中所述不確定性值是0.5結果 - 6.67結果將被報告為6.67 + -  0.5 。您也可以作為結果值的百分比，通過添加“％”在“不確定性的價值”一欄，例如輸入值指定的不確定性值於與10.01最小和一個最大的100，其中的不確定性值是2 ％的範圍內的結果 - 100結果將被報告為100 + - 2，請確保連續範圍是連續的，例如0.00  - 10.00其次是10.01 - 20.00 ， 20.01 - 30 .00等。"
 
-#: bika/lims/browser/invoicebatch.py:41
-#: bika/lims/browser/invoicefolder.py:35
-#: bika/lims/browser/pricelist.py:43
+#: bika/lims/browser/invoicebatch.py:43
+#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr "開始日期"
 
-#: bika/lims/validators.py:132
+#: bika/lims/validators.py:168
 msgid "Start date must be before End Date"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:137
-#: bika/lims/browser/arimports.py:67
-#: bika/lims/browser/batch/batchbook.py:69
+#: bika/lims/browser/analysisrequest/analysisrequests.py:139
+#: bika/lims/browser/arimports.py:69
+#: bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr "狀況/說明"
 
-#: bika/lims/browser/invoicefolder.py:25
+#: bika/lims/browser/invoicefolder.py:27
 msgid "Statements"
 msgstr ""
 
 #: bika/lims/browser/analyses.py:87
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:72
-#: bika/lims/browser/reports/productivity_analysesperclient.py:73
+#: bika/lims/browser/reports/productivity_analysesperclient.py:75
 msgid "Status"
 msgstr "狀態"
 
@@ -5081,33 +5042,33 @@ msgstr "狀態"
 msgid "Sticker templates"
 msgstr "貼紙模板"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:102
-#: bika/lims/browser/sample/view.py:101
-#: bika/lims/content/analysisrequest.py:875
+#: bika/lims/browser/analysisrequest/analysisrequests.py:104
+#: bika/lims/browser/sample/view.py:103
+#: bika/lims/content/analysisrequest.py:877
 msgid "Storage Location"
 msgstr "存儲位置"
 
-#: bika/lims/controlpanel/bika_storagelocations.py:40
+#: bika/lims/controlpanel/bika_storagelocations.py:42
 msgid "Storage Locations"
 msgstr "多個存儲位置"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:85
-#: bika/lims/content/analysisrequest.py:395
-#: bika/lims/controlpanel/bika_subgroups.py:46
+#: bika/lims/browser/analysisrequest/analysisrequests.py:87
+#: bika/lims/content/analysisrequest.py:397
+#: bika/lims/controlpanel/bika_subgroups.py:48
 msgid "Sub-group"
 msgstr "子組"
 
-#: bika/lims/controlpanel/bika_subgroups.py:38
+#: bika/lims/controlpanel/bika_subgroups.py:40
 msgid "Sub-groups"
 msgstr "多個子組"
 
-#: bika/lims/content/subgroup.py:21
+#: bika/lims/content/subgroup.py:23
 msgid "Subgroups are sorted with this key in group views"
 msgstr "在群組顯示時, 子組會用這個關鍵來排序"
 
+#: bika/lims/browser/batch/batchbook.py:252
 #: bika/lims/exportimport/import.pt:54
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
-#: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "Submit"
 msgstr "提交"
 
@@ -5115,37 +5076,34 @@ msgstr "提交"
 msgid "Submit a valid Open XML (.XLSX) file containing Bika setup records to continue."
 msgstr "提交包含Bika 設置記錄繼續有效的Open XML格式（.xlsx ）文件。"
 
-msgid "Submit for verification"
-msgstr ""
-
 #: bika/lims/browser/analyses.py:792
 msgid "Submited and verified by the same user- "
 msgstr ""
 
-#: bika/lims/content/arimport.py:290
+#: bika/lims/content/arimport.py:292
 msgid "Submitting AR Import"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:45
+#: bika/lims/browser/invoicebatch.py:47
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:122
 #: bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt:122
 msgid "Subtotal"
 msgstr "子項總計"
 
-#: bika/lims/browser/referencesample.py:315
+#: bika/lims/browser/referencesample.py:317
 #: bika/lims/content/instrument.py:94
 msgid "Supplier"
 msgstr "供應商"
 
-#: bika/lims/controlpanel/bika_suppliers.py:34
+#: bika/lims/controlpanel/bika_suppliers.py:36
 msgid "Suppliers"
 msgstr "多個供應商"
 
-#: bika/lims/browser/supplyorder.py:21
+#: bika/lims/browser/supplyorder.py:23
 msgid "Supply Order"
 msgstr "供應訂單"
 
-#: bika/lims/content/person.py:48
+#: bika/lims/content/person.py:50
 msgid "Surname"
 msgstr "姓"
 
@@ -5165,11 +5123,11 @@ msgstr ""
 msgid "System Dashboard"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:1562
+#: bika/lims/content/analysisservice.py:1561
 msgid "System default"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:59
+#: bika/lims/browser/instrument.py:61
 msgid "Task"
 msgstr "任務"
 
@@ -5178,20 +5136,20 @@ msgid "Task ID"
 msgstr ""
 
 #. Default: "Type"
-#: bika/lims/browser/instrument.py:61
-#: bika/lims/content/instrumentscheduledtask.py:42
+#: bika/lims/browser/instrument.py:63
+#: bika/lims/content/instrumentscheduledtask.py:44
 msgid "Task type"
 msgstr "任務類型"
 
-#: bika/lims/content/method.py:42
+#: bika/lims/content/method.py:44
 msgid "Technical description and instructions intended for analysts"
 msgstr "為分析員準備的技術描述和說明"
 
-#: bika/lims/browser/sample/printform.py:279
+#: bika/lims/browser/sample/printform.py:281
 msgid "Temperature"
 msgstr "温度"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:146
+#: bika/lims/browser/analysisrequest/analysisrequests.py:148
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt:23
 #: bika/lims/browser/sample/templates/print_form.pt:24
 msgid "Template"
@@ -5209,35 +5167,35 @@ msgstr ""
 msgid "Tests requested"
 msgstr ""
 
-#: bika/lims/content/artemplate.py:166
+#: bika/lims/content/artemplate.py:168
 msgid "The Analysis Profile selection for this template"
 msgstr "分析數據圖表選擇此模板"
 
-#: bika/lims/content/analysisrequest.py:103
+#: bika/lims/content/analysisrequest.py:105
 msgid "The ID assigned to the client's request by the lab"
 msgstr "實驗室為用户請求分配了此ID"
 
-#: bika/lims/content/sample.py:51
+#: bika/lims/content/sample.py:53
 msgid "The ID assigned to the client's sample by the lab"
 msgstr "實驗室為用户樣品分配了此ID"
 
-#: bika/lims/content/laboratory.py:25
+#: bika/lims/content/laboratory.py:27
 msgid "The Laboratory's web address"
 msgstr "實驗室網址"
 
-#: bika/lims/content/analysisservice.py:288
+#: bika/lims/content/analysisservice.py:287
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
 msgstr "檢測下限是指用來測試方法可用的測量最低值。如所輸入的結果小於< LDL,將被報告為"
 
-#: bika/lims/content/analysisservice.py:306
+#: bika/lims/content/analysisservice.py:305
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
 msgstr "檢測下限是指用來測試方法可用的測量最高值。如所輸入的結果大於< UDL,將被報告為"
 
-#: bika/lims/content/laboratory.py:65
+#: bika/lims/content/laboratory.py:67
 msgid "The accreditation standard that applies, e.g. ISO 17025"
 msgstr "適用的認証標準, 如 ISO 17025"
 
-#: bika/lims/content/analysisprofile.py:44
+#: bika/lims/content/analysisprofile.py:46
 msgid "The analyses included in this profile, grouped per category"
 msgstr "分析包含於此數據是按类别分组"
 
@@ -5249,7 +5207,7 @@ msgstr "該分析用於檢測乾燥物質."
 msgid "The analyst or agent responsible of the calibration"
 msgstr "負責校準的分析師或代理人"
 
-#: bika/lims/content/instrumentmaintenancetask.py:69
+#: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
 msgstr "他負責保養/維修的分析師或代理人"
 
@@ -5257,12 +5215,12 @@ msgstr "他負責保養/維修的分析師或代理人"
 msgid "The analyst responsible of the validation"
 msgstr "負責驗證的分析師"
 
-#: bika/lims/browser/reports/productivity_analysesattachments.py:33
+#: bika/lims/browser/reports/productivity_analysesattachments.py:35
 #: bika/lims/browser/reports/templates/productivity.pt:455
 msgid "The attachments linked to analysis requests and analyses"
 msgstr "附件鏈接到分析請求和分析"
 
-#: bika/lims/content/analysisservice.py:776
+#: bika/lims/content/analysisservice.py:775
 msgid "The category the analysis service belongs to"
 msgstr "分析服務所屬的類別"
 
@@ -5270,19 +5228,19 @@ msgstr "分析服務所屬的類別"
 msgid "The date the instrument was installed"
 msgstr "安裝儀器的日期"
 
-#: bika/lims/content/samplinground.py:182
+#: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
 msgstr ""
 
-#: bika/lims/content/client.py:118
+#: bika/lims/content/client.py:120
 msgid "The decimal mark selected in Bika Setup will be used."
 msgstr "在Bika 設置所選的十進制標記將被使用。"
 
-#: bika/lims/content/samplinground.py:161
+#: bika/lims/content/samplinground.py:163
 msgid "The default Sampler for these Sampling Round"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:78
+#: bika/lims/content/sampletype.py:80
 msgid "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
 msgstr "默認容器類型。新的樣本分區被自動分配這種類型的容器中，除非它在每次分析服務有特定的指定"
 
@@ -5294,7 +5252,7 @@ msgstr "輸入折扣的百分數, 該折扣將用於標為'會員'的用户,通�
 msgid "The full URL: http://URL/path:port"
 msgstr "完整的URL如: http://URL/path:port"
 
-#: bika/lims/content/samplepoint.py:45
+#: bika/lims/content/samplepoint.py:47
 msgid "The height or depth at which the sample has to be taken"
 msgstr "取樣的高度或深度"
 
@@ -5311,24 +5269,24 @@ msgstr "該儀器的型號"
 msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:692
+#: bika/lims/browser/analysisrequest/workflow.py:694
 msgid "The item %s can't be transitioned."
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/workflow.py:705
+#: bika/lims/browser/analysisrequest/workflow.py:707
 msgid "The item can't be transitioned."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:168
+#: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:58
+#: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr "該實驗室未經認証, 或者尚未設置認証信息."
 
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/analysisservice.py:862
+#: bika/lims/content/analysiscategory.py:53
+#: bika/lims/content/analysisservice.py:861
 #: bika/lims/content/labcontact.py:59
 msgid "The laboratory department"
 msgstr "實驗室部門"
@@ -5345,27 +5303,27 @@ msgstr "零填充的樣品ID的長度"
 msgid "The length of the zero-padding for the AR number in AR IDs"
 msgstr "在AR IDs的零填充AR數字的長度"
 
-#: bika/lims/content/sampletype.py:93
+#: bika/lims/content/sampletype.py:95
 msgid "The list of sample points from which this sample type can be collected.  If no sample points are selected, then all sample points are available."
 msgstr "可收集樣品類型的取樣點列表。如果沒有樣品類型被選擇，那麼所有的採樣點都可用。"
 
-#: bika/lims/content/samplepoint.py:63
+#: bika/lims/content/samplepoint.py:65
 msgid "The list of sample types that can be collected at this sample point.  If no sample types are selected, then all sample types are available."
 msgstr "可在此樣本點收集樣品類型的列表。如果沒有樣品類型被選擇，那麼所有樣品類型都可用。"
 
-#: bika/lims/content/analysisservice.py:253
+#: bika/lims/content/analysisservice.py:252
 msgid "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
 msgstr "分析結果的單位, 如毫克/升， ppm時，分貝，毫伏等"
 
-#: bika/lims/utils/analysis.py:405
+#: bika/lims/utils/analysis.py:404
 msgid "The method %s is not valid: no manual entry allowed and no instrument assigned"
 msgstr ""
 
-#: bika/lims/utils/analysis.py:407
+#: bika/lims/utils/analysis.py:406
 msgid "The method %s is not valid: only instrument entry for this analysis is allowed, but the method has no instrument assigned"
 msgstr ""
 
-#: bika/lims/content/sampletype.py:67
+#: bika/lims/content/sampletype.py:69
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr "分析所需的最小樣品體積如 '10毫升“或” 1千克“ 。"
 
@@ -5389,7 +5347,7 @@ msgstr "密碼有效天數. 如果輸入0則表示永遠有效"
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr "樣品有效天數, 過期的樣品將不能分析. 該設置可以在樣品類型設置中為具體樣品類型重置."
 
-#: bika/lims/content/samplinground.py:175
+#: bika/lims/content/samplinground.py:177
 #: bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
@@ -5406,11 +5364,11 @@ msgstr "請求和分析的數量"
 msgid "The number of requests and analyses per client"
 msgstr "請求的數量和每個客戶分析"
 
-#: bika/lims/content/arpriority.py:27
+#: bika/lims/content/arpriority.py:29
 msgid "The percentage used to calculate the price for analyses done at this priority"
 msgstr "在這分析優先以百分比來計算的價格"
 
-#: bika/lims/content/sampletype.py:34
+#: bika/lims/content/sampletype.py:36
 msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
 msgstr "在這期間未保存的樣品可在到期之前保持，並且不能被進一步分析"
 
@@ -5427,19 +5385,19 @@ msgstr "這個人在供應商執行任務"
 msgid "The person at the supplier who prepared the certificate"
 msgstr "這個人在供應商執準備證書"
 
-#: bika/lims/content/analysisservice.py:799
+#: bika/lims/content/analysisservice.py:798
 msgid "The price charged per analysis for clients who qualify for bulk discounts"
 msgstr "這個客戶的分析收費合資格享有量大折扣"
 
-#: bika/lims/content/analysisprofile.py:75
+#: bika/lims/content/analysisprofile.py:77
 msgid "The profile's commercial ID for accounting purposes."
 msgstr "數據圖表商業ID為會計目的"
 
-#: bika/lims/content/analysisprofile.py:31
+#: bika/lims/content/analysisprofile.py:33
 msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
 msgstr "該配置文件的關鍵字是用來唯一標識在導入文件。它必須是獨特的，它可能不與任何計算臨時場ID一致"
 
-#: bika/lims/content/laboratory.py:73
+#: bika/lims/content/laboratory.py:75
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "認証機構向實驗室發放的參考碼"
 
@@ -5447,11 +5405,11 @@ msgstr "認証機構向實驗室發放的參考碼"
 msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
 msgstr ""
 
-#: bika/lims/content/method.py:83
+#: bika/lims/content/method.py:85
 msgid "The results for the Analysis Services that use this method can be set manually"
 msgstr "用這方法做分析服務的結果可以手動進行設置"
 
-#: bika/lims/content/analysisservice.py:756
+#: bika/lims/content/analysisservice.py:755
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
 msgstr "分析結果是在採樣點採樣過程中捕獲，例如在河水在取樣的溫度。實驗室分析是在實驗室完成"
 
@@ -5459,7 +5417,7 @@ msgstr "分析結果是在採樣點採樣過程中捕獲，例如在河水在取
 msgid "The room and location where the instrument is installed"
 msgstr "在安裝儀器的房間和位置"
 
-#: bika/lims/content/method.py:59
+#: bika/lims/content/method.py:61
 msgid "The selected instruments have support for this method. Use the Instrument edit view to assign the method to a specific instrument"
 msgstr "所選的儀器都能支持此方法。使用儀器編輯視圖的方法分配給特定的儀器"
 
@@ -5471,11 +5429,11 @@ msgstr ""
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "唯一標識文書的序列號"
 
-#: bika/lims/content/analysisservice.py:1121
+#: bika/lims/content/analysisservice.py:1120
 msgid "The service's analytical protocol ID"
 msgstr "該服務的解析協議ID"
 
-#: bika/lims/content/analysisservice.py:1110
+#: bika/lims/content/analysisservice.py:1109
 msgid "The service's commercial ID for accounting purposes"
 msgstr "為會計目的服務的商業ID"
 
@@ -5483,19 +5441,19 @@ msgstr "為會計目的服務的商業ID"
 msgid "The system wide default configuration to indicate whether file attachments are required, permitted or not per analysis request"
 msgstr "系统范围内的默认配置,表明是否要求,允许或禁止为分析请求添加附件."
 
-#: bika/lims/content/analysisservice.py:556
+#: bika/lims/content/analysisservice.py:555
 msgid "The tests of this type of analysis can be performed by using more than one method with the 'Manual entry of results' option enabled. A selection list with the methods selected here is populated in the manage results view for each test of this type of analysis. Note that only methods with 'Allow manual entry' option enabled are displayed here; if you want the user to be able to assign a method that requires instrument entry, enable the 'Instrument assignment is allowed' option."
 msgstr ""
 
-#: bika/lims/content/samplinground.py:225
+#: bika/lims/content/samplinground.py:227
 msgid "The total number of Containers included in the Round."
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats.py:35
+#: bika/lims/browser/reports/productivity_analysestats.py:37
 msgid "The turnaround time of analyses"
 msgstr ""
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:34
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:36
 msgid "The turnaround time of analyses plotted over time"
 msgstr "分析的周轉時間對時間作圖"
 
@@ -5507,7 +5465,7 @@ msgstr "分析周转时间"
 msgid "The turnaround times of analyses plotted over time"
 msgstr "分析的周轉時間對時間作圖"
 
-#: bika/lims/content/analysisservice.py:401
+#: bika/lims/content/analysisservice.py:400
 msgid "The unique keyword used to identify the analysis service in import files of bulk AR requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
 msgstr "獨特的關鍵字用來識別AR請求和進口導入文件結果的分析服務。它也可以用來在用戶定義的結果計算，以確定相關的分析服務"
 
@@ -5519,37 +5477,37 @@ msgstr "没有结果"
 msgid "These reasons will be displayed for its selection during the rejection process."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1235
-#: bika/lims/content/analysisservice.py:374
-#: bika/lims/content/artemplate.py:95
+#: bika/lims/content/analysisrequest.py:1237
+#: bika/lims/content/analysisservice.py:373
+#: bika/lims/content/artemplate.py:97
 msgid "These results can be reported as dry matter"
 msgstr "這些結果可以被報告為乾物質"
 
-#: bika/lims/browser/analysisrequest/view.py:130
+#: bika/lims/browser/analysisrequest/view.py:132
 msgid "These results have been withdrawn and are listed here for trace-ability purposes. Please follow the link to the retest"
 msgstr "這些結果已被撤回，並在這裡列出了跟踪能力的目的。請按照鏈接到複試/重測"
 
-#: bika/lims/browser/analysisrequest/log.py:34
-#: bika/lims/browser/analysisrequest/published_results.py:81
-#: bika/lims/browser/analysisrequest/results_not_requested.py:46
+#: bika/lims/browser/analysisrequest/log.py:36
+#: bika/lims/browser/analysisrequest/published_results.py:83
+#: bika/lims/browser/analysisrequest/results_not_requested.py:48
 msgid "This Analysis Request has been generated automatically due to the retraction of the Analysis Request ${retracted_request_id}."
 msgstr "該分析請求已因分析請求$ {retracted_request_id} 的回縮自動啟動。"
 
-#: bika/lims/browser/analysisrequest/log.py:24
-#: bika/lims/browser/analysisrequest/published_results.py:70
-#: bika/lims/browser/analysisrequest/results_not_requested.py:36
+#: bika/lims/browser/analysisrequest/log.py:26
+#: bika/lims/browser/analysisrequest/published_results.py:72
+#: bika/lims/browser/analysisrequest/results_not_requested.py:38
 msgid "This Analysis Request has been withdrawn and is shown for trace-ability purposes only. Retest: ${retest_child_id}."
 msgstr "該分析請求已被撤回，並表示只跟踪的目的。複試： $ {retest_child_id }  。"
 
-#: bika/lims/content/analysisservice.py:1593
+#: bika/lims/content/analysisservice.py:1592
 msgid "This Analysis Service cannot be activated because it's calculation is inactive."
 msgstr "這種分析服務不能被激活，因為它的計算是無效的。"
 
-#: bika/lims/content/analysisservice.py:1609
+#: bika/lims/content/analysisservice.py:1608
 msgid "This Analysis Service cannot be deactivated because one or more active calculations list it as a dependency"
 msgstr "這種分析服務不能被停用，因為一個或多個活動列表計算依賴於它的"
 
-#: bika/lims/content/analysisservice.py:512
+#: bika/lims/content/analysisservice.py:511
 msgid "This is the instrument the system will assign by default to tests from this type of analysis in manage results view. The method associated to this instrument will be assigned as the default method too.Note the instrument's method will prevail over any of the methods choosen if the 'Instrument assignment is not required' option is enabled."
 msgstr ""
 
@@ -5561,7 +5519,7 @@ msgstr "該服務不需要一個單獨的分區"
 msgid "This service requires a separate container."
 msgstr "這種服務需要一個單獨的容器"
 
-#: bika/lims/content/samplinground.py:148
+#: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
 msgstr ""
 
@@ -5569,13 +5527,9 @@ msgstr ""
 msgid "This text will be appended to results reports."
 msgstr "該文本將被添加到結果的報告。"
 
-#: bika/lims/content/laboratory.py:32
+#: bika/lims/content/laboratory.py:34
 msgid "This value is reported at the bottom of all published results"
 msgstr "本值为所有发布的结果中最低值"
-
-# ../browser/js/client.js
-msgid "This will remove all existing client analysis specifications and create copies of all lab specifications. Are you sure you want to do this?"
-msgstr ""
 
 #: bika/lims/browser/worksheet/tools.py:64
 msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
@@ -5589,63 +5543,63 @@ msgstr "該工作表已被拒絕。以更換工作$ {ws_id } "
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr "提示. 添加文件不會被加載，除非它們是存在於實例。"
 
-#: bika/lims/browser/arimports.py:60
-#: bika/lims/browser/batchfolder.py:43
+#: bika/lims/browser/arimports.py:62
+#: bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:389
 msgid "Title"
 msgstr "標題"
 
-#: bika/lims/content/storagelocation.py:47
+#: bika/lims/content/storagelocation.py:49
 msgid "Title of location"
 msgstr "位置標題"
 
-#: bika/lims/content/storagelocation.py:71
+#: bika/lims/content/storagelocation.py:73
 msgid "Title of the shelf"
 msgstr "貨架標題"
 
-#: bika/lims/content/storagelocation.py:29
+#: bika/lims/content/storagelocation.py:31
 msgid "Title of the site"
 msgstr "場地的標題"
 
 #: bika/lims/content/instrumentcalibration.py:86
 #: bika/lims/content/instrumentcertification.py:135
-#: bika/lims/content/instrumentmaintenancetask.py:60
+#: bika/lims/content/instrumentmaintenancetask.py:62
 msgid "To"
 msgstr "至"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:233
 #: bika/lims/skins/bika/portlet_to_be_preserved.pt:22
 msgid "To Be Preserved"
 msgstr "需要保留"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:195
+#: bika/lims/browser/analysisrequest/analysisrequests.py:197
 #: bika/lims/skins/bika/portlet_to_be_sampled.pt:22
 msgid "To Be Sampled"
 msgstr "需要取樣"
 
-#: bika/lims/content/analysiscategory.py:37
+#: bika/lims/content/analysiscategory.py:39
 msgid "To be displayed below each Analysis Category section on results reports."
 msgstr "將每個分析類型結果報告顯示"
 
-#: bika/lims/browser/dashboard.py:184
+#: bika/lims/browser/dashboard.py:186
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 #: bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
 msgid "To be preserved"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:284
+#: bika/lims/browser/dashboard.py:286
 msgid "To be published"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:164
-#: bika/lims/browser/sample/view.py:163
+#: bika/lims/browser/dashboard.py:166
+#: bika/lims/browser/sample/view.py:165
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "To be sampled"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:375
-#: bika/lims/browser/dashboard.py:264
-#: bika/lims/browser/samplinground/analysisrequests.py:120
+#: bika/lims/browser/analysisrequest/analysisrequests.py:377
+#: bika/lims/browser/dashboard.py:266
+#: bika/lims/browser/samplinground/analysisrequests.py:122
 msgid "To be verified"
 msgstr "需要驗証"
 
@@ -5657,13 +5611,13 @@ msgstr ""
 msgid "To:"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:203
+#: bika/lims/browser/arimports.py:205
 msgid "Too few lines in CSV file"
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:49
-#: bika/lims/browser/reports/productivity_analysesattachments.py:114
-#: bika/lims/browser/reports/productivity_analysesperclient.py:139
+#: bika/lims/browser/invoicebatch.py:51
+#: bika/lims/browser/reports/productivity_analysesattachments.py:116
+#: bika/lims/browser/reports/productivity_analysesperclient.py:141
 msgid "Total"
 msgstr "總計"
 
@@ -5671,22 +5625,22 @@ msgstr "總計"
 msgid "Total Lag"
 msgstr "總滯後"
 
-#: bika/lims/controlpanel/bika_labproducts.py:59
+#: bika/lims/controlpanel/bika_labproducts.py:61
 msgid "Total Price"
 msgstr "總價格"
 
-#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:150
-#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:165
+#: bika/lims/browser/reports/qualitycontrol_referenceanalysisqc.py:152
+#: bika/lims/browser/reports/qualitycontrol_resultspersamplepoint.py:167
 msgid "Total analyses"
 msgstr "总分析"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:153
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:155
 msgid "Total data points"
 msgstr "總數據點"
 
-#: bika/lims/content/analysisprofile.py:125
-#: bika/lims/content/analysisservice.py:819
-#: bika/lims/content/labproduct.py:50
+#: bika/lims/content/analysisprofile.py:127
+#: bika/lims/content/analysisservice.py:818
+#: bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr "總價格"
 
@@ -5698,11 +5652,11 @@ msgstr "總:"
 msgid "Traceability"
 msgstr "可追溯性"
 
-#: bika/lims/browser/analysisrequest/workflow.py:667
+#: bika/lims/browser/analysisrequest/workflow.py:669
 msgid "Transition done."
 msgstr ""
 
-#: bika/lims/config.py:121
+#: bika/lims/config.py:120
 msgid "Transposed"
 msgstr ""
 
@@ -5710,61 +5664,55 @@ msgstr ""
 msgid "Turn this on if you want to work with sample partitions"
 msgstr "如果你想與樣品分區工作，就要打開這個"
 
-#: bika/lims/browser/reports/productivity_analysestats_overtime.py:129
+#: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
 msgstr "周轉時間（h）"
 
 #: bika/lims/browser/bika_listing.py:387
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:75
-#: bika/lims/controlpanel/bika_instruments.py:46
+#: bika/lims/controlpanel/bika_instruments.py:48
 msgid "Type"
 msgstr "類型"
 
-#: bika/lims/browser/calcs.py:227
+#: bika/lims/browser/calcs.py:229
 msgid "Type Error"
 msgstr "類型錯誤"
 
-#: bika/lims/content/multifile.py:50
+#: bika/lims/content/multifile.py:52
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
 
-#: bika/lims/content/storagelocation.py:65
+#: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
 msgstr "位置類型"
 
-msgid "Unable to apply the selected instrument"
-msgstr ""
-
-msgid "Unable to load instruments: ${invalid_list}"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/publish.py:201
-#: bika/lims/browser/sample/printform.py:450
-#: bika/lims/browser/samplinground/printform.py:102
+#: bika/lims/browser/analysisrequest/publish.py:203
+#: bika/lims/browser/sample/printform.py:452
+#: bika/lims/browser/samplinground/printform.py:104
 msgid "Unable to load the template"
 msgstr "無法加載模板"
 
-#: bika/lims/browser/analysisrequest/workflow.py:555
+#: bika/lims/browser/analysisrequest/workflow.py:557
 msgid "Unable to send an email to alert lab client contacts that the Analysis Request has been retracted: ${error}"
 msgstr "無法發送電子郵件，提醒該分析請求已被收回實驗室客戶聯繫： $ {錯誤 }"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:607
-#: bika/lims/browser/samplinground/analysisrequests.py:231
+#: bika/lims/browser/analysisrequest/analysisrequests.py:609
+#: bika/lims/browser/samplinground/analysisrequests.py:233
 #: bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
 msgid "Unassigned"
 msgstr "未分配"
 
-#: bika/lims/content/analysis.py:213
-#: bika/lims/content/analysisservice.py:900
-#: bika/lims/content/referenceanalysis.py:132
+#: bika/lims/content/analysis.py:212
+#: bika/lims/content/analysisservice.py:899
+#: bika/lims/content/referenceanalysis.py:131
 msgid "Uncertainty"
 msgstr "不确定性"
 
-#: bika/lims/content/analysisservice.py:892
+#: bika/lims/content/analysisservice.py:891
 msgid "Uncertainty value"
 msgstr "不确定值"
 
-#: bika/lims/browser/reports/productivity_analysestats.py:138
+#: bika/lims/browser/reports/productivity_analysestats.py:140
 msgid "Undefined"
 msgstr "未定義"
 
@@ -5772,13 +5720,13 @@ msgstr "未定義"
 msgid "Unique ID"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:72
+#: bika/lims/browser/accreditation.py:71
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:70
-#: bika/lims/browser/fields/interimfieldsfield.py:28
+#: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Unit"
 msgstr "單位"
 
-#: bika/lims/validators.py:993
+#: bika/lims/validators.py:1025
 msgid "Unknown IBAN country %s"
 msgstr "未知IBAN 國家％S"
 
@@ -5803,17 +5751,17 @@ msgstr ""
 msgid "Unpublished"
 msgstr "未公佈"
 
-#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:40
+#: bika/lims/exportimport/instruments/panalytical/omnia/axios_xrf.py:42
 msgid "Unrecognized file format ${file_format}"
 msgstr "無法識別文件格式${file_format}"
 
-#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:38
-#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:55
-#: bika/lims/exportimport/instruments/alere/pima/beads.py:38
+#: bika/lims/exportimport/instruments/abaxis/vetscan/vs2.py:40
+#: bika/lims/exportimport/instruments/agilent/masshunter/quantitative.py:57
+#: bika/lims/exportimport/instruments/alere/pima/beads.py:40
 msgid "Unrecognized file format ${fileformat}"
 msgstr "無法識別文件格式${fileformat}"
 
-#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:42
+#: bika/lims/exportimport/instruments/horiba/jobinyvon/icp.py:44
 msgid "Unrecognized file format ${format}"
 msgstr ""
 
@@ -5825,11 +5773,11 @@ msgstr ""
 msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
 msgstr "上傳一張可用於打印分析報告的簽名掃描檔, 理想尺寸為250像素寬, 150像素高"
 
-#: bika/lims/content/analysisservice.py:305
+#: bika/lims/content/analysisservice.py:304
 msgid "Upper Detection Limit (UDL)"
 msgstr "檢測上限(UDL)"
 
-#: bika/lims/content/analysisprofile.py:84
+#: bika/lims/content/analysisprofile.py:86
 msgid "Use Analysis Profile Price"
 msgstr "使用分析簡介價格"
 
@@ -5837,7 +5785,7 @@ msgstr "使用分析簡介價格"
 msgid "Use Dashboard as default front page"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:614
+#: bika/lims/content/analysisservice.py:613
 msgid "Use default calculation"
 msgstr "使用默認計算"
 
@@ -5849,13 +5797,13 @@ msgstr "使用外部ID服務器"
 msgid "Use this field to pass arbitrary parameters to the export/import modules."
 msgstr "使用此字段的任意參數傳遞給導出/導入模塊。"
 
-#: bika/lims/browser/log.py:52
-#: bika/lims/browser/reports/administration_usershistory.py:93
+#: bika/lims/browser/log.py:54
+#: bika/lims/browser/reports/administration_usershistory.py:95
 #: bika/lims/browser/reports/selection_macros/select_user.pt:4
 msgid "User"
 msgstr "用户"
 
-#: bika/lims/browser/client/views/contacts.py:46
+#: bika/lims/browser/client/views/contacts.py:48
 #: bika/lims/browser/templates/login_details.pt:71
 msgid "User Name"
 msgstr "用户名"
@@ -5868,7 +5816,7 @@ msgstr "用戶歷史記錄"
 msgid "User linked to this Contact"
 msgstr ""
 
-#: bika/lims/browser/reports/administration_usershistory.py:183
+#: bika/lims/browser/reports/administration_usershistory.py:185
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:56
 msgid "Users history"
 msgstr "用戶歷史"
@@ -5877,27 +5825,27 @@ msgstr "用戶歷史"
 msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
 msgstr "取样点太少时分析结果无意义. 请在质量控制统计处理前设置可接受的最小样品量."
 
-#: bika/lims/browser/invoicebatch.py:47
+#: bika/lims/browser/invoicebatch.py:49
 #: bika/lims/browser/templates/supplyorder_edit.pt:41
 #: bika/lims/browser/templates/supplyorder_view.pt:39
 msgid "VAT"
 msgstr "增值税"
 
-#: bika/lims/content/analysisprofile.py:105
-#: bika/lims/content/analysisservice.py:829
+#: bika/lims/content/analysisprofile.py:107
+#: bika/lims/content/analysisservice.py:828
 #: bika/lims/content/bikasetup.py:209
 msgid "VAT %"
 msgstr "增值税%"
 
-#: bika/lims/controlpanel/bika_labproducts.py:56
+#: bika/lims/controlpanel/bika_labproducts.py:58
 msgid "VAT Amount"
 msgstr "增值税額"
 
-#: bika/lims/content/invoice.py:69
+#: bika/lims/content/invoice.py:71
 msgid "VAT Total"
 msgstr "增值稅合計"
 
-#: bika/lims/content/organisation.py:31
+#: bika/lims/content/organisation.py:33
 msgid "VAT number"
 msgstr "增值税数目"
 
@@ -5905,11 +5853,11 @@ msgstr "增值税数目"
 msgid "Valid"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:539
+#: bika/lims/browser/instrument.py:541
 msgid "Valid from"
 msgstr "有效自"
 
-#: bika/lims/browser/instrument.py:540
+#: bika/lims/browser/instrument.py:542
 msgid "Valid to"
 msgstr "有效"
 
@@ -5917,181 +5865,181 @@ msgstr "有效"
 msgid "Validate"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:93
+#: bika/lims/content/instrumentscheduledtask.py:95
 msgid "Validation"
 msgstr "驗證"
 
-#: bika/lims/validators.py:259
+#: bika/lims/validators.py:292
 msgid "Validation failed: '${keyword}': duplicate keyword"
 msgstr "驗證失敗: '${keyword}': 重複關鍵字"
 
-#: bika/lims/validators.py:187
+#: bika/lims/validators.py:220
 msgid "Validation failed: '${title}': This keyword is already in use by calculation '${used_by}'"
 msgstr "驗證失敗: '${title}': 這個關鍵字已有計算在使用 '${used_by}' "
 
-#: bika/lims/validators.py:168
+#: bika/lims/validators.py:201
 msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
 msgstr "驗證失敗: '${title}': 這個關鍵字已有服務在使用 '${used_by}' "
 
-#: bika/lims/validators.py:264
+#: bika/lims/validators.py:297
 msgid "Validation failed: '${title}': duplicate title"
 msgstr "驗證失敗: '${title}': 重複標題"
 
-#: bika/lims/validators.py:106
+#: bika/lims/validators.py:141
 msgid "Validation failed: '${value}' is not unique"
 msgstr "驗證失敗: '${value}' 不是唯一的"
 
-#: bika/lims/validators.py:457
+#: bika/lims/validators.py:490
 msgid "Validation failed: Bearing must be E/W"
 msgstr "驗證失敗: 方向必须是E（東）/W（西）"
 
-#: bika/lims/validators.py:440
+#: bika/lims/validators.py:473
 msgid "Validation failed: Bearing must be N/S"
 msgstr "驗證失敗: 方向必须是N（北）/S（南）"
 
-#: bika/lims/validators.py:682
+#: bika/lims/validators.py:715
 msgid "Validation failed: Error percentage must be between 0 and 100"
 msgstr "驗證失敗：錯誤的百分比必須在0到100之間"
 
-#: bika/lims/validators.py:764
+#: bika/lims/validators.py:797
 msgid "Validation failed: Error value must be 0 or greater"
 msgstr "驗證失敗：錯誤值必須大於等於0"
 
-#: bika/lims/validators.py:744
+#: bika/lims/validators.py:777
 msgid "Validation failed: Error values must be numeric"
 msgstr "驗證失敗：錯誤值必須是數字"
 
-#: bika/lims/validators.py:866
+#: bika/lims/validators.py:898
 msgid "Validation failed: Expected values must be between Min and Max values"
 msgstr "驗證失敗：預期值必須是最小和最大值之間"
 
-#: bika/lims/validators.py:840
+#: bika/lims/validators.py:872
 msgid "Validation failed: Expected values must be numeric"
 msgstr "驗證失敗：預期值必須是數字"
 
-#: bika/lims/validators.py:348
+#: bika/lims/validators.py:381
 msgid "Validation failed: Keyword '${keyword}' is invalid"
 msgstr "驗證失敗：關鍵字 '${keyword}' 無效"
 
-#: bika/lims/validators.py:675
+#: bika/lims/validators.py:708
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr "驗證失敗：最大值必須大於最小值更大"
 
-#: bika/lims/validators.py:663
+#: bika/lims/validators.py:696
 msgid "Validation failed: Max values must be numeric"
 msgstr "驗證失敗：最大值必須是數字"
 
-#: bika/lims/validators.py:657
+#: bika/lims/validators.py:690
 msgid "Validation failed: Min values must be numeric"
 msgstr "驗證失敗：最小值必須是數字"
 
-#: bika/lims/validators.py:872
+#: bika/lims/validators.py:904
 msgid "Validation failed: Percentage error values must be between 0 and 100"
 msgstr "驗證失敗：百分比誤差值必須在0到100之間"
 
-#: bika/lims/validators.py:668
+#: bika/lims/validators.py:701
 msgid "Validation failed: Percentage error values must be numeric"
 msgstr "驗證失敗：百分比誤差值必須是數字"
 
-#: bika/lims/validators.py:577
+#: bika/lims/validators.py:610
 msgid "Validation failed: PrePreserved containers must have a preservation selected."
 msgstr "驗證失敗：預前處厘的容器必須有選擇的保存。"
 
-#: bika/lims/validators.py:496
+#: bika/lims/validators.py:529
 msgid "Validation failed: Result Text cannot be blank"
 msgstr "驗證失敗：結果欄不能為空"
 
-#: bika/lims/validators.py:492
+#: bika/lims/validators.py:525
 msgid "Validation failed: Result Values must be numbers"
 msgstr "驗證失敗：結果值必須是數字"
 
-#: bika/lims/validators.py:538
+#: bika/lims/validators.py:571
 msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
 msgstr "驗證失敗：選擇需要進行選擇以下幾類： ${categories}"
 
-#: bika/lims/validators.py:794
+#: bika/lims/validators.py:827
 msgid "Validation failed: Values must be numbers"
 msgstr "驗證失敗：值必須是數字"
 
-#: bika/lims/validators.py:297
+#: bika/lims/validators.py:330
 msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr "驗證失敗：列標題“ $ { 標題}”必須有關鍵字“ $ { 關鍵字}”"
 
-#: bika/lims/validators.py:449
+#: bika/lims/validators.py:482
 msgid "Validation failed: degrees is 180; minutes must be zero"
 msgstr "驗證失敗：度為180 ;分必須為零"
 
-#: bika/lims/validators.py:453
+#: bika/lims/validators.py:486
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr "驗證失敗：度為180 ;秒必須為零"
 
-#: bika/lims/validators.py:432
+#: bika/lims/validators.py:465
 msgid "Validation failed: degrees is 90; minutes must be zero"
 msgstr "驗證失敗：度為90;分必須為零"
 
-#: bika/lims/validators.py:436
+#: bika/lims/validators.py:469
 msgid "Validation failed: degrees is 90; seconds must be zero"
 msgstr "驗證失敗：度為90;秒必須為零"
 
-#: bika/lims/validators.py:445
+#: bika/lims/validators.py:478
 msgid "Validation failed: degrees must be 0 - 180"
 msgstr "验证失败: 度必须在0-180之间"
 
-#: bika/lims/validators.py:428
+#: bika/lims/validators.py:461
 msgid "Validation failed: degrees must be 0 - 90"
 msgstr "驗證失敗: 度必須為0 - 90"
 
-#: bika/lims/validators.py:401
+#: bika/lims/validators.py:434
 msgid "Validation failed: degrees must be numeric"
 msgstr "驗證失敗: 度必須是數字"
 
-#: bika/lims/validators.py:307
+#: bika/lims/validators.py:340
 msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr "驗證失敗: 關鍵字“ $ {關鍵字}”必須有列標題“ '${title}'"
 
-#: bika/lims/validators.py:159
+#: bika/lims/validators.py:192
 msgid "Validation failed: keyword contains invalid characters"
 msgstr "驗證失敗: 關鍵字包含無效字符"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:108
-#: bika/lims/validators.py:237
+#: bika/lims/controlpanel/bika_analysisservices.py:115
+#: bika/lims/validators.py:270
 msgid "Validation failed: keyword is required"
 msgstr "驗證失敗: 關鍵字是必需的"
 
-#: bika/lims/validators.py:417
+#: bika/lims/validators.py:450
 msgid "Validation failed: minutes must be 0 - 59"
 msgstr "驗證失敗: 分必須是0 -  59"
 
-#: bika/lims/validators.py:407
+#: bika/lims/validators.py:440
 msgid "Validation failed: minutes must be numeric"
 msgstr "驗證失敗: 分鐘必須是數字"
 
-#: bika/lims/validators.py:903
+#: bika/lims/validators.py:935
 msgid "Validation failed: percent values must be between 0 and 100"
 msgstr "驗證失敗: 百分比值必須是0和100之間"
 
-#: bika/lims/validators.py:899
+#: bika/lims/validators.py:931
 msgid "Validation failed: percent values must be numbers"
 msgstr "驗證失敗: 百分比值必須是數字"
 
-#: bika/lims/validators.py:421
+#: bika/lims/validators.py:454
 msgid "Validation failed: seconds must be 0 - 59"
 msgstr "驗證失敗: 秒必須為0 - 59"
 
-#: bika/lims/validators.py:413
+#: bika/lims/validators.py:446
 msgid "Validation failed: seconds must be numeric"
 msgstr "驗證失敗: 秒必須是數字"
 
-#: bika/lims/controlpanel/bika_analysisservices.py:102
-#: bika/lims/validators.py:233
+#: bika/lims/controlpanel/bika_analysisservices.py:109
+#: bika/lims/validators.py:266
 msgid "Validation failed: title is required"
 msgstr "驗證失敗: 標題是必需的"
 
-#: bika/lims/validators.py:1096
+#: bika/lims/validators.py:1128
 msgid "Validation failed: value must be between 0 and 1000"
 msgstr ""
 
-#: bika/lims/validators.py:1092
+#: bika/lims/validators.py:1124
 msgid "Validation failed: value must be float"
 msgstr ""
 
@@ -6099,7 +6047,7 @@ msgstr ""
 msgid "Validation report date"
 msgstr "驗證報告日期"
 
-#: bika/lims/browser/instrument.py:219
+#: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentvalidation.py:74
 msgid "Validator"
 msgstr "驗證"
@@ -6110,12 +6058,12 @@ msgstr "驗證"
 msgid "Value"
 msgstr "值"
 
-#: bika/lims/content/analysisservice.py:706
+#: bika/lims/content/analysisservice.py:705
 msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
 msgstr "值可以在此輸入，將覆蓋在計算臨時字段中指定的默認值。"
 
-#: bika/lims/browser/analysisrequest/analysisrequests.py:412
-#: bika/lims/browser/samplinground/analysisrequests.py:139
+#: bika/lims/browser/analysisrequest/analysisrequests.py:414
+#: bika/lims/browser/samplinground/analysisrequests.py:141
 #: bika/lims/browser/worksheet/views/folder.py:212
 msgid "Verified"
 msgstr "已驗證"
@@ -6126,7 +6074,7 @@ msgstr "已驗證"
 msgid "Verify"
 msgstr ""
 
-#: bika/lims/browser/log.py:50
+#: bika/lims/browser/log.py:52
 msgid "Version"
 msgstr "版本"
 
@@ -6136,11 +6084,11 @@ msgstr "版本"
 msgid "Volume"
 msgstr "卷/體積"
 
-#: bika/lims/content/laboratory.py:57
+#: bika/lims/content/laboratory.py:59
 msgid "Web address for the accreditation body"
 msgstr "認證機構地址的"
 
-#: bika/lims/content/supplier.py:35
+#: bika/lims/content/supplier.py:37
 msgid "Website."
 msgstr "網站"
 
@@ -6148,24 +6096,24 @@ msgstr "網站"
 msgid "Weekly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:57
+#: bika/lims/controlpanel/bika_instruments.py:59
 msgid "Weeks To Expire"
 msgstr "兩週後過期"
 
-#: bika/lims/content/analysisprofile.py:85
+#: bika/lims/content/analysisprofile.py:87
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
 msgstr "當它被設置，系統使用的分析配置文件的價格報價和系統的增值稅由分析配置文件的特殊增值稅覆蓋"
 
-#: bika/lims/content/analysisservice.py:728
+#: bika/lims/content/analysisservice.py:727
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
 msgstr "當重複的結果在工作表上，對同一樣品進行分析，不同的比這個比例更多，引發警報"
 
-#: bika/lims/validators.py:361
+#: bika/lims/validators.py:394
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr "臨時萬用字元不允許使： $ {萬用字元}"
 
 #: bika/lims/content/instrumentcalibration.py:116
-#: bika/lims/content/instrumentmaintenancetask.py:88
+#: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:96
 msgid "Work Performed"
 msgstr "工作完成"
@@ -6176,25 +6124,25 @@ msgstr "工作流程"
 
 #: bika/lims/browser/aggregatedanalyses.py:76
 #: bika/lims/browser/analyses.py:909
-#: bika/lims/browser/referencesample.py:110
+#: bika/lims/browser/referencesample.py:112
 msgid "Worksheet"
 msgstr "工作表"
 
-#: bika/lims/content/worksheettemplate.py:34
+#: bika/lims/content/worksheettemplate.py:36
 msgid "Worksheet Layout"
 msgstr "工作表佈局"
 
-#: bika/lims/controlpanel/bika_worksheettemplates.py:37
+#: bika/lims/controlpanel/bika_worksheettemplates.py:39
 msgid "Worksheet Templates"
 msgstr "工作表模板"
 
-#: bika/lims/browser/dashboard.py:456
+#: bika/lims/browser/dashboard.py:458
 #: bika/lims/browser/worksheet/views/folder.py:63
 #: bika/lims/skins/bika/portlet_to_be_verified.pt:62
 msgid "Worksheets"
 msgstr "多個工作表"
 
-#: bika/lims/validators.py:1000
+#: bika/lims/validators.py:1032
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "錯IBAN長度由%s: %sshort by %i"
 
@@ -6202,9 +6150,9 @@ msgstr "錯IBAN長度由%s: %sshort by %i"
 msgid "Yearly"
 msgstr ""
 
-#: bika/lims/browser/analysisservice.py:102
-#: bika/lims/browser/header_table.py:84
-#: bika/lims/content/analysisservice.py:1561
+#: bika/lims/browser/analysisservice.py:104
+#: bika/lims/browser/header_table.py:86
+#: bika/lims/content/analysisservice.py:1560
 msgid "Yes"
 msgstr "是"
 
@@ -6216,7 +6164,7 @@ msgstr "您沒有足夠的權限來管理工作表。"
 msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
 msgstr "您沒有足夠的權限來查看工作表${worksheet_title}."
 
-#: bika/lims/content/analysisrequest.py:245
+#: bika/lims/content/analysisrequest.py:247
 msgid "You must assign this request to a client"
 msgstr "您必須指定此請求的客戶機"
 
@@ -6224,11 +6172,11 @@ msgstr "您必須指定此請求的客戶機"
 msgid "You must select an instrument"
 msgstr "您必須選擇一個工具"
 
-#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:63
+#: bika/lims/exportimport/instruments/sysmex/xs/i500.py:65
 msgid "You should introduce a default result key."
 msgstr "您應該引入一個默認結果的關鍵。"
 
-#: bika/lims/browser/reports/administration_usershistory.py:121
+#: bika/lims/browser/reports/administration_usershistory.py:123
 msgid "action"
 msgstr "行動"
 
@@ -6244,15 +6192,15 @@ msgstr "分析"
 msgid "analysis requests selected"
 msgstr "分析請求已選擇"
 
-#: bika/lims/browser/analysisrequest/publish.py:1049
+#: bika/lims/browser/analysisrequest/publish.py:1051
 msgid "and others"
 msgstr "和其他"
 
-#: bika/lims/browser/dashboard.py:564
+#: bika/lims/browser/dashboard.py:566
 msgid "assigned"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:440
+#: bika/lims/browser/dashboard.py:442
 msgid "attachment_due"
 msgstr ""
 
@@ -6275,7 +6223,7 @@ msgstr "bika-頭版-描述"
 msgid "bika-frontpage-title"
 msgstr "bika-頭版-標題"
 
-#: bika/lims/browser/reports/administration_usershistory.py:148
+#: bika/lims/browser/reports/administration_usershistory.py:150
 msgid "comment"
 msgstr "評論"
 
@@ -6283,37 +6231,9 @@ msgstr "評論"
 msgid "daily"
 msgstr ""
 
-#: bika/lims/browser/batch/publish.py:118
+#: bika/lims/browser/batch/publish.py:120
 msgid "datalines"
 msgstr "數據傳輸線"
-
-#. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "date_format_long"
-msgstr ""
-
-#. Default: "${Y}-${m}-${d}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
-msgid "date_format_short"
-msgstr ""
-
-#. Date format used with the datepicker jqueryui plugin.
-#. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
-#. Default: "mm/dd/yy"
-msgid "date_format_short_datepicker"
-msgstr ""
 
 #: bika/lims/browser/templates/referencesample_view.pt:124
 msgid "deactivate"
@@ -6324,7 +6244,7 @@ msgstr "關閉"
 msgid "heading_arpriority"
 msgstr "標題_ar_優先"
 
-#: bika/lims/browser/dashboard.py:329
+#: bika/lims/browser/dashboard.py:331
 msgid "inactive"
 msgstr ""
 
@@ -6373,19 +6293,19 @@ msgstr "新版本可用說明"
 msgid "new_version_available_title"
 msgstr "新版本的標題"
 
-#: bika/lims/browser/dashboard.py:171
+#: bika/lims/browser/dashboard.py:173
 msgid "of"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:438
+#: bika/lims/browser/dashboard.py:440
 msgid "open"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:330
+#: bika/lims/browser/dashboard.py:332
 msgid "other_status"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:328
+#: bika/lims/browser/dashboard.py:330
 msgid "published"
 msgstr ""
 
@@ -6393,19 +6313,19 @@ msgstr ""
 msgid "quarterly"
 msgstr ""
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeating every"
 msgstr "每重複"
 
-#: bika/lims/content/instrumentscheduledtask.py:105
+#: bika/lims/content/instrumentscheduledtask.py:107
 msgid "repeatperiod"
 msgstr "重複週期"
 
-#: bika/lims/browser/dashboard.py:324
+#: bika/lims/browser/dashboard.py:326
 msgid "sample_due"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:325
+#: bika/lims/browser/dashboard.py:327
 msgid "sample_received"
 msgstr ""
 
@@ -6424,19 +6344,8 @@ msgstr "摘要內容列表"
 msgid "text_default_site_title"
 msgstr "文字默認網站的標題"
 
-#: bika/lims/content/samplinground.py:218
+#: bika/lims/content/samplinground.py:220
 msgid "the total number of Sample Points defined in the Round."
-msgstr ""
-
-#. Default: "${I}:${M} ${p}"
-#. The variables used here are the same as used in the strftime formating.
-#. Supported are ${A}, ${a}, ${B}, ${b}, ${H}, ${I}, ${m}, ${d}, ${M}, ${p},
-#. ${S}, ${Y}, ${y}, ${Z}, each used as variable in the msgstr.
-#. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
-#. In english speaking countries default is:
-#. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
-msgid "time_format"
 msgstr ""
 
 #. Default: "Required"
@@ -6448,7 +6357,7 @@ msgstr "標題要求"
 msgid "to"
 msgstr "至"
 
-#: bika/lims/browser/dashboard.py:326
+#: bika/lims/browser/dashboard.py:328
 msgid "to_be_verified"
 msgstr ""
 
@@ -6456,7 +6365,7 @@ msgstr ""
 msgid "type"
 msgstr "類型"
 
-#: bika/lims/content/instrumentscheduledtask.py:107
+#: bika/lims/content/instrumentscheduledtask.py:109
 msgid "until"
 msgstr "直到"
 
@@ -6482,7 +6391,7 @@ msgstr "值"
 msgid "verification(s) pending"
 msgstr ""
 
-#: bika/lims/browser/dashboard.py:327
+#: bika/lims/browser/dashboard.py:329
 msgid "verified"
 msgstr ""
 
@@ -6494,6 +6403,6 @@ msgstr ""
 msgid "yearly"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_instruments.py:120
+#: bika/lims/controlpanel/bika_instruments.py:122
 msgid "{} weeks and {} day(s)"
 msgstr ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
On AR listing, if an AR in To Be Sampled state that has no sampler selected and the Sample button is clicked, the portal message says "Info No change made". 

https://github.com/bikalabs/bika.lims/issues/2122

## Current behavior before PR
"No change made" message is displayed

## Desired behavior after PR is merged
"Both Sample and DateSampled are required" is no displayed
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
